### PR TITLE
fix(cdp-attach): headless 브라우저 감지 및 차단

### DIFF
--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/scripts/cdp_client.py
+++ b/cdp-attach/scripts/cdp_client.py
@@ -73,6 +73,32 @@ class CDPClient:
         """Get browser version info."""
         return self._http_get("/json/version")
 
+    def is_headless(self):
+        """Check if the connected browser is running in headless mode."""
+        try:
+            info = self.get_version()
+            browser = info.get("Browser", "")
+            ua = info.get("User-Agent", "")
+            return "Headless" in browser or "HeadlessChrome" in ua
+        except CDPError:
+            return False
+
+    def require_headed(self):
+        """Raise CDPError if the browser is running headless.
+
+        Headless browsers pose silent execution risks — actions happen
+        without user visibility. Use a visible browser instance instead.
+        """
+        if self.is_headless():
+            raise CDPError(
+                "Headless Chrome detected — cdp-attach requires a visible browser.\n"
+                "Silent execution risk: actions occur without user visibility.\n"
+                "\n"
+                "Launch a visible Chrome instance:\n"
+                "  /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome "
+                "--remote-debugging-port=9222"
+            )
+
     def new_tab(self, url=""):
         """Open a new tab."""
         path = f"/json/new?{url}" if url else "/json/new"

--- a/cdp-attach/scripts/cdp_client.py
+++ b/cdp-attach/scripts/cdp_client.py
@@ -74,14 +74,16 @@ class CDPClient:
         return self._http_get("/json/version")
 
     def is_headless(self):
-        """Check if the connected browser is running in headless mode."""
-        try:
-            info = self.get_version()
-            browser = info.get("Browser", "")
-            ua = info.get("User-Agent", "")
-            return "Headless" in browser or "HeadlessChrome" in ua
-        except CDPError:
-            return False
+        """Check if the browser is running in headless mode.
+
+        Raises CDPError if the CDP endpoint is unreachable (fail-closed).
+        """
+        info = self.get_version()
+        browser = info.get("Browser", "").lower()
+        ua = info.get("User-Agent", "").lower()
+        # Detects classic headless ("HeadlessChrome") only.
+        # Chrome --headless=new (112+) is indistinguishable via /json/version.
+        return "headless" in browser or "headlesschrome" in ua
 
     def require_headed(self):
         """Raise CDPError if the browser is running headless.

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -354,6 +354,10 @@ def main():
     args = parser.parse_args()
     client = CDPClient(host=args.host, port=args.port)
 
+    # Block headless browsers (except version for diagnostics)
+    if args.command != "version":
+        client.require_headed()
+
     commands = {
         "version": cmd_version,
         "list": cmd_list,

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -354,10 +354,6 @@ def main():
     args = parser.parse_args()
     client = CDPClient(host=args.host, port=args.port)
 
-    # Block headless browsers (except version for diagnostics)
-    if args.command != "version":
-        client.require_headed()
-
     commands = {
         "version": cmd_version,
         "list": cmd_list,
@@ -369,6 +365,9 @@ def main():
     }
 
     try:
+        # Block headless browsers (except version for diagnostics)
+        if args.command != "version":
+            client.require_headed()
         commands[args.command](client, args)
     except CDPError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/cdp-attach/scripts/v2_interact.py
+++ b/cdp-attach/scripts/v2_interact.py
@@ -257,6 +257,7 @@ def main():
 
     args = parser.parse_args()
     client = CDPClient(host=args.host, port=args.port)
+    client.require_headed()
 
     commands = {
         "click": cmd_click,

--- a/cdp-attach/scripts/v2_interact.py
+++ b/cdp-attach/scripts/v2_interact.py
@@ -257,7 +257,6 @@ def main():
 
     args = parser.parse_args()
     client = CDPClient(host=args.host, port=args.port)
-    client.require_headed()
 
     commands = {
         "click": cmd_click,
@@ -269,6 +268,7 @@ def main():
     }
 
     try:
+        client.require_headed()  # Block headless browsers
         commands[args.command](client, args)
     except CDPError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/cdp-attach/scripts/v3_advanced.py
+++ b/cdp-attach/scripts/v3_advanced.py
@@ -456,7 +456,8 @@ def main():
     args = parser.parse_args()
     client = CDPClient(host=args.host, port=args.port)
 
-    # Commands that only read local state or manage local processes
+    # Exempt from headless guard: read local files or manage local PIDs,
+    # never sending CDP commands to the browser. Keep in sync with commands dict.
     LOCAL_COMMANDS = {"network_list", "network_stop", "console_list", "console_stop"}
 
     commands = {

--- a/cdp-attach/scripts/v3_advanced.py
+++ b/cdp-attach/scripts/v3_advanced.py
@@ -455,7 +455,9 @@ def main():
 
     args = parser.parse_args()
     client = CDPClient(host=args.host, port=args.port)
-    client.require_headed()
+
+    # Commands that only read local state or manage local processes
+    LOCAL_COMMANDS = {"network_list", "network_stop", "console_list", "console_stop"}
 
     commands = {
         "network_start": cmd_network_start,
@@ -473,6 +475,9 @@ def main():
     }
 
     try:
+        # Block headless browsers (except local-only commands)
+        if args.command not in LOCAL_COMMANDS:
+            client.require_headed()
         commands[args.command](client, args)
     except CDPError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/cdp-attach/scripts/v3_advanced.py
+++ b/cdp-attach/scripts/v3_advanced.py
@@ -455,6 +455,7 @@ def main():
 
     args = parser.parse_args()
     client = CDPClient(host=args.host, port=args.port)
+    client.require_headed()
 
     commands = {
         "network_start": cmd_network_start,

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -17,14 +17,14 @@ Attach to a running Chrome DevTools Protocol instance. Immune to frozen-tab time
 
 ## Prerequisites
 
-A CDP-enabled browser must be running. Typical launch methods:
-```bash
-# Via claude --chrome (recommended)
-claude --chrome
+A **visible** (headed) CDP-enabled browser must be running. Headless instances are blocked — silent execution without user visibility is a security risk.
 
-# Manual launch
+```bash
+# Manual launch (visible browser)
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
 ```
+
+> **Note**: `claude --chrome` may launch a headless instance. If `v1 version` shows `HeadlessChrome`, use the manual launch method above instead.
 
 ## Scope Guard
 


### PR DESCRIPTION
## Summary

- `CDPClient`에 `is_headless()`, `require_headed()` 메서드를 추가하여 headless Chrome 연결을 감지
- v1/v2/v3 모든 스크립트 진입점에서 headless 감지 시 `CDPError`로 차단 (silent execution 방지)
- `v1 version`만 예외로 허용하여 사용자가 연결 상태를 진단할 수 있도록 함
- SKILL.md Prerequisites를 visible browser 요구사항으로 갱신

## Background

세션 `399f4646`에서 `claude --chrome`이 headless 인스턴스를 기동하고, cdp-attach가 이를 구분 없이 연결하여 screenshot 타임아웃, `/json/new` 405 에러 등이 발생. 근본적으로 headless 환경에서의 브라우저 액션은 사용자 모르게 실행되는 보안 위험이 있어 차단 가드를 추가함.

## Test plan

- [ ] visible Chrome(`--remote-debugging-port=9222`)에서 v1/v2/v3 명령 정상 동작 확인
- [ ] headless Chrome에서 `v1 version` 실행 → 정상 출력 (HeadlessChrome 표시)
- [ ] headless Chrome에서 `v1 list` 실행 → CDPError 차단 메시지 확인
- [ ] headless Chrome에서 `v2 new_page` 실행 → CDPError 차단 메시지 확인
- [ ] CDP 미연결 상태에서 명령 실행 → 기존 연결 에러 메시지 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)