### PR TITLE
feat(cdp-attach): fallback strategy 추가

### DIFF
--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -203,6 +203,17 @@ Or use `--host` / `--port` flags on any command.
 | WebSocket connection failed | Tab closed or navigated away | Re-select tab with `list` + `select` |
 | Element not found | Invalid CSS selector | Check selector with `evaluate` + `querySelector` |
 
+### Fallback Strategy
+
+Tab attachment and screenshot capture are inherently flaky. When a CDP operation fails after 2 attempts, escalate through the fallback chain before abandoning CDP entirely.
+
+| Symptom | 1st fallback (stay in CDP) | 2nd fallback (leave CDP) |
+|---------|---------------------------|--------------------------|
+| Tab attachment fails | `v1 list` → re-select a different tab index | Ask user to manually navigate, then retry |
+| Screenshot capture times out | `v1 evaluate "document.title"` to extract DOM text directly | Ask user to capture screenshot manually |
+| DOM navigation unreliable (react-select, dynamic SPAs) | `v1 evaluate` with JS to manipulate state directly | Manual intervention — inform user which element to interact with |
+| HTTP/TLS inspection needed | `v1 evaluate` with `fetch()` to inspect responses | `curl` / `openssl s_client` as CLI alternative |
+
 ## Protocol Reference
 
 For CDP domain methods, key codes, and device presets, see `references/cdp-protocol.md`.


### PR DESCRIPTION
## Summary
- CDP Error Handling 섹션에 **Fallback Strategy** 서브섹션 추가
- Tab attachment 실패, screenshot timeout, DOM navigation 불안정 시 CLI fallback 가이드 (curl, openssl, JS evaluate)
- 2회 실패 후 CDP 포기 원칙 명시
- 버전 1.1.0 → 1.2.0

## Test plan
- [x] `/cdp-attach` 스킬 로드 후 Fallback Strategy 섹션 표시 확인
- [ ] plugin.json 버전 1.2.0 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
