### PR TITLE
feat(cdp-browser): add CDP browser automation plugin

### DIFF
--- a/cdp-browser/.claude-plugin/plugin.json
+++ b/cdp-browser/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "cdp-browser",
+  "description": "CDP browser automation: tab management, screenshots, interaction, network/console monitoring (Puppeteer-free)",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/cdp-browser/scripts/cdp_client.py
+++ b/cdp-browser/scripts/cdp_client.py
@@ -1,0 +1,222 @@
+"""
+CDP Client — Shared module for direct Chrome DevTools Protocol communication.
+
+Bypasses Puppeteer to avoid frozen-tab timeouts. Uses:
+- HTTP API (urllib.request) for tab discovery (immune to frozen tabs)
+- Per-tab WebSocket (websocket-client) for CDP commands
+
+Import via sys.path manipulation in v1/v2/v3 scripts:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from cdp_client import CDPClient
+"""
+
+import json
+import os
+import time
+import urllib.request
+import urllib.error
+
+# State file location
+STATE_DIR = os.path.expanduser("~/.cache/cdp-browser")
+STATE_FILE = os.path.join(STATE_DIR, "state.json")
+
+
+class CDPError(Exception):
+    """CDP protocol or connection error."""
+    pass
+
+
+class CDPClient:
+    """Direct CDP client using HTTP discovery + per-tab WebSocket."""
+
+    def __init__(self, host=None, port=None):
+        self.host = host or os.environ.get("CDP_HOST", "127.0.0.1")
+        self.port = int(port or os.environ.get("CDP_PORT", "9222"))
+        self._base_url = f"http://{self.host}:{self.port}"
+        self._ws = None
+        self._msg_id = 0
+        self._event_buffer = []
+
+    # ── HTTP API (frozen-tab immune) ──────────────────────────────
+
+    def _http_get(self, path):
+        """GET request to CDP HTTP endpoint."""
+        url = f"{self._base_url}{path}"
+        try:
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                return json.loads(resp.read())
+        except urllib.error.URLError as e:
+            raise CDPError(f"CDP HTTP endpoint unreachable ({self._base_url}): {e}")
+
+    def _http_get_raw(self, path):
+        """GET request returning raw response text."""
+        url = f"{self._base_url}{path}"
+        try:
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                return resp.read().decode()
+        except urllib.error.URLError as e:
+            raise CDPError(f"CDP HTTP endpoint unreachable ({self._base_url}): {e}")
+
+    def list_tabs(self, type_filter="page"):
+        """List browser tabs via HTTP API. type_filter: 'page', 'all', etc."""
+        tabs = self._http_get("/json/list")
+        if type_filter and type_filter != "all":
+            tabs = [t for t in tabs if t.get("type") == type_filter]
+        return tabs
+
+    def get_version(self):
+        """Get browser version info."""
+        return self._http_get("/json/version")
+
+    def new_tab(self, url=""):
+        """Open a new tab."""
+        path = f"/json/new?{url}" if url else "/json/new"
+        return self._http_get(path)
+
+    def close_tab(self, target_id):
+        """Close a tab by target ID."""
+        resp = self._http_get_raw(f"/json/close/{target_id}")
+        return "Target is closing" in resp
+
+    def activate_tab(self, target_id):
+        """Bring tab to foreground."""
+        resp = self._http_get_raw(f"/json/activate/{target_id}")
+        return "Target activated" in resp
+
+    # ── WebSocket (per-tab CDP commands) ──────────────────────────
+
+    def connect(self, target_id=None, timeout=10):
+        """Connect WebSocket to a specific tab.
+
+        If target_id is None, uses the selected target from state.
+        """
+        import websocket
+
+        if target_id is None:
+            target_id = self.get_selected_target()
+            if not target_id:
+                raise CDPError("No tab selected. Use 'select' first or provide target_id.")
+
+        ws_url = f"ws://{self.host}:{self.port}/devtools/page/{target_id}"
+
+        try:
+            self._ws = websocket.create_connection(
+                ws_url,
+                timeout=timeout,
+                suppress_origin=True,
+            )
+        except Exception as e:
+            raise CDPError(
+                f"WebSocket connection failed for {target_id}: {e}\n"
+                "Tab may be frozen/suspended. Try selecting an active tab."
+            )
+
+        self._msg_id = 0
+        self._event_buffer = []
+
+    def send(self, method, params=None, timeout=30):
+        """Send CDP command and wait for response.
+
+        Events received while waiting are buffered in self._event_buffer.
+        Raises CDPError on timeout (common with frozen tabs).
+        """
+        if not self._ws:
+            raise CDPError("Not connected. Call connect() first.")
+
+        self._msg_id += 1
+        msg_id = self._msg_id
+        payload = {"id": msg_id, "method": method}
+        if params:
+            payload["params"] = params
+
+        self._ws.send(json.dumps(payload))
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                break
+            self._ws.settimeout(min(remaining, 1.0))
+            try:
+                raw = self._ws.recv()
+                resp = json.loads(raw)
+                if resp.get("id") == msg_id:
+                    if "error" in resp:
+                        err = resp["error"]
+                        raise CDPError(f"CDP error ({err.get('code')}): {err.get('message')}")
+                    return resp.get("result", {})
+                else:
+                    # Buffer events (no 'id' field) for later inspection
+                    self._event_buffer.append(resp)
+            except Exception as e:
+                if "timed out" in str(e).lower():
+                    continue
+                raise
+
+        raise CDPError(
+            f"Timeout waiting for response to {method} ({timeout}s). "
+            "Tab may be frozen or suspended."
+        )
+
+    def close(self):
+        """Close WebSocket connection."""
+        if self._ws:
+            try:
+                self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+
+    def drain_events(self):
+        """Return and clear buffered events."""
+        events = self._event_buffer[:]
+        self._event_buffer.clear()
+        return events
+
+    # ── State persistence ─────────────────────────────────────────
+
+    def load_state(self):
+        """Load persisted state."""
+        try:
+            with open(STATE_FILE) as f:
+                return json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return {}
+
+    def save_state(self, target_id, host=None, port=None):
+        """Save selected target to state file."""
+        os.makedirs(STATE_DIR, exist_ok=True)
+        state = self.load_state()
+        state["selected_target"] = target_id
+        state["host"] = host or self.host
+        state["port"] = port or self.port
+        state["timestamp"] = time.time()
+        with open(STATE_FILE, "w") as f:
+            json.dump(state, f, indent=2)
+
+    def get_selected_target(self):
+        """Get the currently selected target ID from state."""
+        state = self.load_state()
+        return state.get("selected_target")
+
+    def save_pid(self, process_type, pid):
+        """Save a background process PID to state."""
+        os.makedirs(STATE_DIR, exist_ok=True)
+        state = self.load_state()
+        pids = state.setdefault("pids", {})
+        pids[process_type] = pid
+        with open(STATE_FILE, "w") as f:
+            json.dump(state, f, indent=2)
+
+    def get_pid(self, process_type):
+        """Get a saved background process PID."""
+        state = self.load_state()
+        return state.get("pids", {}).get(process_type)
+
+    def clear_pid(self, process_type):
+        """Remove a saved PID."""
+        state = self.load_state()
+        pids = state.get("pids", {})
+        pids.pop(process_type, None)
+        with open(STATE_FILE, "w") as f:
+            json.dump(state, f, indent=2)

--- a/cdp-browser/scripts/v1_core.py
+++ b/cdp-browser/scripts/v1_core.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env uv run --quiet --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "websocket-client>=1.6.0",
+# ]
+# ///
+"""
+v1_core — Core CDP operations: list, select, screenshot, snapshot, evaluate, navigate, version.
+"""
+
+import argparse
+import base64
+import json
+import sys
+import time
+from pathlib import Path
+
+# Import shared client from same directory
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from cdp_client import CDPClient, CDPError
+
+
+def cmd_version(client, args):
+    """Show browser version info."""
+    info = client.get_version()
+    print(f"Browser: {info.get('Browser', 'Unknown')}")
+    print(f"Protocol: {info.get('Protocol-Version', 'Unknown')}")
+    print(f"V8: {info.get('V8-Version', 'Unknown')}")
+    print(f"User-Agent: {info.get('User-Agent', 'Unknown')}")
+
+
+def cmd_list(client, args):
+    """List browser tabs."""
+    type_filter = args.type if args.type != "all" else "all"
+    tabs = client.list_tabs(type_filter=type_filter if type_filter != "all" else None)
+
+    # Apply search filter
+    if args.search:
+        query = args.search.lower()
+        tabs = [
+            t for t in tabs
+            if query in t.get("title", "").lower() or query in t.get("url", "").lower()
+        ]
+
+    # Apply limit
+    total = len(tabs)
+    tabs = tabs[:args.limit]
+
+    selected = client.get_selected_target()
+
+    for i, tab in enumerate(tabs):
+        tid = tab.get("id", "?")
+        title = tab.get("title", "Untitled")[:70]
+        url = tab.get("url", "")[:80]
+        tab_type = tab.get("type", "?")
+        marker = " *" if tid == selected else ""
+        print(f"  [{i}]{marker} ({tab_type}) {title}")
+        print(f"       {url}")
+        print(f"       id: {tid}")
+
+    if total > args.limit:
+        print(f"\n  ... and {total - args.limit} more (use --limit or --search to filter)")
+    print(f"\nTotal: {total} tabs (showing {min(len(tabs), args.limit)})")
+
+
+def cmd_select(client, args):
+    """Select a tab by index or target ID."""
+    selector = args.target
+
+    # Try as integer index first
+    try:
+        idx = int(selector)
+        tabs = client.list_tabs(type_filter="page")
+        if 0 <= idx < len(tabs):
+            tab = tabs[idx]
+            target_id = tab["id"]
+            client.activate_tab(target_id)
+            client.save_state(target_id)
+            print(f"Selected tab [{idx}]: {tab.get('title', 'Untitled')[:60]}")
+            print(f"  ID: {target_id}")
+            return
+        else:
+            print(f"Error: Index {idx} out of range (0-{len(tabs)-1})", file=sys.stderr)
+            sys.exit(1)
+    except ValueError:
+        pass
+
+    # Try as target ID
+    tabs = client.list_tabs(type_filter=None)
+    for tab in tabs:
+        if tab.get("id") == selector:
+            client.activate_tab(selector)
+            client.save_state(selector)
+            print(f"Selected tab: {tab.get('title', 'Untitled')[:60]}")
+            print(f"  ID: {selector}")
+            return
+
+    print(f"Error: No tab found with index or ID: {selector}", file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_screenshot(client, args):
+    """Take a screenshot of the selected tab."""
+    client.connect()
+    try:
+        params = {"format": args.format}
+        if args.format == "jpeg":
+            params["quality"] = 80
+
+        if args.full_page:
+            # Get full page dimensions
+            metrics = client.send("Page.getLayoutMetrics")
+            content = metrics.get("contentSize", {})
+            width = content.get("width", 1280)
+            height = content.get("height", 800)
+
+            # Override device metrics for full page
+            client.send("Emulation.setDeviceMetricsOverride", {
+                "width": int(width),
+                "height": int(height),
+                "deviceScaleFactor": 1,
+                "mobile": False,
+            })
+            params["captureBeyondViewport"] = True
+
+        result = client.send("Page.captureScreenshot", params)
+
+        if args.full_page:
+            client.send("Emulation.clearDeviceMetricsOverride")
+
+        # Decode and save
+        data = base64.b64decode(result["data"])
+        ext = "jpg" if args.format == "jpeg" else args.format
+        output = args.output or f"/tmp/cdp-screenshot-{int(time.time())}.{ext}"
+        Path(output).write_bytes(data)
+        print(f"Screenshot saved: {output} ({len(data)} bytes)")
+    finally:
+        client.close()
+
+
+def cmd_snapshot(client, args):
+    """Get accessibility tree snapshot."""
+    client.connect()
+    try:
+        client.send("Accessibility.enable")
+        result = client.send("Accessibility.getFullAXTree", {"depth": args.depth})
+        nodes = result.get("nodes", [])
+
+        # Build parent-child map
+        node_map = {}
+        for n in nodes:
+            node_map[n["nodeId"]] = n
+
+        # Print tree (limited depth already handled by CDP)
+        for node in nodes:
+            # Calculate depth from backend
+            depth = 0
+            parent_id = node.get("parentId")
+            visited = set()
+            while parent_id and parent_id not in visited:
+                visited.add(parent_id)
+                depth += 1
+                parent_node = node_map.get(parent_id)
+                if parent_node:
+                    parent_id = parent_node.get("parentId")
+                else:
+                    break
+
+            role = node.get("role", {}).get("value", "")
+            name = node.get("name", {}).get("value", "")
+            if role in ("none", "generic") and not name:
+                continue
+
+            prefix = "  " * min(depth, 10)
+            line = f"{prefix}[{role}]"
+            if name:
+                line += f" {name[:80]}"
+            print(line)
+
+    finally:
+        client.close()
+
+
+def cmd_evaluate(client, args):
+    """Evaluate JavaScript expression."""
+    client.connect()
+    try:
+        params = {
+            "expression": args.expression,
+            "returnByValue": True,
+        }
+        if args.await_promise:
+            params["awaitPromise"] = True
+
+        result = client.send("Runtime.evaluate", params)
+        obj = result.get("result", {})
+
+        if obj.get("type") == "undefined":
+            print("undefined")
+        elif "value" in obj:
+            val = obj["value"]
+            if isinstance(val, (dict, list)):
+                print(json.dumps(val, indent=2, ensure_ascii=False))
+            else:
+                print(val)
+        elif obj.get("description"):
+            print(obj["description"])
+        else:
+            print(json.dumps(obj, indent=2, ensure_ascii=False))
+
+        # Print exception if any
+        exc = result.get("exceptionDetails")
+        if exc:
+            text = exc.get("text", "")
+            exception = exc.get("exception", {})
+            desc = exception.get("description", "")
+            print(f"Exception: {text} {desc}", file=sys.stderr)
+            sys.exit(1)
+
+    finally:
+        client.close()
+
+
+def cmd_navigate(client, args):
+    """Navigate to a URL."""
+    client.connect()
+    try:
+        result = client.send("Page.navigate", {"url": args.url})
+
+        if args.wait_for == "load":
+            # Wait for Page.loadEventFired
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                try:
+                    client._ws.settimeout(1.0)
+                    raw = client._ws.recv()
+                    resp = json.loads(raw)
+                    if resp.get("method") == "Page.loadEventFired":
+                        break
+                except Exception:
+                    continue
+
+        error = result.get("errorText")
+        if error:
+            print(f"Navigation error: {error}", file=sys.stderr)
+            sys.exit(1)
+
+        frame_id = result.get("frameId", "")
+        print(f"Navigated to: {args.url}")
+        print(f"  Frame: {frame_id}")
+    finally:
+        client.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="cdp-v1",
+        description="Core CDP browser operations",
+    )
+    parser.add_argument("--host", help="CDP host (default: $CDP_HOST or 127.0.0.1)")
+    parser.add_argument("--port", type=int, help="CDP port (default: $CDP_PORT or 9222)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # version
+    sub.add_parser("version", help="Show browser version")
+
+    # list
+    p_list = sub.add_parser("list", help="List browser tabs")
+    p_list.add_argument("--type", default="page", help="Tab type filter: page, all (default: page)")
+    p_list.add_argument("--limit", type=int, default=50, help="Max tabs to show (default: 50)")
+    p_list.add_argument("--search", help="Filter by title/URL substring")
+
+    # select
+    p_sel = sub.add_parser("select", help="Select a tab by index or ID")
+    p_sel.add_argument("target", help="Tab index (integer) or target ID")
+
+    # screenshot
+    p_ss = sub.add_parser("screenshot", help="Capture screenshot")
+    p_ss.add_argument("--output", "-o", help="Output file path")
+    p_ss.add_argument("--format", choices=["png", "jpeg"], default="png")
+    p_ss.add_argument("--full-page", action="store_true", help="Capture full page")
+
+    # snapshot
+    p_snap = sub.add_parser("snapshot", help="Accessibility tree snapshot")
+    p_snap.add_argument("--depth", type=int, default=5, help="Tree depth (default: 5)")
+
+    # evaluate
+    p_eval = sub.add_parser("evaluate", help="Evaluate JavaScript")
+    p_eval.add_argument("expression", help="JavaScript expression")
+    p_eval.add_argument("--await", dest="await_promise", action="store_true",
+                        help="Await promise result")
+
+    # navigate
+    p_nav = sub.add_parser("navigate", help="Navigate to URL")
+    p_nav.add_argument("url", help="Target URL")
+    p_nav.add_argument("--wait-for", choices=["load", "none"], default="load",
+                       help="Wait condition (default: load)")
+
+    args = parser.parse_args()
+    client = CDPClient(host=args.host, port=args.port)
+
+    commands = {
+        "version": cmd_version,
+        "list": cmd_list,
+        "select": cmd_select,
+        "screenshot": cmd_screenshot,
+        "snapshot": cmd_snapshot,
+        "evaluate": cmd_evaluate,
+        "navigate": cmd_navigate,
+    }
+
+    try:
+        commands[args.command](client, args)
+    except CDPError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/cdp-browser/scripts/v2_interact.py
+++ b/cdp-browser/scripts/v2_interact.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env uv run --quiet --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "websocket-client>=1.6.0",
+# ]
+# ///
+"""
+v2_interact — Browser interaction: click, fill, press_key, hover, new_page, close_page.
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from cdp_client import CDPClient, CDPError
+
+
+def _resolve_selector(client, selector):
+    """Resolve CSS selector to element center coordinates via Runtime.evaluate."""
+    js = f"""
+    (() => {{
+        const el = document.querySelector({json.dumps(selector)});
+        if (!el) return {{error: 'Element not found: {selector}'}};
+        const rect = el.getBoundingClientRect();
+        return {{
+            x: rect.x + rect.width / 2,
+            y: rect.y + rect.height / 2,
+            width: rect.width,
+            height: rect.height,
+            tag: el.tagName.toLowerCase(),
+            text: (el.textContent || '').slice(0, 50)
+        }};
+    }})()
+    """
+    result = client.send("Runtime.evaluate", {
+        "expression": js,
+        "returnByValue": True,
+    })
+    obj = result.get("result", {}).get("value", {})
+    if not obj or "error" in obj:
+        raise CDPError(obj.get("error", f"Cannot resolve selector: {selector}"))
+    return obj
+
+
+def _dispatch_mouse(client, x, y, event_type, button="left", click_count=1):
+    """Send mouse event at coordinates."""
+    client.send("Input.dispatchMouseEvent", {
+        "type": event_type,
+        "x": x,
+        "y": y,
+        "button": button,
+        "clickCount": click_count,
+    })
+
+
+def cmd_click(client, args):
+    """Click at coordinates or CSS selector."""
+    if not args.selector and (args.x is None or args.y is None):
+        print("Error: Provide --selector or both x y coordinates", file=sys.stderr)
+        sys.exit(1)
+    client.connect()
+    try:
+        if args.selector:
+            info = _resolve_selector(client, args.selector)
+            x, y = info["x"], info["y"]
+            print(f"Resolved: <{info['tag']}> \"{info['text']}\" at ({x:.0f}, {y:.0f})")
+        else:
+            x, y = args.x, args.y
+
+        _dispatch_mouse(client, x, y, "mousePressed")
+        _dispatch_mouse(client, x, y, "mouseReleased")
+        print(f"Clicked at ({x:.0f}, {y:.0f})")
+    finally:
+        client.close()
+
+
+def cmd_fill(client, args):
+    """Fill text into an element."""
+    client.connect()
+    try:
+        info = _resolve_selector(client, args.selector)
+        x, y = info["x"], info["y"]
+
+        # Click to focus
+        _dispatch_mouse(client, x, y, "mousePressed")
+        _dispatch_mouse(client, x, y, "mouseReleased")
+        time.sleep(0.05)
+
+        # Select all existing text (Ctrl+A / Cmd+A)
+        client.send("Input.dispatchKeyEvent", {
+            "type": "keyDown",
+            "key": "a",
+            "code": "KeyA",
+            "modifiers": 8 if sys.platform == "darwin" else 2,  # meta or ctrl
+        })
+        client.send("Input.dispatchKeyEvent", {
+            "type": "keyUp",
+            "key": "a",
+            "code": "KeyA",
+        })
+
+        # Type characters via insertText
+        client.send("Input.insertText", {"text": args.text})
+        print(f"Filled <{info['tag']}> with: {args.text[:50]}")
+    finally:
+        client.close()
+
+
+def cmd_press_key(client, args):
+    """Press a keyboard key."""
+    client.connect()
+    try:
+        # Build modifiers bitmask: 1=Alt, 2=Ctrl, 4=Shift, 8=Meta
+        modifiers = 0
+        if args.modifiers:
+            mod_parts = [m.strip().lower() for m in args.modifiers.split(",")]
+            for m in mod_parts:
+                if m == "alt":
+                    modifiers |= 1
+                elif m == "ctrl":
+                    modifiers |= 2
+                elif m == "shift":
+                    modifiers |= 4
+                elif m in ("meta", "cmd"):
+                    modifiers |= 8
+
+        key = args.key
+        # Map common key names
+        key_map = {
+            "enter": ("Enter", "Enter", 13),
+            "tab": ("Tab", "Tab", 9),
+            "escape": ("Escape", "Escape", 27),
+            "esc": ("Escape", "Escape", 27),
+            "backspace": ("Backspace", "Backspace", 8),
+            "delete": ("Delete", "Delete", 46),
+            "space": (" ", "Space", 32),
+            "arrowup": ("ArrowUp", "ArrowUp", 38),
+            "arrowdown": ("ArrowDown", "ArrowDown", 40),
+            "arrowleft": ("ArrowLeft", "ArrowLeft", 37),
+            "arrowright": ("ArrowRight", "ArrowRight", 39),
+        }
+
+        if key.lower() in key_map:
+            key_val, code, keycode = key_map[key.lower()]
+        else:
+            key_val = key
+            code = f"Key{key.upper()}" if len(key) == 1 else key
+            keycode = ord(key.upper()) if len(key) == 1 else 0
+
+        params = {
+            "type": "keyDown",
+            "key": key_val,
+            "code": code,
+            "modifiers": modifiers,
+            "windowsVirtualKeyCode": keycode,
+        }
+        client.send("Input.dispatchKeyEvent", params)
+
+        params["type"] = "keyUp"
+        client.send("Input.dispatchKeyEvent", params)
+        print(f"Pressed: {key}" + (f" (modifiers: {args.modifiers})" if args.modifiers else ""))
+    finally:
+        client.close()
+
+
+def cmd_hover(client, args):
+    """Hover over coordinates or CSS selector."""
+    if not args.selector and (args.x is None or args.y is None):
+        print("Error: Provide --selector or both x y coordinates", file=sys.stderr)
+        sys.exit(1)
+    client.connect()
+    try:
+        if args.selector:
+            info = _resolve_selector(client, args.selector)
+            x, y = info["x"], info["y"]
+            print(f"Resolved: <{info['tag']}> \"{info['text']}\" at ({x:.0f}, {y:.0f})")
+        else:
+            x, y = args.x, args.y
+
+        _dispatch_mouse(client, x, y, "mouseMoved")
+        print(f"Hovered at ({x:.0f}, {y:.0f})")
+    finally:
+        client.close()
+
+
+def cmd_new_page(client, args):
+    """Open a new tab."""
+    tab = client.new_tab(args.url or "")
+    target_id = tab.get("id", "?")
+    title = tab.get("title", "New Tab")
+    print(f"New tab: {title}")
+    print(f"  ID: {target_id}")
+    # Auto-select the new tab
+    client.save_state(target_id)
+    print(f"  (auto-selected)")
+
+
+def cmd_close_page(client, args):
+    """Close a tab."""
+    target_id = args.target_id or client.get_selected_target()
+    if not target_id:
+        print("Error: No tab specified or selected", file=sys.stderr)
+        sys.exit(1)
+
+    if client.close_tab(target_id):
+        print(f"Closed tab: {target_id}")
+        # Clear selection if we closed the selected tab
+        if client.get_selected_target() == target_id:
+            client.save_state("")
+    else:
+        print(f"Error: Failed to close tab {target_id}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="cdp-v2",
+        description="CDP browser interaction",
+    )
+    parser.add_argument("--host", help="CDP host")
+    parser.add_argument("--port", type=int, help="CDP port")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # click
+    p_click = sub.add_parser("click", help="Click element")
+    p_click.add_argument("x", nargs="?", type=float, help="X coordinate")
+    p_click.add_argument("y", nargs="?", type=float, help="Y coordinate")
+    p_click.add_argument("--selector", "-s", help="CSS selector (alternative to x,y)")
+
+    # fill
+    p_fill = sub.add_parser("fill", help="Fill text into element")
+    p_fill.add_argument("--selector", "-s", required=True, help="CSS selector")
+    p_fill.add_argument("text", help="Text to fill")
+
+    # press_key
+    p_key = sub.add_parser("press_key", help="Press keyboard key")
+    p_key.add_argument("key", help="Key name (e.g., Enter, Tab, a)")
+    p_key.add_argument("--modifiers", "-m", help="Comma-separated: ctrl,shift,alt,meta")
+
+    # hover
+    p_hover = sub.add_parser("hover", help="Hover over element")
+    p_hover.add_argument("x", nargs="?", type=float, help="X coordinate")
+    p_hover.add_argument("y", nargs="?", type=float, help="Y coordinate")
+    p_hover.add_argument("--selector", "-s", help="CSS selector")
+
+    # new_page
+    p_new = sub.add_parser("new_page", help="Open new tab")
+    p_new.add_argument("url", nargs="?", default="", help="URL to open")
+
+    # close_page
+    p_close = sub.add_parser("close_page", help="Close a tab")
+    p_close.add_argument("target_id", nargs="?", help="Target ID (default: selected)")
+
+    args = parser.parse_args()
+    client = CDPClient(host=args.host, port=args.port)
+
+    commands = {
+        "click": cmd_click,
+        "fill": cmd_fill,
+        "press_key": cmd_press_key,
+        "hover": cmd_hover,
+        "new_page": cmd_new_page,
+        "close_page": cmd_close_page,
+    }
+
+    try:
+        commands[args.command](client, args)
+    except CDPError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/cdp-browser/scripts/v3_advanced.py
+++ b/cdp-browser/scripts/v3_advanced.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env uv run --quiet --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "websocket-client>=1.6.0",
+# ]
+# ///
+"""
+v3_advanced — Advanced CDP: network/console monitoring, perf tracing, emulation, drag, dialog.
+"""
+
+import argparse
+import json
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from cdp_client import CDPClient, CDPError
+
+CACHE_DIR = os.path.expanduser("~/.cache/cdp-browser")
+NETWORK_EVENTS = os.path.join(CACHE_DIR, "network-events.jsonl")
+CONSOLE_EVENTS = os.path.join(CACHE_DIR, "console-events.jsonl")
+AUTO_TIMEOUT = 300  # 5 minutes
+
+
+def _kill_existing(client, process_type):
+    """Kill existing background process if running."""
+    pid = client.get_pid(process_type)
+    if pid:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            time.sleep(0.2)
+        except ProcessLookupError:
+            pass
+        client.clear_pid(process_type)
+
+
+def _run_collector(client, process_type, events_file, enable_method, event_names):
+    """Fork a background collector process."""
+    import websocket
+
+    target_id = client.get_selected_target()
+    if not target_id:
+        raise CDPError("No tab selected. Use 'select' first.")
+
+    _kill_existing(client, process_type)
+    os.makedirs(CACHE_DIR, exist_ok=True)
+
+    # Clear previous events
+    open(events_file, "w").close()
+
+    pid = os.fork()
+    if pid > 0:
+        # Parent
+        client.save_pid(process_type, pid)
+        print(f"{process_type} collector started (PID {pid})")
+        print(f"Events: {events_file}")
+        return
+
+    # Child — collector process
+    try:
+        # Detach from parent
+        os.setsid()
+        signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+
+        ws = websocket.create_connection(
+            f"ws://{client.host}:{client.port}/devtools/page/{target_id}",
+            timeout=AUTO_TIMEOUT,
+            suppress_origin=True,
+        )
+
+        # Enable domain
+        msg_id = 1
+        ws.send(json.dumps({"id": msg_id, "method": enable_method}))
+        # Wait for ack
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            resp = json.loads(ws.recv())
+            if resp.get("id") == msg_id:
+                break
+
+        # Collect events
+        start_time = time.time()
+        with open(events_file, "a") as f:
+            while time.time() - start_time < AUTO_TIMEOUT:
+                try:
+                    ws.settimeout(1.0)
+                    raw = ws.recv()
+                    data = json.loads(raw)
+                    method = data.get("method", "")
+                    if method in event_names:
+                        entry = {
+                            "t": time.time(),
+                            "method": method,
+                            "params": data.get("params", {}),
+                        }
+                        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                        f.flush()
+                except Exception:
+                    continue
+
+        ws.close()
+    except Exception:
+        pass
+    finally:
+        os._exit(0)
+
+
+def cmd_network_start(client, args):
+    """Start network request collector."""
+    _run_collector(
+        client, "network", NETWORK_EVENTS,
+        "Network.enable",
+        {
+            "Network.requestWillBeSent",
+            "Network.responseReceived",
+            "Network.loadingFinished",
+            "Network.loadingFailed",
+        },
+    )
+
+
+def cmd_network_list(client, args):
+    """List collected network requests."""
+    if not os.path.exists(NETWORK_EVENTS):
+        print("No network events collected. Run network_start first.")
+        return
+
+    requests = {}  # requestId -> info
+    with open(NETWORK_EVENTS) as f:
+        for line in f:
+            if not line.strip():
+                continue
+            entry = json.loads(line)
+            method = entry["method"]
+            params = entry["params"]
+
+            if method == "Network.requestWillBeSent":
+                req = params.get("request", {})
+                rid = params.get("requestId", "")
+                requests[rid] = {
+                    "url": req.get("url", "")[:100],
+                    "method": req.get("method", ""),
+                    "status": "pending",
+                    "type": params.get("type", ""),
+                }
+            elif method == "Network.responseReceived":
+                rid = params.get("requestId", "")
+                resp = params.get("response", {})
+                if rid in requests:
+                    requests[rid]["status"] = str(resp.get("status", "?"))
+                    requests[rid]["mime"] = resp.get("mimeType", "")[:30]
+            elif method == "Network.loadingFailed":
+                rid = params.get("requestId", "")
+                if rid in requests:
+                    requests[rid]["status"] = "FAILED"
+
+    # Filter
+    items = list(requests.values())
+    if args.filter:
+        pattern = args.filter.lower()
+        items = [r for r in items if pattern in r.get("url", "").lower()]
+
+    if not items:
+        print("No matching requests.")
+        return
+
+    print(f"{'Method':<7} {'Status':<8} {'Type':<12} URL")
+    print("-" * 80)
+    for r in items:
+        print(f"{r.get('method','?'):<7} {r.get('status','?'):<8} {r.get('type',''):<12} {r['url']}")
+    print(f"\nTotal: {len(items)} requests")
+
+
+def cmd_network_stop(client, args):
+    """Stop network collector."""
+    _kill_existing(client, "network")
+    print("Network collector stopped.")
+    # Show final count
+    if os.path.exists(NETWORK_EVENTS):
+        with open(NETWORK_EVENTS) as f:
+            count = sum(1 for _ in f)
+        print(f"Collected {count} events → {NETWORK_EVENTS}")
+
+
+def cmd_console_start(client, args):
+    """Start console message collector."""
+    _run_collector(
+        client, "console", CONSOLE_EVENTS,
+        "Runtime.enable",
+        {"Runtime.consoleAPICalled", "Runtime.exceptionThrown"},
+    )
+
+
+def cmd_console_list(client, args):
+    """List collected console messages."""
+    if not os.path.exists(CONSOLE_EVENTS):
+        print("No console events collected. Run console_start first.")
+        return
+
+    messages = []
+    with open(CONSOLE_EVENTS) as f:
+        for line in f:
+            if not line.strip():
+                continue
+            entry = json.loads(line)
+            params = entry["params"]
+
+            if entry["method"] == "Runtime.consoleAPICalled":
+                level = params.get("type", "log")
+                call_args = params.get("args", [])
+                text = " ".join(
+                    a.get("value", a.get("description", str(a)))
+                    for a in call_args
+                )[:200]
+                messages.append({"level": level, "text": text, "t": entry["t"]})
+            elif entry["method"] == "Runtime.exceptionThrown":
+                exc = params.get("exceptionDetails", {})
+                text = exc.get("text", "")
+                exception = exc.get("exception", {})
+                desc = exception.get("description", "")
+                messages.append({
+                    "level": "error",
+                    "text": f"{text} {desc}"[:200],
+                    "t": entry["t"],
+                })
+
+    # Filter by level
+    if args.level and args.level != "all":
+        messages = [m for m in messages if m["level"] == args.level]
+
+    if not messages:
+        print("No matching console messages.")
+        return
+
+    for m in messages:
+        ts = time.strftime("%H:%M:%S", time.localtime(m["t"]))
+        print(f"[{ts}] {m['level'].upper():<7} {m['text']}")
+    print(f"\nTotal: {len(messages)} messages")
+
+
+def cmd_console_stop(client, args):
+    """Stop console collector."""
+    _kill_existing(client, "console")
+    print("Console collector stopped.")
+    if os.path.exists(CONSOLE_EVENTS):
+        with open(CONSOLE_EVENTS) as f:
+            count = sum(1 for _ in f)
+        print(f"Collected {count} events → {CONSOLE_EVENTS}")
+
+
+def cmd_perf_start(client, args):
+    """Start performance tracing."""
+    client.connect()
+    try:
+        params = {}
+        if args.categories:
+            params["categories"] = args.categories
+        client.send("Tracing.start", params)
+        print("Tracing started.")
+        if args.categories:
+            print(f"  Categories: {args.categories}")
+    finally:
+        client.close()
+
+
+def cmd_perf_stop(client, args):
+    """Stop tracing and save results."""
+    client.connect()
+    try:
+        client.send("Tracing.end")
+
+        # Collect trace chunks
+        chunks = []
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            try:
+                client._ws.settimeout(2.0)
+                raw = client._ws.recv()
+                resp = json.loads(raw)
+                method = resp.get("method", "")
+                if method == "Tracing.dataCollected":
+                    chunks.extend(resp.get("params", {}).get("value", []))
+                elif method == "Tracing.tracingComplete":
+                    break
+            except Exception:
+                continue
+
+        output = args.output or f"/tmp/cdp-trace-{int(time.time())}.json"
+        with open(output, "w") as f:
+            json.dump({"traceEvents": chunks}, f)
+        print(f"Trace saved: {output} ({len(chunks)} events)")
+    finally:
+        client.close()
+
+
+def cmd_emulate(client, args):
+    """Set device emulation."""
+    client.connect()
+    try:
+        params = {
+            "width": args.width,
+            "height": args.height,
+            "deviceScaleFactor": args.scale,
+            "mobile": args.mobile,
+        }
+        client.send("Emulation.setDeviceMetricsOverride", params)
+        print(f"Emulation set: {args.width}x{args.height} (scale={args.scale}, mobile={args.mobile})")
+    finally:
+        client.close()
+
+
+def cmd_drag(client, args):
+    """Drag from (x1,y1) to (x2,y2)."""
+    client.connect()
+    try:
+        steps = args.steps or 10
+        dx = (args.x2 - args.x1) / steps
+        dy = (args.y2 - args.y1) / steps
+
+        # Mouse down at start
+        client.send("Input.dispatchMouseEvent", {
+            "type": "mousePressed",
+            "x": args.x1, "y": args.y1,
+            "button": "left", "clickCount": 1,
+        })
+
+        # Intermediate moves
+        for i in range(1, steps + 1):
+            client.send("Input.dispatchMouseEvent", {
+                "type": "mouseMoved",
+                "x": args.x1 + dx * i,
+                "y": args.y1 + dy * i,
+                "button": "left",
+            })
+            time.sleep(0.01)
+
+        # Mouse up at end
+        client.send("Input.dispatchMouseEvent", {
+            "type": "mouseReleased",
+            "x": args.x2, "y": args.y2,
+            "button": "left", "clickCount": 1,
+        })
+
+        print(f"Dragged ({args.x1},{args.y1}) → ({args.x2},{args.y2}) in {steps} steps")
+    finally:
+        client.close()
+
+
+def cmd_dialog(client, args):
+    """Handle JavaScript dialog (alert/confirm/prompt)."""
+    client.connect()
+    try:
+        params = {"accept": args.action == "accept"}
+        if args.prompt_text:
+            params["promptText"] = args.prompt_text
+        client.send("Page.handleJavaScriptDialog", params)
+        print(f"Dialog {args.action}ed" + (f" with: {args.prompt_text}" if args.prompt_text else ""))
+    finally:
+        client.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="cdp-v3",
+        description="Advanced CDP operations",
+    )
+    parser.add_argument("--host", help="CDP host")
+    parser.add_argument("--port", type=int, help="CDP port")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # network
+    sub.add_parser("network_start", help="Start network collector")
+    p_nl = sub.add_parser("network_list", help="List collected requests")
+    p_nl.add_argument("--filter", help="URL pattern filter")
+    sub.add_parser("network_stop", help="Stop network collector")
+
+    # console
+    sub.add_parser("console_start", help="Start console collector")
+    p_cl = sub.add_parser("console_list", help="List console messages")
+    p_cl.add_argument("--level", choices=["error", "warn", "all"], default="all")
+    sub.add_parser("console_stop", help="Stop console collector")
+
+    # perf
+    p_ps = sub.add_parser("perf_start", help="Start tracing")
+    p_ps.add_argument("--categories", help="Trace categories (comma-separated)")
+    p_pst = sub.add_parser("perf_stop", help="Stop tracing")
+    p_pst.add_argument("--output", "-o", help="Output trace file path")
+
+    # emulate
+    p_em = sub.add_parser("emulate", help="Device emulation")
+    p_em.add_argument("--width", type=int, required=True)
+    p_em.add_argument("--height", type=int, required=True)
+    p_em.add_argument("--scale", type=float, default=1.0, help="Device scale factor")
+    p_em.add_argument("--mobile", action="store_true")
+
+    # drag
+    p_drag = sub.add_parser("drag", help="Drag gesture")
+    p_drag.add_argument("x1", type=float)
+    p_drag.add_argument("y1", type=float)
+    p_drag.add_argument("x2", type=float)
+    p_drag.add_argument("y2", type=float)
+    p_drag.add_argument("--steps", type=int, default=10, help="Interpolation steps")
+
+    # dialog
+    p_dlg = sub.add_parser("dialog", help="Handle JS dialog")
+    p_dlg.add_argument("action", choices=["accept", "dismiss"])
+    p_dlg.add_argument("prompt_text", nargs="?", help="Text for prompt dialogs")
+
+    args = parser.parse_args()
+    client = CDPClient(host=args.host, port=args.port)
+
+    commands = {
+        "network_start": cmd_network_start,
+        "network_list": cmd_network_list,
+        "network_stop": cmd_network_stop,
+        "console_start": cmd_console_start,
+        "console_list": cmd_console_list,
+        "console_stop": cmd_console_stop,
+        "perf_start": cmd_perf_start,
+        "perf_stop": cmd_perf_stop,
+        "emulate": cmd_emulate,
+        "drag": cmd_drag,
+        "dialog": cmd_dialog,
+    }
+
+    try:
+        commands[args.command](client, args)
+    except CDPError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/cdp-browser/skills/cdp-browser/SKILL.md
+++ b/cdp-browser/skills/cdp-browser/SKILL.md
@@ -90,12 +90,15 @@ $V3 perf_stop -o /tmp/trace.json               # Save trace
 
 # Device emulation
 $V3 emulate --width 375 --height 812 --scale 3 --mobile
+$V3 emulate_reset                                       # Reset emulation to defaults
 
 # Drag and dialog
 $V3 drag 100 100 300 300 --steps 20
 $V3 dialog accept                              # Handle alert/confirm
 $V3 dialog accept "prompt input"               # Handle prompt
 ```
+
+> **Note**: `dialog` is reactive — it handles an already-open dialog. It will fail if no dialog is currently visible. Trigger the dialog first (e.g., via `evaluate` or navigation), then call `dialog` to respond.
 
 ## Typical Workflows
 

--- a/cdp-browser/skills/cdp-browser/SKILL.md
+++ b/cdp-browser/skills/cdp-browser/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: cdp-browser
+description: |
+  This skill should be used when the user asks to "take browser screenshot",
+  "list browser tabs", "click page element", "navigate browser",
+  "automate browser", "inspect accessibility tree", "monitor network",
+  "run JavaScript in browser", "fill form in browser", "debug web page",
+  or mentions CDP. Provides direct Chrome DevTools Protocol browser automation without Puppeteer.
+user_invocable: true
+context: fork
+argument-hint: "<operation> [args...]"
+---
+
+# CDP Browser Automation
+
+Direct Chrome DevTools Protocol client bypassing Puppeteer. Immune to frozen-tab timeouts.
+
+## Prerequisites
+
+Chrome must be running with remote debugging enabled:
+```bash
+# macOS
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
+```
+
+## Execution
+
+Each Bash call is a separate shell. Always combine the variable assignment with the command:
+```bash
+V1="${CLAUDE_PLUGIN_ROOT}/scripts/v1_core.py" && $V1 list
+V2="${CLAUDE_PLUGIN_ROOT}/scripts/v2_interact.py" && $V2 click --selector "a"
+V3="${CLAUDE_PLUGIN_ROOT}/scripts/v3_advanced.py" && $V3 network_start
+```
+
+## Quick Reference
+
+### v1 — Core (`v1_core.py`)
+
+```bash
+V1="${CLAUDE_PLUGIN_ROOT}/scripts/v1_core.py"
+
+$V1 version                                    # Browser info
+$V1 list                                       # List tabs (default: first 50 pages)
+$V1 list --search "github" --limit 20          # Search tabs
+$V1 list --type all                            # Include iframes, workers
+$V1 select 0                                   # Select tab by index
+$V1 select AB71CD183BCE05DD...                  # Select by target ID
+$V1 screenshot                                 # PNG of selected tab
+$V1 screenshot --full-page --format jpeg -o /tmp/page.jpg
+$V1 snapshot --depth 3                         # Accessibility tree
+$V1 evaluate "document.title"                  # Run JavaScript
+$V1 evaluate "fetch('/api').then(r=>r.json())" --await
+$V1 navigate "https://example.com"             # Navigate
+$V1 navigate "https://example.com" --wait-for none
+```
+
+### v2 — Interaction (`v2_interact.py`)
+
+```bash
+V2="${CLAUDE_PLUGIN_ROOT}/scripts/v2_interact.py"
+
+$V2 click 100 200                              # Click at coordinates
+$V2 click --selector "button.submit"           # Click CSS selector
+$V2 fill --selector "input[name=q]" "search query"
+$V2 press_key Enter                            # Press key
+$V2 press_key a --modifiers ctrl               # Ctrl+A
+$V2 hover --selector "a.nav-link"
+$V2 new_page "https://example.com"             # Open new tab
+$V2 close_page                                 # Close selected tab
+```
+
+### v3 — Advanced (`v3_advanced.py`)
+
+```bash
+V3="${CLAUDE_PLUGIN_ROOT}/scripts/v3_advanced.py"
+
+# Network monitoring (background collector)
+$V3 network_start                              # Start collecting
+$V3 network_list --filter "api"                # View requests
+$V3 network_stop                               # Stop + summary
+
+# Console monitoring
+$V3 console_start
+$V3 console_list --level error                 # Errors only
+$V3 console_stop
+
+# Performance tracing
+$V3 perf_start --categories "devtools.timeline"
+$V3 perf_stop -o /tmp/trace.json               # Save trace
+
+# Device emulation
+$V3 emulate --width 375 --height 812 --scale 3 --mobile
+
+# Drag and dialog
+$V3 drag 100 100 300 300 --steps 20
+$V3 dialog accept                              # Handle alert/confirm
+$V3 dialog accept "prompt input"               # Handle prompt
+```
+
+## Typical Workflows
+
+### Screenshot Analysis
+```
+1. v1 list --search "target"    → Find the tab
+2. v1 select <index>            → Select it
+3. v1 screenshot                → Capture PNG
+4. Read /tmp/cdp-screenshot-*.png → View in Claude
+```
+
+### Form Interaction
+```
+1. v1 select <tab>
+2. v1 snapshot --depth 3        → Understand page structure
+3. v2 fill --selector "input" "text"
+4. v2 click --selector "button[type=submit]"
+5. v1 screenshot                → Verify result
+```
+
+### Network Debugging
+```
+1. v1 select <tab>
+2. v3 network_start             → Begin capture
+3. v1 navigate "https://..."    → Trigger requests
+4. v3 network_list --filter "api" → Inspect
+5. v3 network_stop              → Cleanup
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CDP_HOST` | `127.0.0.1` | Chrome DevTools host |
+| `CDP_PORT` | `9222` | Chrome DevTools port |
+
+Or use `--host` / `--port` flags on any command.
+
+## State
+
+- Selected tab: `~/.cache/cdp-browser/state.json`
+- Network events: `~/.cache/cdp-browser/network-events.jsonl`
+- Console events: `~/.cache/cdp-browser/console-events.jsonl`
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| CDP HTTP endpoint unreachable | Browser not running with `--remote-debugging-port` | Start browser with CDP enabled |
+| Timeout waiting for response | Tab frozen/suspended | Select a different active tab |
+| WebSocket connection failed | Tab closed or navigated away | Re-select tab with `list` + `select` |
+| Element not found | Invalid CSS selector | Check selector with `evaluate` + `querySelector` |
+
+## Protocol Reference
+
+For CDP domain methods, key codes, and device presets, see `references/cdp-protocol.md`.
+
+## Argument Dispatch
+
+When user provides arguments to `/cdp-browser`:
+- Single word matching a subcommand → run directly (e.g., `/cdp-browser list`)
+- Free-form request → map to appropriate v1/v2/v3 command sequence

--- a/cdp-browser/skills/cdp-browser/references/cdp-protocol.md
+++ b/cdp-browser/skills/cdp-browser/references/cdp-protocol.md
@@ -1,0 +1,113 @@
+# CDP Protocol Reference
+
+Quick reference for Chrome DevTools Protocol methods used by this skill.
+
+## Core Domains
+
+### Page
+
+```
+Page.navigate({url})                    → {frameId, loaderId}
+Page.captureScreenshot({format, quality, captureBeyondViewport})  → {data: base64}
+Page.getLayoutMetrics()                 → {contentSize: {width, height}}
+Page.handleJavaScriptDialog({accept, promptText})
+  accept: boolean (true=OK/Yes, false=Cancel/No)
+  promptText: string (optional, for window.prompt() only)
+  Dialog types: alert → accept only, confirm → accept/dismiss, prompt → accept with text
+Page.loadEventFired                     ← event
+```
+
+### Runtime
+
+```
+Runtime.evaluate({expression, returnByValue, awaitPromise})  → {result: {type, value, description}}
+Runtime.enable()
+Runtime.consoleAPICalled                ← {type, args[], timestamp}
+Runtime.exceptionThrown                 ← {exceptionDetails}
+```
+
+### Input
+
+```
+Input.dispatchMouseEvent({type, x, y, button, clickCount, modifiers})
+  type: mousePressed | mouseReleased | mouseMoved
+
+Input.dispatchKeyEvent({type, key, code, modifiers, windowsVirtualKeyCode})
+  type: keyDown | keyUp | char
+
+Input.insertText({text})
+```
+
+**Modifier bitmask**: Alt=1, Ctrl=2, Shift=4, Meta=8
+
+### Accessibility
+
+```
+Accessibility.enable()
+Accessibility.getFullAXTree({depth})    → {nodes[]}
+  node: {nodeId, role: {value}, name: {value}, parentId, childIds[]}
+```
+
+### Network
+
+```
+Network.enable()
+Network.requestWillBeSent              ← {requestId, request: {url, method}}
+Network.responseReceived               ← {requestId, response: {status, mimeType}}
+Network.loadingFinished                ← {requestId}
+Network.loadingFailed                  ← {requestId, errorText}
+```
+
+### Emulation
+
+```
+Emulation.setDeviceMetricsOverride({width, height, deviceScaleFactor, mobile})
+Emulation.clearDeviceMetricsOverride()
+```
+
+### Tracing
+
+```
+Tracing.start({categories})
+Tracing.end()
+Tracing.dataCollected                  ← {value: traceEvent[]}
+Tracing.tracingComplete                ← event
+```
+
+## Key Codes (Common)
+
+| Key | code | windowsVirtualKeyCode |
+|-----|------|-----------------------|
+| Enter | Enter | 13 |
+| Tab | Tab | 9 |
+| Escape | Escape | 27 |
+| Backspace | Backspace | 8 |
+| Delete | Delete | 46 |
+| Space | Space | 32 |
+| ArrowUp | ArrowUp | 38 |
+| ArrowDown | ArrowDown | 40 |
+| ArrowLeft | ArrowLeft | 37 |
+| ArrowRight | ArrowRight | 39 |
+| a-z | KeyA-KeyZ | 65-90 |
+| 0-9 | Digit0-Digit9 | 48-57 |
+
+## Device Presets
+
+| Device | Width | Height | Scale | Mobile |
+|--------|-------|--------|-------|--------|
+| iPhone 14 | 390 | 844 | 3 | true |
+| iPhone 14 Pro Max | 430 | 932 | 3 | true |
+| iPad Air | 820 | 1180 | 2 | true |
+| Pixel 7 | 412 | 915 | 2.625 | true |
+| Desktop HD | 1920 | 1080 | 1 | false |
+| Desktop 4K | 3840 | 2160 | 2 | false |
+
+## HTTP Endpoints
+
+```
+GET /json/list              → [{id, type, title, url, webSocketDebuggerUrl}]
+GET /json/version           → {Browser, Protocol-Version, V8-Version}
+GET /json/new?{url}         → {id, ...}  (open new tab)
+GET /json/close/{targetId}  → "Target is closing"
+GET /json/activate/{targetId} → "Target activated"
+```


### PR DESCRIPTION
## Summary

- Direct Chrome DevTools Protocol client (Puppeteer-free) with 3-tier script architecture: v1 core (tab/screenshot/evaluate), v2 interaction (click/fill/hover), v3 advanced (network/console/emulation/tracing)
- Skill review 반영: zero-context Execution 가이드, Prerequisites, Protocol Reference 포인터, click/hover validation, description 트리거 개선

## 구조

```
cdp-browser/
  .claude-plugin/plugin.json
  scripts/
    cdp_client.py          # 공유 CDP 클라이언트 (HTTP + WebSocket)
    v1_core.py             # 탭 관리, 스크린샷, JS 실행, 접근성 트리
    v2_interact.py         # 클릭, 폼 입력, 키 입력, 호버
    v3_advanced.py         # 네트워크/콘솔 모니터링, 디바이스 에뮬레이션, 드래그
  skills/cdp-browser/
    SKILL.md               # 스킬 프롬프트
    references/
      cdp-protocol.md      # CDP 프로토콜 레퍼런스
```

## Skill Review 반영 사항

| 항목 | 변경 |
|------|------|
| Major 1 | "interact with Dia" → "fill form in browser", "debug web page" + capability 요약문 |
| Major 2 | `## Protocol Reference` 섹션 추가 |
| Minor 1 | `## Prerequisites` — Chrome remote debugging 설정 |
| Minor 4 | `v2_interact.py` click/hover coordinate validation |
| Minor 5 | `cdp-protocol.md` handleJavaScriptDialog 파라미터 상세화 |
| zero-context | `## Execution` — `V1=... && $V1` 패턴 명시 |

## Test plan

- [x] Chrome `--remote-debugging-port=9222`로 실행 후 `v1_core.py list` 동작 확인
- [x] `v2_interact.py click` (selector/좌표 미입력 시 에러 메시지 확인)
- [x] `/cdp-browser list` 스킬 호출 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)


