### PR TITLE
feat(codex): support multi-model parallel execution

### DIFF
--- a/codex/.claude-plugin/plugin.json
+++ b/codex/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex",
   "description": "OpenAI Codex CLI integration",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex/skills/codex/SKILL.md
+++ b/codex/skills/codex/SKILL.md
@@ -14,7 +14,7 @@ All prompts passed to `codex` MUST be in English.
 2. Pipe the file content to codex: `cat /tmp/codex_prompt.txt | codex exec ...`
 
 ## Running a Task
-1. Ask the user (via `AskUserQuestion`) which model and reasoning effort in a **single prompt with two questions**.
+1. Ask the user (via `AskUserQuestion`) which model(s) and reasoning effort in a **single prompt with two questions**. Model selection is **multi-select** — multiple models can be chosen for parallel execution.
 
 | Model | Characteristics |
 |-------|-----------------|
@@ -22,13 +22,18 @@ All prompts passed to `codex` MUST be in English.
 | `gpt-5.2-codex` | Prior-generation agentic coding model |
 | `gpt-5.1-codex-max` | Codex-optimized flagship for deep and fast reasoning |
 | `gpt-5.2` | General-purpose frontier model (knowledge, reasoning, coding) |
+
+   Reasoning effort is selected once and applied identically to all chosen models.
+
 2. Select sandbox mode; default to `--sandbox read-only` unless edits or network access are necessary.
 3. Assemble command with options (always include `--skip-git-repo-check`):
    - `-m, --model <MODEL>` / `--config model_reasoning_effort="<medium|high|xhigh>"`
    - `--sandbox <read-only|workspace-write|danger-full-access>` / `--full-auto` / `-C <DIR>`
-4. Resume: `cat /tmp/codex_prompt.txt | codex exec --skip-git-repo-check resume --last 2>/dev/null`. If user requests different model/reasoning, insert flags between `exec` and `resume`.
+   - **Single model**: run one Bash call as usual.
+   - **Multiple models**: issue parallel Bash tool calls (one per model) in a single response. Each call uses the same prompt, sandbox, and reasoning effort but a different `-m` value.
+4. Resume: `cat /tmp/codex_prompt.txt | codex exec --skip-git-repo-check resume --last 2>/dev/null`. If user requests different model/reasoning, insert flags between `exec` and `resume`. Resume applies to the last single session only.
 5. Append `2>/dev/null` to suppress thinking tokens (stderr). Show stderr only for debugging.
-6. Run command, summarize outcome, inform user: "Resume anytime with 'codex resume'."
+6. Run command(s), summarize each outcome, inform user: "Resume anytime with 'codex resume'."
 
 ### Quick Reference
 | Use case | Command pattern |


### PR DESCRIPTION
## Summary
- codex skill의 모델 선택을 single-select에서 **multi-select**로 변경
- 복수 모델 선택 시 **parallel Bash tool calls**로 동시 실행 안내
- reasoning effort는 한 번 선택하여 모든 모델에 동일 적용
- 버전 1.2.0 → 1.3.0

## Test plan
- [x] `/codex` 호출 시 모델 multi-select UI 표시 확인
- [x] 단일 모델 선택 시 기존 동작과 동일하게 작동
- [x] 복수 모델 선택 시 병렬 Bash 호출로 실행되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)