### PR TITLE
fix(claude-code-internals): --setting-sources 플래그 오타 수정

### DIFF
--- a/claude-code-internals/.claude-plugin/plugin.json
+++ b/claude-code-internals/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-internals",
   "description": "Claude Code internals explorer",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/claude-code-internals/skills/claude-code-internals/scripts/analyze-binary.sh
+++ b/claude-code-internals/skills/claude-code-internals/scripts/analyze-binary.sh
@@ -49,5 +49,5 @@ fi
     --disable-slash-commands \
     --strict-mcp-config \
     --dangerously-skip-permissions \
-    --settings-sources "" \
+    --setting-sources "" \
     2>/dev/null


### PR DESCRIPTION
## Summary
- `analyze-binary.sh`의 `--settings-sources` → `--setting-sources` 오타 수정 (claude CLI 공식 플래그는 단수 setting + 복수 sources)
- `claude-code-internals` 버전 2.0.3 → 2.0.4 패치 범프
- cc-plugin · ClaudePanel.spoon · epistemic-protocols 3개 저장소 전수조사 결과 동류 오타는 이 파일이 유일

## Test plan
- [ ] `bash claude-code-internals/skills/claude-code-internals/scripts/analyze-binary.sh` 실행 시 플래그 에러 없이 진행되는지 확인
- [ ] 머지 후 플러그인 재설치 시 `/claude-code-internals` 스킬이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)