### PR TITLE
feat(safe-uninstall): macOS 프로그램 안전 제거 플러그인

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -68,6 +68,11 @@
       "name": "review-ensemble",
       "source": "./review-ensemble",
       "description": "Multi-reviewer code review composition layer (ensemble, cross-model)"
+    },
+    {
+      "name": "safe-uninstall",
+      "source": "./safe-uninstall",
+      "description": "Safely identify, investigate, and remove macOS programs with risk-assessed execution"
     }
   ]
 }

--- a/safe-uninstall/.claude-plugin/plugin.json
+++ b/safe-uninstall/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "safe-uninstall",
+  "description": "Safely identify, investigate, and remove macOS programs with risk-assessed execution",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/safe-uninstall/skills/safe-uninstall/SKILL.md
+++ b/safe-uninstall/skills/safe-uninstall/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: safe-uninstall
+description: |
+  This skill should be used when the user asks to "remove program", "uninstall app",
+  "delete daemon", "clean up process", "safe uninstall", "find resource hog",
+  "what is this process", "remove bloatware", "kill daemon", "remove LaunchDaemon",
+  "remove security program", "Activity Monitor finding", "high memory process",
+  or wants to safely identify and remove macOS programs and daemons.
+  Also triggers when the user mentions high memory/CPU usage by unknown processes,
+  Activity Monitor concerns, unwanted LaunchDaemons/Agents, or Korean banking
+  security programs (TouchEn, AhnLab, Veraport, INISAFE, CrossEX).
+  Use this skill even when the user simply provides a process name and wants it gone,
+  or describes a process consuming excessive resources they want to investigate.
+---
+
+# Safe Uninstall
+
+Safely identify, investigate, and remove macOS programs through a structured
+workflow: target identification, comprehensive investigation, removal approach
+selection, risk-assessed execution, and verification.
+
+## Dependency
+
+This skill delegates execution of irreversible operations (file deletion, service
+removal) to **Prosoche** (`/attend`). The epistemic-protocols plugin must be
+installed for safe execution gating.
+
+## Workflow Overview
+
+```
+Target Identification → Investigation → Report → Approach Selection → /attend Execution → Verification
+```
+
+## Phase 1: Target Identification
+
+Support two entry points depending on user context.
+
+### A. Resource Scan
+
+When the user reports high resource usage, unknown processes, or Activity Monitor
+concerns, start with a resource scan to identify the target:
+
+1. Scan top processes by memory and CPU:
+   ```bash
+   ps aux --sort=-%mem | head -20
+   ps aux --sort=-%cpu | head -20
+   ```
+2. Present non-system processes consuming significant resources (filter out
+   kernel_task, WindowServer, and other known macOS system processes)
+3. For unknown processes, gather identification signals:
+   ```bash
+   codesign -dv --verbose=2 <binary_path> 2>&1  # vendor identity
+   ```
+4. User selects target process for investigation
+
+### B. Direct Specification
+
+When the user names a specific process or program, confirm the target and derive
+search patterns (see `references/investigation-paths.md` for pattern derivation).
+
+## Phase 2: Comprehensive Investigation
+
+Delegate investigation to a subagent for efficient parallel execution.
+
+Derive multiple search patterns from the target: binary path components, process
+name, vendor name, product name. Use case-insensitive grep across ALL locations.
+
+### Investigation Checklist
+
+Every investigation must cover all of these (no shortcuts):
+
+| Category | Command Pattern |
+|----------|----------------|
+| Running processes | `ps aux \| grep -i -E "<patterns>"` |
+| LaunchDaemons | `ls /Library/LaunchDaemons/ \| grep -i -E "<patterns>"` |
+| LaunchAgents (system) | `ls /Library/LaunchAgents/ \| grep -i -E "<patterns>"` |
+| LaunchAgents (user) | `ls ~/Library/LaunchAgents/ \| grep -i -E "<patterns>"` |
+| Application Support | `ls "/Library/Application Support/" \| grep -i -E "<patterns>"` |
+| Applications | `ls /Applications/ \| grep -i -E "<patterns>"` |
+| Kernel Extensions | `ls /Library/Extensions/ \| grep -i -E "<patterns>"` |
+| System Extensions | `ls /Library/SystemExtensions/ \| grep -i -E "<patterns>"` |
+| Privileged Helpers | `ls /Library/PrivilegedHelperTools/ \| grep -i -E "<patterns>"` |
+| Browser Plugins | `ls "/Library/Internet Plug-Ins/" \| grep -i -E "<patterns>"` |
+| Login Items | `osascript -e 'tell application "System Events" to get the name of every login item'` |
+| Package Receipts | `pkgutil --pkgs \| grep -i -E "<patterns>"` |
+| Uninstaller search | `find /Applications -iname "*uninstall*" \| grep -i -E "<patterns>"` |
+
+For each LaunchDaemon/Agent plist found, **read it** to extract KeepAlive,
+RunAtLoad, and Program properties — these determine the removal strategy.
+
+Also check for companion frameworks in sibling Application Support directories
+(see `references/investigation-paths.md` for known companion patterns).
+
+## Phase 3: Report
+
+Present findings as a structured report so the user can make an informed decision.
+
+**Template:**
+
+```
+## [Program Name] — Investigation Report
+
+**Running Processes:**
+| PID | User | %MEM | %CPU | Binary Path |
+|-----|------|------|------|-------------|
+
+**LaunchDaemons/Agents (KeepAlive services respawn after kill):**
+| plist Path | KeepAlive | RunAtLoad |
+|------------|-----------|-----------|
+
+**Installed Files:**
+| Category | Path | Notes |
+|----------|------|-------|
+
+**Uninstaller:** [path or "Not found"]
+**Package Receipts:** [list or "None"]
+**Companion Frameworks:** [list or "None"]
+```
+
+## Phase 4: Removal Approach Selection
+
+Present options based on findings:
+
+1. **Official Uninstaller** (when found) — Run first, then verify and clean up
+   leftovers. The vendor understands their own installation layout best.
+2. **Manual Removal** — Direct removal of all identified components.
+   Appropriate when no uninstaller exists.
+
+## Phase 5: Execution via Prosoche
+
+Invoke `/attend` with the removal task list. Prosoche will classify each task
+for risk and gate irreversible operations through user judgment.
+
+**Typical task ordering** (KeepAlive-aware):
+
+1. Unload services — `launchctl bootout`/`unload` for KeepAlive plist (before kill)
+2. Run uninstaller — `open /path/to/Uninstaller.app` (if selected)
+3. Verify post-uninstaller — check what remains
+4. Kill remaining processes — `kill <PID>`
+5. Remove remaining service registrations — `launchctl remove <label>`
+6. Delete files — `sudo rm -rf` for remaining directories
+7. Remove browser plugins — `sudo rm` symlinks and plugin bundles
+8. Forget package receipts — `sudo pkgutil --forget <id>`
+
+### Handling sudo Failures
+
+Non-interactive terminal sessions cannot accept sudo passwords.
+When sudo operations fail:
+
+1. Complete all non-sudo operations (kill, launchctl remove)
+2. Collect failed sudo commands into a single executable block
+3. Present to user as a copy-paste command with `!` prefix for Claude Code prompt
+4. After user executes, proceed to verification
+
+## Phase 6: Verification
+
+Run a comprehensive post-removal check against all previously identified items:
+
+1. Processes: `ps aux | grep -i -E "<patterns>" | grep -v grep`
+2. Services: `launchctl list 2>/dev/null | grep -i -E "<patterns>"`
+3. Files: Check each previously found path exists
+4. Package receipts: `pkgutil --pkgs | grep -i -E "<patterns>"`
+
+Present final status:
+
+```
+## Removal Verification
+
+| Item | Status |
+|------|--------|
+| [item description] | [Removed] / [Remaining] |
+
+**Result:** [N] items removed, [M] remaining
+```
+
+## Edge Cases
+
+- **Process not running**: Search by name in file system (`mdfind -name "<name>"`)
+  to find installed-but-inactive programs
+- **Companion frameworks**: Detect related vendor directories in Application Support
+  and include in removal scope (present to user for confirmation)
+- **KeepAlive services**: Always unload via launchctl before killing — otherwise
+  launchd immediately respawns the process
+- **Modern macOS kext restrictions**: Kernel extensions may be present on disk but
+  not loaded (blocked by SIP). Note in report; still remove files
+- **Broken symlinks**: Partial uninstalls may leave dangling symlinks (especially
+  browser plugins). Detect via `ls -la` and include in cleanup
+- **Multiple user contexts**: Some programs install both root-level (LaunchDaemon)
+  and user-level (LaunchAgent) services. Ensure both are addressed

--- a/safe-uninstall/skills/safe-uninstall/references/investigation-paths.md
+++ b/safe-uninstall/skills/safe-uninstall/references/investigation-paths.md
@@ -1,0 +1,80 @@
+# macOS Program Investigation Paths
+
+## System Directories
+
+| Category | Path | What to Find |
+|----------|------|-------------|
+| LaunchDaemons | `/Library/LaunchDaemons/` | System-level persistent services (root) |
+| LaunchAgents (System) | `/Library/LaunchAgents/` | User-level persistent services (all users) |
+| LaunchAgents (User) | `~/Library/LaunchAgents/` | User-level persistent services (current user) |
+| Application Support | `/Library/Application Support/` | Program data, configs, binaries |
+| Applications | `/Applications/` | App bundles, uninstallers |
+| Kernel Extensions | `/Library/Extensions/` | Kernel drivers (legacy, often blocked by SIP) |
+| System Extensions | `/Library/SystemExtensions/` | Modern system extensions |
+| Privileged Helpers | `/Library/PrivilegedHelperTools/` | Privileged helper binaries |
+| Browser Plugins | `/Library/Internet Plug-Ins/` | Browser plugins (NPAPI, legacy) |
+| Login Items | System Preferences | Auto-start programs |
+| Package Receipts | `pkgutil --pkgs` | Installer package records |
+
+## Search Pattern Derivation
+
+When investigating a process, derive multiple search patterns from:
+
+1. **Binary path**: `/Library/Application Support/raonsecure/TouchEn nxKey/TEK_Daemon` yields `raon`, `raonsecure`, `touchen`, `nxkey`
+2. **Process name**: `TEK_Daemon` yields `TEK`, `tek`
+3. **Vendor name**: Code signature or path components (e.g., `raonsecure`, `ahnlab`)
+4. **Product name**: Known product names (e.g., `TouchEn`, `Safe Transaction`)
+
+Combine patterns with case-insensitive extended grep:
+```bash
+grep -i -E "pattern1|pattern2|pattern3"
+```
+
+## LaunchDaemon/Agent plist Properties
+
+Read each found plist to determine removal strategy:
+
+| Property | Impact |
+|----------|--------|
+| `KeepAlive: true` | launchd respawns after kill — must `launchctl bootout`/`unload` first |
+| `RunAtLoad: true` | Starts at boot/login |
+| `Program` / `ProgramArguments` | Actual binary path — verify it matches target |
+
+## Companion Framework Detection
+
+Programs may install companion frameworks requiring separate removal:
+
+| Primary | Companion | Shared Location |
+|---------|-----------|----------------|
+| TouchEn nxKey | CrossEX (iniLINE) | `/Library/Application Support/iniLINE/` |
+| Various banking | Veraport | `/Library/Application Support/Wizvera/` |
+
+Detection: after identifying the primary program's Application Support directory, check sibling directories for related vendor names.
+
+## Non-Interactive sudo Limitation
+
+Claude Code subagents run in non-interactive terminals where `sudo` password prompts fail.
+
+**Mitigation strategy:**
+1. Execute all non-sudo operations first (`kill`, `launchctl remove`)
+2. Collect remaining sudo commands into a single block
+3. Present to user with `! <command>` prefix instructions for Claude Code prompt execution
+4. Verify after user executes
+
+## Process Identification Aids
+
+When a process is unknown, gather identification signals:
+
+```bash
+# Binary path from PID
+ps -p <PID> -o comm=
+
+# Code signature (vendor identity)
+codesign -dv --verbose=2 <binary_path> 2>&1
+
+# File system search by name
+mdfind -name "<keyword>"
+
+# Package that installed the binary
+pkgutil --file-info <binary_path>
+```


### PR DESCRIPTION
## Summary
- macOS 프로그램을 안전하게 식별, 조사, 제거하는 `safe-uninstall` 플러그인 추가
- 리소스 스캔(ps --sort) 또는 프로세스명 직접 지정의 듀얼 진입점
- Prosoche(`/attend`) 연동으로 비가역 작업(sudo rm, kill, pkgutil forget)에 Gate 처리

## 구조
```
safe-uninstall/
  .claude-plugin/plugin.json
  skills/safe-uninstall/
    SKILL.md                              # 6 Phase 워크플로우
    references/investigation-paths.md     # macOS 시스템 디렉토리 패턴
```

## 워크플로우
1. Target Identification (리소스 스캔 / 직접 지정)
2. Comprehensive Investigation (14+ 시스템 디렉토리 전수 조사)
3. Report (구조화된 조사 보고서)
4. Approach Selection (언인스톨러 / 수동)
5. Execution via Prosoche (`/attend` 연동)
6. Verification (삭제 후 검증)

## Test plan
- [ ] `/safe-uninstall` 트리거로 스킬 로드 확인
- [ ] 리소스 스캔 진입점에서 `ps aux --sort` 실행 및 시스템 프로세스 필터링
- [ ] 프로세스명 직접 지정 시 다중 패턴 파생 및 전수 조사
- [ ] 프로세스 미발견 시 mdfind fallback 동작
- [ ] Phase 5에서 `/attend` 호출하여 Prosoche 연동

🤖 Generated with [Claude Code](https://claude.com/claude-code)
