### PR TITLE
fix(caffeinate): 스크립트 경로 CLAUDE_PLUGIN_ROOT 수정

### DIFF
--- a/caffeinate/.claude-plugin/plugin.json
+++ b/caffeinate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "caffeinate",
   "description": "macOS sleep prevention toggle with battery and network monitoring",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/caffeinate/skills/caffeinate/SKILL.md
+++ b/caffeinate/skills/caffeinate/SKILL.md
@@ -12,7 +12,7 @@ description: >
 Run the toggle script and report the result:
 
 ```bash
-bash ~/.claude/cc-plugin/caffeinate/scripts/toggle.sh
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/toggle.sh"
 ```
 
 - Output `STARTED` → sleep prevention activated (`caffeinate -ims`).


### PR DESCRIPTION
## Summary
- 하드코딩된 `~/.claude/cc-plugin/` 경로를 `${CLAUDE_PLUGIN_ROOT}`로 변경
- 플러그인 설치 위치에 무관하게 toggle.sh 실행 가능
- version bump 1.0.0 → 1.0.1

## Test plan
- [ ] `/caffeinate` 실행 시 toggle.sh 정상 동작 확인 (플러그인 reload 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
