### PR TITLE
feat(release): commit-based release notes

### DIFF
--- a/release/.claude-plugin/plugin.json
+++ b/release/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "release",
   "description": "Automated version bump, git tag, push, and GitHub release note creation",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"


### PR DESCRIPTION
## Summary
- GitHub `--generate-notes`(PR 기반) 대신 커밋 로그를 conventional commit 타입별로 분류하여 릴리스 노트 생성
- Phase 8 워크플로우를 3단계(수집→분류→생성)로 구조화
- Prerelease/Draft 섹션도 동일하게 `--notes` 방식으로 통일

## Test plan
- [x] `/release` 실행 시 커밋 기반 분류된 릴리스 노트 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)