### PR TITLE
feat(codex): gpt-5.5 기본 모델 승격 + gpt-5.3-codex 제거

### DIFF
--- a/codex-plus/scripts/codex-run.sh
+++ b/codex-plus/scripts/codex-run.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # Defaults
-readonly DEFAULT_MODEL="gpt-5.4"
+readonly DEFAULT_MODEL="gpt-5.5"
 readonly DEFAULT_EFFORT="xhigh"
 readonly DEFAULT_SANDBOX="read-only"
 
@@ -21,7 +21,7 @@ usage() {
 Usage: codex-run.sh [options] <prompt_file>
 
 Options:
-  -m, --model MODEL      Model name (default: gpt-5.4)
+  -m, --model MODEL      Model name (default: gpt-5.5)
   -r, --effort EFFORT    Reasoning effort: medium|high|xhigh (default: xhigh)
   -s, --sandbox SANDBOX  Sandbox: read-only|workspace-write|danger-full-access (default: read-only)
   -C, --cwd DIR          Working directory for codex
@@ -31,7 +31,7 @@ Options:
 
 Examples:
   codex-run.sh /tmp/codex_prompt_a3f9.txt
-  codex-run.sh -m gpt-5.3-codex -r high /tmp/codex_prompt_a3f9.txt
+  codex-run.sh -m gpt-5.4 -r high /tmp/codex_prompt_a3f9.txt
   codex-run.sh --resume /tmp/codex_prompt_a3f9.txt
   codex-run.sh -s workspace-write --full-auto /tmp/codex_prompt_a3f9.txt
 USAGE

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -63,8 +63,8 @@ When the delegated task is image generation or image editing:
 
 | Model | Characteristics |
 |-------|-----------------|
-| `gpt-5.4` | Current default model for Codex CLI tasks |
-| `gpt-5.3-codex` | Prior codex-specific coding model |
+| `gpt-5.5` | Current default model for Codex CLI tasks |
+| `gpt-5.4` | Supplementary model (prior default) |
 
    Reasoning effort is selected once and applied identically to all chosen models.
 
@@ -85,7 +85,7 @@ When the delegated task is image generation or image editing:
 | Network access | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s danger-full-access --full-auto /tmp/codex_prompt_<suffix>.txt` |
 | Resume session | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh --resume /tmp/codex_prompt_<suffix>.txt` (options like -m, -r, -s are ignored; uses last session settings) |
 | Different dir | Add `-C <DIR>` to non-resume patterns above |
-| Custom model | Add `-m gpt-5.3-codex -r high` to any pattern above |
+| Custom model | Add `-m gpt-5.4 -r high` to any pattern above |
 
 ## Following Up
 After `codex` completes, use `AskUserQuestion` to confirm next steps. Restate model/reasoning/sandbox when proposing actions.


### PR DESCRIPTION
## Summary
- codex-plus `/codex` 기본 모델을 **gpt-5.4 → gpt-5.5**로 승격
- `gpt-5.3-codex` 제거, `gpt-5.4`는 supplementary 옵션으로 유지
- 식별자 유효성은 PR 생성 전 `codex exec -m gpt-5.5` 실측으로 확인 완료

## Scope
**변경 파일** (5 hunk):
- `codex-plus/skills/codex/SKILL.md:66-67` — 모델 테이블 재구성
- `codex-plus/skills/codex/SKILL.md:88` — Custom 예시 식별자 교체
- `codex-plus/scripts/codex-run.sh:8` — `DEFAULT_MODEL="gpt-5.5"`
- `codex-plus/scripts/codex-run.sh:24` — help 텍스트 default 갱신
- `codex-plus/scripts/codex-run.sh:34` — 예시 usage 식별자 교체

**의도적 비변경** (non-goal, Telos 스코프에서 제외):
- `codex-plus/.claude-plugin/plugin.json` version — 2.1.0 유지
- `codex-plus/skills/codex/references/gpt-5-4_prompting_guide.md` — 5.5 prompting guide 미존재로 일시적 불일치 허용
- `codex-plus/skills/codex/SKILL.md:100-102` — 5.4 가이드 참조 안내 문구 (여전히 5.4 가이드 위치 기술로 정확)

## Test plan
- [x] `grep -rn gpt-5.3-codex codex-plus/skills codex-plus/scripts` 결과 0건
- [x] `codex exec -m gpt-5.5 -s read-only "Respond with exactly: OK"` 성공 (사전 실행 시 exit 0, 응답 OK 확인)
- [x] `bash codex-plus/scripts/codex-run.sh -h` 출력에 `(default: gpt-5.5)` 표시
- [x] Plugin reload 후 `/codex` 호출 시 모델 선택지에 `gpt-5.5 (default)`, `gpt-5.4 (supplementary)`로 제시됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)

