### PR TITLE
feat(calendar-sync): add repository boundary to session grouping

### DIFF
--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google services: Gemini CLI, Veo, video understanding, image prompts, calendar sync",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/skills/calendar-sync/SKILL.md
+++ b/google/skills/calendar-sync/SKILL.md
@@ -106,9 +106,8 @@ Group related activities into coherent work sessions for clean calendar visualiz
 **Session formation rules:**
 1. Sort activities by timestamp (completion time)
 2. Backdate each activity to get time range
-3. Group by repository/project first, then merge within each group
-4. Merge overlapping/adjacent activities (gap ≤ 30min) into sessions only within the same repository/project
-5. Cross-repository activities are always separate events, even if temporally adjacent
+3. Group by repository/project first (GitHub: `repository`, Linear: `metadata.project`)
+4. Merge overlapping/adjacent activities (gap ≤ 30min) within each group; never merge across repositories
 
 **Example transformation:**
 
@@ -136,8 +135,9 @@ Raw activity data:
 **Cross-repository isolation** (different repos stay separate):
 ```
 Input:
-  09:39 ✅ PR #1 merged in org/foundation
-  10:08 ✅ PR #10 merged in user/ClaudeTasks (29min gap, but different repo)
+  09:39 ✅ PR #1 merged in org/foundation (15min) → 09:15-09:39
+  10:08 ✅ PR #10 merged in user/ClaudeTasks (15min) → 09:45-10:08
+  (29min gap, but different repo)
 
 Result: TWO separate events (not merged despite gap ≤ 30min)
   09:15-09:39 ✅ PR #1 in org/foundation
@@ -154,7 +154,7 @@ Resolution: Merge into 08:30-09:15 session (same repo)
 ```
 
 **Session output format:**
-- **Title**: `{icons} {summary} in {repo}`
+- **Title**: `{icons} {summary} in {repo}` (always single repo per session)
 - **Start**: Earliest backdated start (snapped to 15min)
 - **End**: Latest activity timestamp
 - **Description**: Timeline of activities
@@ -168,7 +168,9 @@ Resolution: Merge into 08:30-09:15 session (same repo)
   https://github.com/org/repo/pull/234
   ```
 
-**User override:** "without grouping" or "separate events" to disable session merge.
+**User override:**
+- "without grouping" or "separate events" → disable all session merging
+- "without repository grouping" or "merge across repos" → disable repository boundary only (temporal merge preserved)
 
 ### 5. Check for Duplicates (Optional)
 
@@ -256,6 +258,7 @@ echo "Import Summary: $SUCCESS/$TOTAL succeeded"
 - "Convert markdown to calendar events" → Auto-detect format, create events
 - "Sync ~/reports/github-2025-11-01.json without duplicate check" → Fast import with grouping
 - "Sync activities without grouping" → Create separate calendar events for each activity
+- "Sync activities without repository grouping" → Merge across repos by time only (pre-1.3 behavior)
 
 ## Troubleshooting
 

--- a/google/skills/calendar-sync/SKILL.md
+++ b/google/skills/calendar-sync/SKILL.md
@@ -106,16 +106,17 @@ Group related activities into coherent work sessions for clean calendar visualiz
 **Session formation rules:**
 1. Sort activities by timestamp (completion time)
 2. Backdate each activity to get time range
-3. Merge overlapping/adjacent activities (gap ≤ 30min) into sessions
-4. Same repository activities prefer single session
+3. Group by repository/project first, then merge within each group
+4. Merge overlapping/adjacent activities (gap ≤ 30min) into sessions only within the same repository/project
+5. Cross-repository activities are always separate events, even if temporally adjacent
 
 **Example transformation:**
 
 Raw activity data:
 ```
-09:00 🔨 Commit A (30min work)
-09:30 🔨 Commit B (30min work)
-10:00 🔀 PR #234 created (60min work)
+09:00 🔨 Commit A in org/repo (30min work)
+09:30 🔨 Commit B in org/repo (30min work)
+10:00 🔀 PR #234 created in org/repo (60min work)
 ```
 
 **Before (forward projection - wrong):**
@@ -132,13 +133,24 @@ Raw activity data:
 - Session start: earliest backdate (09:00 - 30min = 08:30)
 - Session end: latest timestamp (10:00, when PR completed)
 
-**Overlap resolution** (when backdated blocks collide):
+**Cross-repository isolation** (different repos stay separate):
+```
+Input:
+  09:39 ✅ PR #1 merged in org/foundation
+  10:08 ✅ PR #10 merged in user/ClaudeTasks (29min gap, but different repo)
+
+Result: TWO separate events (not merged despite gap ≤ 30min)
+  09:15-09:39 ✅ PR #1 in org/foundation
+  09:45-10:08 ✅ PR #10 in user/ClaudeTasks
+```
+
+**Overlap resolution** (when backdated blocks collide within same repo):
 ```
 Input:
   09:00 🔨 Commit (30min) → 08:30-09:00
   09:15 💬 Comment (15min) → 09:00-09:15
 
-Resolution: Merge into 08:30-09:15 session
+Resolution: Merge into 08:30-09:15 session (same repo)
 ```
 
 **Session output format:**


### PR DESCRIPTION
## Summary

- 캘린더 동기화 시 세션 병합 조건에 **리포지토리 경계** 추가
- 다른 리포지토리의 활동은 시간 갭이 30분 이내여도 별도 캘린더 이벤트로 생성
- `build_sessions()` pseudocode를 리포지토리별 선그룹핑 로직으로 업데이트
- Linear 활동은 `metadata.project`로 그룹핑, attribution 없는 활동은 isolated 처리
- `"without repository grouping"` override 추가 (pre-1.3 동작 복원)

## Test plan

- [x] calendar-sync 스킬로 다중 리포지토리 활동 동기화 시 리포지토리별 분리 확인
- [x] 같은 리포지토리 내 30분 이내 활동은 여전히 병합되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)