### PR TITLE
feat(cdp-attach): CDP 좌표 발견 메커니즘 추가

### DIFF
--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/scripts/v2_interact.py
+++ b/cdp-attach/scripts/v2_interact.py
@@ -413,7 +413,10 @@ def cmd_find_element(client, args):
         if has_ax:
             # Accessibility.queryAXTree → backendDOMNodeId
             _ensure_a11y(client)
-            ax_params = {}
+            # queryAXTree requires a root node to start from
+            doc = client.send("DOM.getDocument", {"depth": 0})
+            root_node_id = doc["root"]["nodeId"]
+            ax_params = {"nodeId": root_node_id}
             if args.name:
                 ax_params["accessibleName"] = args.name
             if args.role:

--- a/cdp-attach/scripts/v2_interact.py
+++ b/cdp-attach/scripts/v2_interact.py
@@ -43,6 +43,14 @@ def _resolve_selector(client, selector):
     obj = result.get("result", {}).get("value", {})
     if not obj or "error" in obj:
         raise CDPError(obj.get("error", f"Cannot resolve selector: {selector}"))
+
+    # Zero-dimension detection → CDPError with guidance (silent failure 제거)
+    if obj["width"] == 0 and obj["height"] == 0:
+        raise CDPError(
+            f"Element '{selector}' has zero dimensions (collapsed/hidden).\n"
+            f"  Try: v2 get_bounds --selector '{selector}'\n"
+            f"  Or:  v2 scan_interactive"
+        )
     return obj
 
 
@@ -55,6 +63,177 @@ def _dispatch_mouse(client, x, y, event_type, button="left", click_count=1):
         "button": button,
         "clickCount": click_count,
     })
+
+
+# ── CDP DOM/Accessibility helpers ──────────────────────────────
+
+
+def _ensure_dom(client):
+    """Enable DOM domain (idempotent per connection)."""
+    if not getattr(client, '_dom_enabled', False):
+        client.send("DOM.enable")
+        client._dom_enabled = True
+
+
+def _ensure_a11y(client):
+    """Enable Accessibility domain (idempotent per connection)."""
+    if not getattr(client, '_a11y_enabled', False):
+        client.send("Accessibility.enable")
+        client._a11y_enabled = True
+
+
+def _node_id_params(node_id=None, backend_node_id=None, **extra):
+    """Build CDP params dict from node_id or backend_node_id."""
+    params = dict(extra)
+    if backend_node_id is not None:
+        params["backendNodeId"] = backend_node_id
+    elif node_id is not None:
+        params["nodeId"] = node_id
+    return params
+
+
+def _quad_to_box(values):
+    """Convert 8-element quad array [x1,y1,...x4,y4] to (cx, cy, w, h)."""
+    xs = [values[i] for i in range(0, 8, 2)]
+    ys = [values[i] for i in range(1, 8, 2)]
+    x_min, y_min = min(xs), min(ys)
+    width = max(xs) - x_min
+    height = max(ys) - y_min
+    return x_min + width / 2, y_min + height / 2, width, height
+
+
+def _get_node_description(client, node_id=None, backend_node_id=None):
+    """Get tag name and text content for a node via DOM.describeNode."""
+    id_params = _node_id_params(node_id, backend_node_id)
+    if not id_params:
+        return "unknown", ""
+    try:
+        result = client.send("DOM.describeNode", {"depth": 0, **id_params})
+        node = result.get("node", {})
+        tag = node.get("localName", node.get("nodeName", "unknown")).lower()
+
+        text = ""
+        try:
+            obj_result = client.send("DOM.resolveNode", id_params)
+            object_id = obj_result.get("object", {}).get("objectId")
+            if object_id:
+                text_result = client.send("Runtime.callFunctionOn", {
+                    "objectId": object_id,
+                    "functionDeclaration": "function(){return(this.textContent||'').trim().slice(0,50)}",
+                    "returnByValue": True,
+                })
+                text = text_result.get("result", {}).get("value", "")
+        except CDPError:
+            pass
+
+        return tag, text
+    except CDPError:
+        return "unknown", ""
+
+
+def _get_node_bounds(client, node_id=None, backend_node_id=None, scroll=True,
+                     describe=True):
+    """Resolve node to bounding box via CDP DOM domain.
+
+    1. DOM.scrollIntoViewIfNeeded (when scroll=True)
+    2. DOM.getBoxModel → content quad → center
+    3. Fallback: DOM.getContentQuads
+
+    Returns: {x, y, width, height, visible, tag, text}
+    Set describe=False to skip tag/text lookup (saves 3 CDP calls per element).
+    """
+    _ensure_dom(client)
+
+    params = _node_id_params(node_id, backend_node_id)
+    if not params:
+        raise CDPError("_get_node_bounds requires nodeId or backendNodeId")
+
+    # Scroll into view
+    if scroll:
+        try:
+            client.send("DOM.scrollIntoViewIfNeeded", params)
+        except CDPError:
+            pass  # Non-scrollable or detached; continue
+
+    # Try DOM.getBoxModel, fallback to DOM.getContentQuads
+    quad_values = None
+    for method, extract in [
+        ("DOM.getBoxModel", lambda r: r.get("model", {}).get("content", [])),
+        ("DOM.getContentQuads", lambda r: (r.get("quads") or [[]])[0]),
+    ]:
+        try:
+            result = client.send(method, params)
+            values = extract(result)
+            if len(values) >= 8:
+                quad_values = values
+                break
+        except CDPError:
+            pass
+
+    if quad_values is None:
+        raise CDPError(
+            "Cannot resolve element bounds (getBoxModel + getContentQuads failed). "
+            "Element may be detached or in a different frame."
+        )
+
+    cx, cy, width, height = _quad_to_box(quad_values)
+    tag, text = _get_node_description(client, node_id, backend_node_id) if describe else ("", "")
+    visible = width > 0 and height > 0
+
+    info = {
+        "x": cx, "y": cy,
+        "width": width, "height": height,
+        "visible": visible, "tag": tag, "text": text,
+    }
+    if not visible:
+        info["warning"] = (
+            f"Element <{tag or 'unknown'}> has zero dimensions ({width:.0f}x{height:.0f}). "
+            "It may be collapsed, hidden, or not yet rendered."
+        )
+    return info
+
+
+def _dom_search(client, query, include_shadow_dom=False, limit=20):
+    """Perform DOM.performSearch → getSearchResults → describeNode → discard.
+
+    Returns list of {nodeId, backendNodeId, tag} dicts.
+    """
+    results = []
+    search_result = client.send("DOM.performSearch", {
+        "query": query,
+        "includeUserAgentShadowDOM": include_shadow_dom,
+    })
+    search_id = search_result.get("searchId")
+    count = search_result.get("resultCount", 0)
+
+    if count > 0:
+        fetch_count = min(count, limit)
+        fetch_result = client.send("DOM.getSearchResults", {
+            "searchId": search_id,
+            "fromIndex": 0,
+            "toIndex": fetch_count,
+        })
+        for nid in fetch_result.get("nodeIds", []):
+            try:
+                desc = client.send("DOM.describeNode", {"nodeId": nid, "depth": 0})
+                node_info = desc.get("node", {})
+                results.append({
+                    "nodeId": nid,
+                    "backendNodeId": node_info.get("backendNodeId"),
+                    "tag": node_info.get("localName", node_info.get("nodeName", "")).lower(),
+                })
+            except CDPError:
+                pass
+
+    try:
+        client.send("DOM.discardSearchResults", {"searchId": search_id})
+    except CDPError:
+        pass
+
+    return results
+
+
+# ── Commands ───────────────────────────────────────────────────
 
 
 def cmd_click(client, args):
@@ -216,6 +395,236 @@ def cmd_close_page(client, args):
         sys.exit(1)
 
 
+def cmd_find_element(client, args):
+    """Find element by accessible name, role, text, XPath, or CSS selector."""
+    has_ax = args.name is not None or args.role is not None
+    has_search = args.text is not None or args.xpath is not None
+    has_selector = args.selector is not None
+
+    if not (has_ax or has_search or has_selector):
+        print("Error: Provide --name/--role, --text, --xpath, or --selector", file=sys.stderr)
+        sys.exit(1)
+
+    client.connect()
+    try:
+        _ensure_dom(client)
+        results = []
+
+        if has_ax:
+            # Accessibility.queryAXTree → backendDOMNodeId
+            _ensure_a11y(client)
+            ax_params = {}
+            if args.name:
+                ax_params["accessibleName"] = args.name
+            if args.role:
+                ax_params["role"] = args.role
+
+            ax_result = client.send("Accessibility.queryAXTree", ax_params)
+            for node in ax_result.get("nodes", []):
+                backend_id = node.get("backendDOMNodeId")
+                if backend_id:
+                    results.append({
+                        "backendNodeId": backend_id,
+                        "role": node.get("role", {}).get("value", ""),
+                        "name": node.get("name", {}).get("value", ""),
+                    })
+
+        elif has_search:
+            query = args.text or args.xpath
+            results = _dom_search(client, query, args.pierce)
+
+        elif has_selector:
+            if args.pierce:
+                results = _dom_search(client, args.selector, True)
+            else:
+                # DOM.querySelector (no shadow DOM piercing)
+                doc = client.send("DOM.getDocument", {"depth": 0})
+                root_id = doc["root"]["nodeId"]
+                result = client.send("DOM.querySelector", {
+                    "nodeId": root_id,
+                    "selector": args.selector,
+                })
+                nid = result.get("nodeId", 0)
+                if nid:
+                    desc = client.send("DOM.describeNode", {"nodeId": nid, "depth": 0})
+                    node_info = desc.get("node", {})
+                    results.append({
+                        "nodeId": nid,
+                        "backendNodeId": node_info.get("backendNodeId"),
+                        "tag": node_info.get("localName", "").lower(),
+                    })
+
+        if not results:
+            print("No elements found.")
+            return
+
+        print(f"Found {len(results)} element(s):")
+        for i, r in enumerate(results):
+            parts = [f"#{i}"]
+            if r.get("tag"):
+                parts.append(f"<{r['tag']}>")
+            if r.get("role"):
+                parts.append(f"role={r['role']}")
+            if r.get("name"):
+                parts.append(f'name="{r["name"]}"')
+            if r.get("nodeId"):
+                parts.append(f"nodeId={r['nodeId']}")
+            if r.get("backendNodeId"):
+                parts.append(f"backendNodeId={r['backendNodeId']}")
+            print("  " + "  ".join(parts))
+    finally:
+        client.close()
+
+
+def cmd_get_bounds(client, args):
+    """Get element bounding box and center coordinates."""
+    has_id = args.node_id is not None or args.backend_node_id is not None
+    has_selector = args.selector is not None
+
+    if not (has_id or has_selector):
+        print("Error: Provide --node-id, --backend-node-id, or --selector", file=sys.stderr)
+        sys.exit(1)
+
+    client.connect()
+    try:
+        _ensure_dom(client)
+        scroll = not args.no_scroll
+
+        node_id = args.node_id
+        backend_node_id = args.backend_node_id
+
+        # Resolve selector to nodeId if needed
+        if has_selector and not has_id:
+            doc = client.send("DOM.getDocument", {"depth": 0})
+            root_id = doc["root"]["nodeId"]
+            result = client.send("DOM.querySelector", {
+                "nodeId": root_id,
+                "selector": args.selector,
+            })
+            node_id = result.get("nodeId", 0)
+            if not node_id:
+                raise CDPError(f"Element not found: {args.selector}")
+
+        info = _get_node_bounds(
+            client,
+            node_id=node_id,
+            backend_node_id=backend_node_id,
+            scroll=scroll,
+        )
+
+        print(f"Element: <{info['tag']}> \"{info['text']}\"")
+        print(f"  Center: ({info['x']:.0f}, {info['y']:.0f})")
+        print(f"  Box: {info['width']:.0f}x{info['height']:.0f}")
+        print(f"  Visible: {info['visible']}")
+        if info.get("warning"):
+            print(f"  Warning: {info['warning']}")
+        print(f"\nUse: v2 click {info['x']:.0f} {info['y']:.0f}")
+    finally:
+        client.close()
+
+
+def cmd_scan_interactive(client, args):
+    """List all interactive elements with coordinates."""
+    INTERACTIVE_ROLES = {
+        "button", "link", "textbox", "checkbox", "radio",
+        "combobox", "listbox", "menuitem", "menuitemcheckbox",
+        "menuitemradio", "option", "searchbox", "slider",
+        "spinbutton", "switch", "tab", "treeitem",
+    }
+
+    client.connect()
+    try:
+        _ensure_dom(client)
+        _ensure_a11y(client)
+
+        # Get full accessibility tree
+        ax_result = client.send("Accessibility.getFullAXTree", {"depth": -1})
+        nodes = ax_result.get("nodes", [])
+
+        # Role filter
+        role_filter = None
+        if args.role:
+            role_filter = set(r.strip() for r in args.role.split(","))
+
+        candidates = []
+        for node in nodes:
+            role = node.get("role", {}).get("value", "")
+            if role_filter:
+                if role not in role_filter:
+                    continue
+            elif role not in INTERACTIVE_ROLES:
+                continue
+
+            backend_id = node.get("backendDOMNodeId")
+            if not backend_id:
+                continue
+
+            name = node.get("name", {}).get("value", "")
+            candidates.append({
+                "backendNodeId": backend_id,
+                "role": role,
+                "name": name,
+            })
+
+        candidates = candidates[:args.limit]
+
+        if not candidates:
+            print("No interactive elements found.")
+            return
+
+        # Get viewport dimensions once (for --viewport filter)
+        vw, vh = None, None
+        if args.viewport:
+            try:
+                layout = client.send("Page.getLayoutMetrics")
+                vp = layout.get("cssVisualViewport", {})
+                vw = vp.get("clientWidth", 1920)
+                vh = vp.get("clientHeight", 1080)
+            except CDPError:
+                pass
+
+        # Resolve bounds for each candidate
+        results = []
+        for item in candidates:
+            try:
+                info = _get_node_bounds(
+                    client,
+                    backend_node_id=item["backendNodeId"],
+                    scroll=False,
+                    describe=False,  # Skip tag/text lookup (3 CDP calls saved per element)
+                )
+                if not info["visible"]:
+                    continue
+                if args.viewport and vw is not None:
+                    if info["x"] < 0 or info["y"] < 0 or info["x"] > vw or info["y"] > vh:
+                        continue
+
+                results.append({
+                    "role": item["role"],
+                    "name": item["name"],
+                    "x": info["x"],
+                    "y": info["y"],
+                })
+            except CDPError:
+                continue
+
+        if not results:
+            print("No visible interactive elements found.")
+            return
+
+        # Print table
+        print(f"{'#':<4} {'Role':<14} {'Center':<12} Name")
+        print("-" * 50)
+        for i, r in enumerate(results):
+            center = f"({r['x']:.0f},{r['y']:.0f})"
+            name_display = f'"{r["name"]}"' if r["name"] else ""
+            print(f"{i:<4} {r['role']:<14} {center:<12} {name_display}")
+
+        print(f"\nUse: v2 click <x> <y>")
+    finally:
+        client.close()
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="cdp-v2",
@@ -255,6 +664,28 @@ def main():
     p_close = sub.add_parser("close_page", help="Close a tab")
     p_close.add_argument("target_id", nargs="?", help="Target ID (default: selected)")
 
+    # find_element
+    p_find = sub.add_parser("find_element", help="Find element by name/role/text/xpath/selector")
+    p_find.add_argument("--name", "-n", help="Accessible name")
+    p_find.add_argument("--role", "-r", help="ARIA role")
+    p_find.add_argument("--text", "-t", help="Visible text content")
+    p_find.add_argument("--xpath", help="XPath expression")
+    p_find.add_argument("--selector", "-s", help="CSS selector")
+    p_find.add_argument("--pierce", action="store_true", help="Pierce shadow DOM")
+
+    # get_bounds
+    p_bounds = sub.add_parser("get_bounds", help="Get element bounding box")
+    p_bounds.add_argument("--node-id", type=int, help="DOM nodeId")
+    p_bounds.add_argument("--backend-node-id", type=int, help="Backend DOM nodeId")
+    p_bounds.add_argument("--selector", "-s", help="CSS selector")
+    p_bounds.add_argument("--no-scroll", action="store_true", help="Skip scroll-into-view")
+
+    # scan_interactive
+    p_scan = sub.add_parser("scan_interactive", help="List interactive elements")
+    p_scan.add_argument("--viewport", action="store_true", help="Only viewport-visible elements")
+    p_scan.add_argument("--role", help="Comma-separated role filter")
+    p_scan.add_argument("--limit", type=int, default=50, help="Max elements (default: 50)")
+
     args = parser.parse_args()
     client = CDPClient(host=args.host, port=args.port)
 
@@ -265,6 +696,9 @@ def main():
         "hover": cmd_hover,
         "new_page": cmd_new_page,
         "close_page": cmd_close_page,
+        "find_element": cmd_find_element,
+        "get_bounds": cmd_get_bounds,
+        "scan_interactive": cmd_scan_interactive,
     }
 
     try:

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -91,6 +91,9 @@ $V1 navigate "https://example.com" --wait-for none
 - `click --coordinates x y` — use positional: `click 100 200`
 - `click --text "..."` — use `click --selector` with a CSS selector instead
 - `screenshot --selector` — not supported; screenshot captures the full viewport (or `--full-page`)
+- `find_element --id` — use `--node-id` or `--backend-node-id` in `get_bounds`
+- `scan_interactive --selector` — not supported; use `find_element --selector` instead
+- `get_bounds --text` — use `find_element --text` first, then `get_bounds --node-id`
 
 **JavaScript in evaluate:**
 - `const`/`let` are auto-rewritten to `var` by default (prevents re-declaration errors on repeated calls). Use `--no-rewrite` to disable.
@@ -118,6 +121,32 @@ $V2 press_key a --modifiers ctrl               # Ctrl+A
 $V2 hover --selector "a.nav-link"
 $V2 new_page "https://example.com"             # Open new tab
 $V2 close_page                                 # Close selected tab
+```
+
+### v2 — Element Discovery (`v2_interact.py`)
+
+When CSS selectors fail (collapsed SPA panels, shadow DOM, hashed classes), use CDP DOM/Accessibility API.
+
+```bash
+V2="${CLAUDE_PLUGIN_ROOT}/scripts/v2_interact.py"
+
+# find_element — semantic element search
+$V2 find_element --name "Search" --role button     # accessible name + role
+$V2 find_element --text "Property Info"            # visible text
+$V2 find_element --xpath "//button[contains(.,'Search')]"
+$V2 find_element --selector "div.panel" --pierce   # pierce shadow DOM
+
+# get_bounds — coordinate resolution + auto scroll-into-view
+$V2 get_bounds --node-id 42                    # use find_element result
+$V2 get_bounds --backend-node-id 87
+$V2 get_bounds --selector "button.submit"
+$V2 get_bounds --selector "button.submit" --no-scroll
+
+# scan_interactive — enumerate interactive elements
+$V2 scan_interactive                           # all
+$V2 scan_interactive --viewport                # viewport-visible only
+$V2 scan_interactive --role button,link        # filter by role
+$V2 scan_interactive --limit 30
 ```
 
 ### v3 — Advanced (`v3_advanced.py`)
@@ -170,6 +199,32 @@ $V3 dialog accept "prompt input"               # Handle prompt
 5. v1 screenshot                → Verify result
 ```
 
+### SPA / Dynamic Page Interaction
+When CSS selector fails (zero-dimension, hashed class, shadow DOM):
+```
+1. v2 scan_interactive                  → List interactive elements + coordinates
+2. v2 click <x> <y>                     → Click by coordinates
+
+Or:
+1. v2 find_element --name "Search"       → Discover backendNodeId
+2. v2 get_bounds --backend-node-id <id>  → Resolve coordinates
+3. v2 click <x> <y>                     → Click
+```
+
+### Vision Fallback (last resort)
+When all programmatic approaches fail:
+```
+1. v1 screenshot -o /tmp/page.png       → Capture page
+2. Read /tmp/page.png                   → AI visually estimates coordinates
+3. v2 click <x> <y>                     → Click estimated coordinates
+4. v1 screenshot                        → Verify result
+```
+
+**Known Limitations:**
+- During React hydration, `find_element --name/--role` may return empty results. Wait for hydration via `v1 evaluate`, then retry.
+- `scan_interactive` makes a CDP call per element; use `--limit` to constrain (default 50).
+- nodeId is invalidated on DOM changes. For stable references, use backendNodeId.
+
 ### Network Debugging
 ```
 1. v1 select <tab>
@@ -211,7 +266,7 @@ Tab attachment and screenshot capture are inherently flaky. When a CDP operation
 |---------|---------------------------|--------------------------|
 | Tab attachment fails | `v1 list` → re-select a different tab index | Ask user to manually navigate, then retry |
 | Screenshot capture times out | `v1 evaluate "document.title"` to extract DOM text directly | Ask user to capture screenshot manually |
-| DOM navigation unreliable (react-select, dynamic SPAs) | `v1 evaluate` with JS to manipulate state directly | Manual intervention — inform user which element to interact with |
+| DOM navigation unreliable (react-select, dynamic SPAs) | `v2 scan_interactive` or `v2 find_element --name/--role` to discover elements via CDP DOM/Accessibility API | Vision fallback: screenshot → Read → click coordinates |
 | HTTP/TLS inspection needed | `v1 evaluate` with `fetch()` to inspect responses | `curl` / `openssl s_client` as CLI alternative |
 
 ## Protocol Reference

--- a/cdp-attach/skills/cdp-attach/references/cdp-protocol.md
+++ b/cdp-attach/skills/cdp-attach/references/cdp-protocol.md
@@ -40,12 +40,35 @@ Input.insertText({text})
 
 **Modifier bitmask**: Alt=1, Ctrl=2, Shift=4, Meta=8
 
+### DOM
+
+```
+DOM.enable()
+DOM.getDocument({depth, pierce})        → {root: {nodeId, ...}}
+DOM.querySelector({nodeId, selector})   → {nodeId}
+DOM.querySelectorAll({nodeId, selector}) → {nodeIds[]}
+DOM.performSearch({query, includeUserAgentShadowDOM})  → {searchId, resultCount}
+DOM.getSearchResults({searchId, fromIndex, toIndex})   → {nodeIds[]}
+DOM.discardSearchResults({searchId})
+DOM.describeNode({nodeId?, backendNodeId?, depth})     → {node: {localName, backendNodeId, ...}}
+DOM.resolveNode({nodeId?, backendNodeId?})             → {object: {objectId, ...}}
+DOM.getBoxModel({nodeId?, backendNodeId?})             → {model: {content[], padding[], border[], margin[]}}
+  content/padding/border/margin: [x1,y1, x2,y2, x3,y3, x4,y4] (quad)
+DOM.getContentQuads({nodeId?, backendNodeId?})         → {quads: [[x1,y1,...x4,y4], ...]}
+DOM.scrollIntoViewIfNeeded({nodeId?, backendNodeId?})
+DOM.getFlattenedDocument({depth, pierce})              → {nodes[]}
+  pierce: true → includes shadow DOM subtrees
+```
+
 ### Accessibility
 
 ```
 Accessibility.enable()
 Accessibility.getFullAXTree({depth})    → {nodes[]}
-  node: {nodeId, role: {value}, name: {value}, parentId, childIds[]}
+  node: {nodeId, role: {value}, name: {value}, parentId, childIds[], backendDOMNodeId}
+Accessibility.queryAXTree({nodeId?, backendNodeId?, accessibleName?, role?})  → {nodes[]}
+  Searches accessibility tree by accessible name and/or ARIA role.
+  Returns nodes with backendDOMNodeId for use with DOM.getBoxModel.
 ```
 
 ### Network


### PR DESCRIPTION
## Summary

- CSS selector 실패 시(SPA 접힌 패널, shadow DOM, 동적 클래스) CDP DOM/Accessibility API를 활용하는 3계층 폴백 전략 구현
- `find_element`, `get_bounds`, `scan_interactive` 3개 신규 커맨드 추가 (v2_interact.py)
- Zero-dimension 요소가 silent failure 대신 CDPError + 신규 커맨드 안내를 제공하도록 `_resolve_selector` 개선
- `/simplify` 리뷰 반영: `_quad_to_box`, `_dom_search`, `_node_id_params` 헬퍼 추출, `describe=False` 최적화로 scan_interactive에서 ~150 CDP 호출 절약

## Test plan

- [x] 기존 `click --selector`, `fill --selector`, `hover --selector` 정상 동작 확인 (회귀 테스트)
- [x] Zero-dimension 요소에 대해 CDPError + 안내 메시지 출력 확인
- [x] `scan_interactive --limit 10` — 인터랙티브 요소 열거 확인
- [x] `find_element --role button` — 버튼 검색 확인
- [x] `find_element --name "Google Search"` — accessible name 검색 확인
- [x] `get_bounds --selector "input[name=q]"` — 좌표 + scroll 확인
- [x] `get_bounds --node-id <id>` — find_element 결과 연계 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

