### PR TITLE
chore: BigQuery MCP 제거 및 bq CLI 전환

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,11 +10,6 @@
       "description": "Deep web research agent powered by Tavily search API"
     },
     {
-      "name": "bigquery",
-      "source": "./external-plugin/bigquery",
-      "description": "BigQuery data analysis agent with SQL generation and schema exploration"
-    },
-    {
       "name": "google",
       "source": "./google",
       "description": "Google services: Gemini CLI, Veo, video understanding, image prompts, calendar sync"

--- a/activity-workflow/.claude-plugin/plugin.json
+++ b/activity-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "activity-workflow",
   "description": "Orchestrates developer activity collection from GitHub and Linear, syncing to Google Calendar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/activity-workflow/agents/daily-activity-sync.md
+++ b/activity-workflow/agents/daily-activity-sync.md
@@ -62,7 +62,12 @@ gh search commits --author=@me --committer-date="${START_DATE}..${END_DATE}" \
 
 ### Phase 3: Linear Activity Collection
 
-Use MCP tools:
+Load deferred Linear MCP tools first:
+```
+ToolSearch("select:mcp__claude_ai_Linear__list_issues")
+```
+
+Then collect:
 ```
 mcp__claude_ai_Linear__list_issues(
   assignee="me",


### PR DESCRIPTION
## Summary

- BigQuery MCP 서버 제거, `bq` CLI로 대체
- marketplace.json에서 bigquery 플러그인 항목 제거
- activity-workflow 플러그인 버전 1.0.0 → 1.0.1 bump

## Test plan

- [x] `bq ls --format=json` CLI 정상 동작 확인
- [x] Claude Code 재시작 후 `mcp__bigquery__*` 도구 미노출 확인
- [ ] bigquery-sql-data-analyst 에이전트 bq CLI 기반 쿼리 실행 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)


