### PR TITLE
feat(claude-code-internals): document agent memory frontmatter feature (v2.1.37)

### DIFF
--- a/claude-code-internals/.claude-plugin/plugin.json
+++ b/claude-code-internals/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-internals",
   "description": "Claude Code internals explorer",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"


### PR DESCRIPTION
Add comprehensive analysis of the new `memory` frontmatter field for agents,
covering scope types (user/project/local), storage paths, tool auto-injection,
permission system integration, and internal function mapping.

https://claude.ai/code/session_01Da4pu6yYQUCfdyKRPDpvSJ