### PR TITLE
fix(cdp-attach): evaluate 강화 — var 재작성, --stdin, Common Mistakes

### DIFF
--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -53,9 +53,34 @@ $V1 screenshot --full-page --format jpeg -o /tmp/page.jpg
 $V1 snapshot --depth 3                         # Accessibility tree
 $V1 evaluate "document.title"                  # Run JavaScript
 $V1 evaluate "fetch('/api').then(r=>r.json())" --await
+$V1 evaluate --stdin <<< 'var x = document.title; x'  # Stdin mode
+$V1 evaluate --no-rewrite "const x = 1"       # Skip var rewriting
 $V1 navigate "https://example.com"             # Navigate
 $V1 navigate "https://example.com" --wait-for none
 ```
+
+### Common Mistakes
+
+**Commands that do NOT exist:**
+- `read_screenshot` — use `v1 screenshot` then `Read /tmp/cdp-screenshot-*.png`
+
+**Arguments that do NOT exist:**
+- `click --coordinates x y` — use positional: `click 100 200`
+- `click --text "..."` — use `click --selector` with a CSS selector instead
+- `screenshot --selector` — not supported; screenshot captures the full viewport (or `--full-page`)
+
+**JavaScript in evaluate:**
+- `const`/`let` are auto-rewritten to `var` by default (prevents re-declaration errors on repeated calls). Use `--no-rewrite` to disable.
+- For complex JS with quotes/backticks, use `--stdin` with heredoc:
+  ```bash
+  $V1 evaluate --stdin <<'JS'
+  document.querySelectorAll('a').forEach(a => console.log(a.href))
+  JS
+  ```
+- Use `--await` flag for promises (auto-wraps in async IIFE if needed):
+  ```bash
+  $V1 evaluate --await "await fetch('/api').then(r => r.json())"
+  ```
 
 ### v2 — Interaction (`v2_interact.py`)
 

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -26,6 +26,29 @@ claude --chrome
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
 ```
 
+## Scope Guard
+
+cdp-attach is for **acting on** the attached browser, not for **researching through** it.
+
+**WILL** use cdp-attach for:
+- Capturing current state (screenshot, snapshot, network/console logs)
+- Interacting with attached page (click, fill, JS evaluate, dialog handling)
+- Navigating as a workflow step (e.g., form submit → result page, SPA state transitions)
+- Monitoring (network_start/stop, console, performance tracing)
+- Error diagnosis (screenshot + Read of error pages during automation)
+- API response debugging (navigate to endpoint as part of debugging workflow)
+
+**WILL NOT** use cdp-attach for:
+- Browsing documentation or API references
+- Searching for information via web pages
+- Opening new tabs to research topics
+- Reading web content for knowledge gathering
+
+**Litmus test**: "Am I acting on the page, or learning from it?"
+If learning → switch to Tavily MCP (`tavily_search`, `tavily_extract`) or Prothesis for multi-perspective investigation.
+
+**Redirect rule**: When a research need arises mid-workflow, pause the cdp-attach context, resolve via Tavily, then resume cdp-attach with the findings.
+
 ## Execution
 
 Each Bash call is a separate shell. Always combine the variable assignment with the command:


### PR DESCRIPTION
## Summary

- hooks.log PostToolUseFailure 27건 분석 → 71% (19/27건) 구조적 제거
- Prothesis 6-관점 병렬 분석 + cross-dialogue를 통해 IIFE 대신 `var` 재작성으로 수렴
- 5개 이슈 제기 에이전트의 peer review 전원 PASS

## Changes

### v1_core.py (6 fixes)

| Fix | Pattern | Impact | Description |
|-----|---------|--------|-------------|
| var 재작성 | A (37%) | High | `const`/`let` → `var` 자동 치환, `--no-rewrite` 탈출구, stderr 로깅 |
| `--stdin` | B (19%) | High | stdin에서 JS 읽기 — shell 인용부호 문제 완전 우회 |
| await 자동감지 | F | Medium | `--await` + `await` 키워드 시 async IIFE 자동 래핑 (return 포함) |
| 0-width 가드 | F | Low | `--full-page` 스크린샷 시 `max(width, 1)` 가드 |
| navigate 경고 | Silent | Medium | Page.loadEventFired 미수신 시 stderr 경고 |

### SKILL.md

- **Common Mistakes** 섹션 추가: 존재하지 않는 명령(`read_screenshot`), 인자(`--coordinates`, `--text`), JS 패턴 안내
- Quick Reference에 `--stdin`, `--no-rewrite` 예시 추가

## Design Decisions

- **var 재작성 > IIFE 래핑**: cross-dialogue에서 IIFE가 반환값을 깨뜨리는 문제 확인 → `var` 재작성이 반환값 보존 + 낮은 복잡도로 수렴
- **알려진 제한**: regex가 문자열 리터럴 내부 `const`/`let`도 매칭 — `--no-rewrite`로 완화

## Test plan

- [ ] `$V1 evaluate "document.title"` — var 재작성 미적용 확인 (const/let 없음)
- [ ] `$V1 evaluate "const x = document.title; x"` — var 재작성 + 정상 반환
- [ ] `$V1 evaluate --stdin <<< 'var x = 1; x'` — stdin 모드 정상 동작
- [ ] `$V1 evaluate --await "await fetch('https://example.com')"` — async IIFE return 포함 확인
- [ ] `$V1 evaluate --no-rewrite "const x = 1"` — 재작성 비활성화 확인
- [ ] `$V1 screenshot --full-page` — 0-width 페이지에서 에러 없음
- [ ] `$V1 navigate "https://example.com"` — 30s 타임아웃 시 stderr 경고

🤖 Generated with [Claude Code](https://claude.com/claude-code)