### PR TITLE
feat(review-ensemble): lens 선택 자동화 — select_all_perspectives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,10 @@ tools: [mcp__bigquery__*, Read]                      # Read-only + MCP
 }
 ```
 
+## Prerequisites
+
+- **review-ensemble**: Requires [Codex CLI](https://github.com/openai/codex) for cross-model review. Falls back to /frame-only mode when unavailable.
+
 ## 개발 워크플로우
 
 ### 테스트

--- a/review-ensemble/.claude-plugin/plugin.json
+++ b/review-ensemble/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "review-ensemble",
   "description": "Multi-reviewer code review composition layer (ensemble, cross-model)",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/review-ensemble/skills/review-ensemble/SKILL.md
+++ b/review-ensemble/skills/review-ensemble/SKILL.md
@@ -119,13 +119,13 @@ Check if the `prothesis:frame` skill is available. If not available (epistemic-p
 
 If available:
 ```
-Skill("prothesis:frame", args: "Assemble a code review team for these changes. Scope: {scope_description}. Changed files: {file_list}")
+Skill("prothesis:frame", args: "Assemble a code review team for these changes. Scope: {scope_description}. Changed files: {file_list}. [select_all_perspectives]")
 ```
 
 /frame will:
 1. **Phase 0**: Mission Brief (elidable — explicit argument provided)
 2. **Phase 1**: Context gathering (codebase exploration)
-3. **Phase 2**: Perspective selection (always_gated — user selects review perspectives)
+3. **Phase 2**: Perspective selection (elidable — select_all_perspectives: auto-select all proposed lenses)
 4. **Phase 3**: AgentMap? → map perspectives to available agents → team investigation
 5. **Phase 4**: Cross-dialogue + synthesis → **Lens L** (convergence, divergence, assessment)
 


### PR DESCRIPTION
## Summary
- `/frame` 호출 시 `[select_all_perspectives]` 신호 추가로 Phase 2 lens gate 자동화
- Phase 2 설명을 `always_gated` → `elidable` 반영으로 업데이트
- CLAUDE.md Prerequisites 섹션 추가

## Dependencies
- jongwony/epistemic-protocols#223 (`/frame` Phase 2 elidable 조건 추가)

## Test plan
- [ ] `/review-ensemble` 실행 시 lens 선택 gate 없이 전체 lens 자동 선택 확인
- [ ] `/frame` 단독 호출 시 기존 gate 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
