### PR TITLE
feat(cdp-attach): Phase 1 — errors.jsonl + cdp_call + doctor

### DIFF
--- a/cdp-attach/scripts/cdp_client.py
+++ b/cdp-attach/scripts/cdp_client.py
@@ -28,6 +28,31 @@ import urllib.error
 # State file location
 STATE_DIR = os.path.expanduser("~/.cache/cdp-attach")
 STATE_FILE = os.path.join(STATE_DIR, "state.json")
+ERRORS_FILE = os.path.join(STATE_DIR, "errors.jsonl")
+ERRORS_ROTATE_BYTES = 1024 * 1024  # 1MB
+
+
+def _log_error(category, payload):
+    """Append an error event to ~/.cache/cdp-attach/errors.jsonl.
+
+    Best-effort: never raises. Disabled when CDP_ATTACH_NO_ERROR_LOG=1.
+    Rotates errors.jsonl -> errors.jsonl.1 when size exceeds ERRORS_ROTATE_BYTES.
+    """
+    if os.environ.get("CDP_ATTACH_NO_ERROR_LOG") == "1":
+        return
+    try:
+        os.makedirs(STATE_DIR, exist_ok=True)
+        try:
+            if os.path.getsize(ERRORS_FILE) > ERRORS_ROTATE_BYTES:
+                os.replace(ERRORS_FILE, ERRORS_FILE + ".1")
+        except FileNotFoundError:
+            pass
+        entry = {"t": time.time(), "category": category, **payload}
+        with open(ERRORS_FILE, "a") as f:
+            f.write(json.dumps(entry, ensure_ascii=False, default=str) + "\n")
+    except Exception:
+        # Logger must never break the caller.
+        pass
 
 
 class CDPError(Exception):
@@ -208,20 +233,43 @@ class CDPClient:
                 if resp.get("id") == msg_id:
                     if "error" in resp:
                         err = resp["error"]
-                        raise CDPError(f"CDP error ({err.get('code')}): {err.get('message')}")
+                        error_msg = f"CDP error ({err.get('code')}): {err.get('message')}"
+                        _log_error("send", {
+                            "method": method,
+                            "params": params or {},
+                            "error": error_msg,
+                            "code": err.get("code"),
+                        })
+                        raise CDPError(error_msg)
                     return resp.get("result", {})
                 else:
                     # Buffer events (no 'id' field) for later inspection
                     self._event_buffer.append(resp)
+            except CDPError:
+                # Already logged at the raise site.
+                raise
             except Exception as e:
                 if "timed out" in str(e).lower():
                     continue
+                _log_error("send", {
+                    "method": method,
+                    "params": params or {},
+                    "error": f"{type(e).__name__}: {e}",
+                    "kind": "ws_error",
+                })
                 raise
 
-        raise CDPError(
+        timeout_msg = (
             f"Timeout waiting for response to {method} ({timeout}s). "
             "Tab may be frozen or suspended."
         )
+        _log_error("send", {
+            "method": method,
+            "params": params or {},
+            "error": timeout_msg,
+            "kind": "timeout",
+        })
+        raise CDPError(timeout_msg)
 
     def close(self):
         """Close WebSocket connection."""

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -204,7 +204,6 @@ def cmd_snapshot(client, args):
 
 def cmd_evaluate(client, args):
     """Evaluate JavaScript expression."""
-    # Fix 2: Resolve expression from --stdin or positional arg
     if args.stdin:
         expression = sys.stdin.read().strip()
     elif args.expression:
@@ -213,11 +212,10 @@ def cmd_evaluate(client, args):
         print("Error: Provide expression argument or use --stdin", file=sys.stderr)
         sys.exit(1)
 
-    # Fix 1: Rewrite const/let to var for re-declaration safety
     if not args.no_rewrite:
         expression = _redeclare_safe(expression)
 
-    # Fix 3: Auto-wrap await expressions in async IIFE
+    # Auto-wrap await expressions in async IIFE
     if args.await_promise and 'await ' in expression and not expression.strip().startswith('(async'):
         stripped = expression.rstrip().rstrip(';')
         if ';' not in stripped and '\n' not in stripped:
@@ -437,7 +435,6 @@ def cmd_doctor(client, args):
 
     print(f"cdp-attach doctor — host={client.host} port={client.port}")
 
-    # Step 1: HTTP /json/version
     try:
         info = client.get_version()
         browser = info.get("Browser", "?") if isinstance(info, dict) else "?"
@@ -454,7 +451,6 @@ def cmd_doctor(client, args):
     except Exception as e:
         step("Browser visible (not headless)", False, str(e))
 
-    # Step 3: /json/list non-empty
     tabs = []
     try:
         tabs = client.list_tabs(type_filter="page")
@@ -462,7 +458,6 @@ def cmd_doctor(client, args):
     except Exception as e:
         step("Tab list non-empty", False, str(e))
 
-    # Step 4: selected_target valid
     selected = client.get_selected_target()
     target_ids = {t.get("id") for t in tabs}
     if selected is None:
@@ -558,15 +553,15 @@ def cmd_cdp_call(client, args):
 
 def cmd_error_list(client, args):
     """List recent error events from errors.jsonl."""
-    if not os.path.exists(ERRORS_FILE):
-        print(f"No errors logged ({ERRORS_FILE} not found)")
-        return
-
     cutoff = time.time() - args.since_seconds if args.since_seconds else 0
     filter_str = (args.filter or "").lower()
 
-    with open(ERRORS_FILE) as f:
-        lines = f.readlines()
+    try:
+        with open(ERRORS_FILE) as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        print(f"No errors logged ({ERRORS_FILE} not found)")
+        return
 
     matching = []
     for line in lines:
@@ -590,7 +585,7 @@ def cmd_error_list(client, args):
     matching = matching[-args.limit:]
 
     if not matching:
-        print(f"No matching errors (limit={args.limit}, filter={filter_str!r})")
+        print(f"No matching errors (limit={args.limit}, filter={args.filter!r})")
         return
 
     for entry in matching:
@@ -603,6 +598,13 @@ def cmd_error_list(client, args):
         suffix = f" {'/'.join(suffix_parts)}" if suffix_parts else ""
         error = entry.get("error", "")
         print(f"[{ts_str}] {category}{suffix}: {error}")
+
+
+# Commands that bypass the headless guard:
+# - version: diagnostic/info-only
+# - error_list: reads local JSONL file, no CDP commands
+# - doctor: diagnostic, reports headless status itself
+LOCAL_COMMANDS = {"version", "error_list", "doctor"}
 
 
 def main():
@@ -695,10 +697,6 @@ def main():
 
     args = parser.parse_args()
     client = CDPClient(host=args.host, port=args.port)
-
-    # Exempt from headless guard: diagnostic / local-file commands only.
-    # Keep in sync with commands dict below.
-    LOCAL_COMMANDS = {"version", "error_list", "doctor"}
 
     commands = {
         "version": cmd_version,

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -590,7 +590,7 @@ def cmd_error_list(client, args):
     matching = matching[-args.limit:]
 
     if not matching:
-        print(f"No matching errors (limit={args.limit}, filter={args.filter!r})")
+        print(f"No matching errors (limit={args.limit}, filter={filter_str!r})")
         return
 
     for entry in matching:
@@ -603,13 +603,6 @@ def cmd_error_list(client, args):
         suffix = f" {'/'.join(suffix_parts)}" if suffix_parts else ""
         error = entry.get("error", "")
         print(f"[{ts_str}] {category}{suffix}: {error}")
-
-
-# Commands that bypass the headless guard:
-# - version: diagnostic/info-only
-# - error_list: reads local JSONL file, no CDP commands
-# - doctor: diagnostic, reports headless status itself
-LOCAL_COMMANDS = {"version", "error_list", "doctor"}
 
 
 def main():
@@ -702,6 +695,10 @@ def main():
 
     args = parser.parse_args()
     client = CDPClient(host=args.host, port=args.port)
+
+    # Exempt from headless guard: diagnostic / local-file commands only.
+    # Keep in sync with commands dict below.
+    LOCAL_COMMANDS = {"version", "error_list", "doctor"}
 
     commands = {
         "version": cmd_version,

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -12,6 +12,7 @@ v1_core — Core CDP operations: list, select, screenshot, snapshot, evaluate, n
 import argparse
 import base64
 import json
+import os
 import re
 import sys
 import time
@@ -19,7 +20,7 @@ from pathlib import Path
 
 # Import shared client from same directory
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from cdp_client import CDPClient, CDPError
+from cdp_client import CDPClient, CDPError, ERRORS_FILE
 
 
 _TOP_LEVEL_CONST_LET_RE = re.compile(r'(?m)^(\s*)(const|let)\b')
@@ -422,6 +423,61 @@ def cmd_wait(client, args):
         client.close()
 
 
+def cmd_error_list(client, args):
+    """List recent error events from errors.jsonl."""
+    if not os.path.exists(ERRORS_FILE):
+        print(f"No errors logged ({ERRORS_FILE} not found)")
+        return
+
+    cutoff = time.time() - args.since_seconds if args.since_seconds else 0
+    filter_str = (args.filter or "").lower()
+
+    with open(ERRORS_FILE) as f:
+        lines = f.readlines()
+
+    matching = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if cutoff and entry.get("t", 0) < cutoff:
+            continue
+        if filter_str:
+            haystack = " ".join(
+                str(entry.get(k, "")) for k in ("category", "method", "error", "kind")
+            ).lower()
+            if filter_str not in haystack:
+                continue
+        matching.append(entry)
+
+    matching = matching[-args.limit:]
+
+    if not matching:
+        print(f"No matching errors (limit={args.limit}, filter={args.filter!r})")
+        return
+
+    for entry in matching:
+        ts = entry.get("t", 0)
+        ts_str = time.strftime("%H:%M:%S", time.localtime(ts))
+        category = entry.get("category", "?")
+        method = entry.get("method", "")
+        kind = entry.get("kind", "")
+        suffix_parts = [p for p in (method, kind) if p]
+        suffix = f" {'/'.join(suffix_parts)}" if suffix_parts else ""
+        error = entry.get("error", "")
+        print(f"[{ts_str}] {category}{suffix}: {error}")
+
+
+# Commands that bypass the headless guard:
+# - version: diagnostic/info-only
+# - error_list: reads local JSONL file, no CDP commands
+LOCAL_COMMANDS = {"version", "error_list"}
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="cdp-v1",
@@ -486,6 +542,13 @@ def main():
     p_wait.add_argument("--timeout-ms", dest="timeout_ms", type=int, default=30000,
                         help="Timeout in milliseconds (default: 30000)")
 
+    # error_list
+    p_err = sub.add_parser("error_list", help="List recent CDP error events from errors.jsonl")
+    p_err.add_argument("--limit", type=int, default=50, help="Max entries to show (default: 50)")
+    p_err.add_argument("--filter", help="Substring to match in category/method/error/kind")
+    p_err.add_argument("--since-seconds", dest="since_seconds", type=int,
+                       help="Only entries within last N seconds")
+
     args = parser.parse_args()
     client = CDPClient(host=args.host, port=args.port)
 
@@ -498,11 +561,12 @@ def main():
         "evaluate": cmd_evaluate,
         "navigate": cmd_navigate,
         "wait": cmd_wait,
+        "error_list": cmd_error_list,
     }
 
     try:
-        # Block headless browsers (except version for diagnostics)
-        if args.command != "version":
+        # Block headless browsers (except for diagnostic / local commands).
+        if args.command not in LOCAL_COMMANDS:
             client.require_headed()
         commands[args.command](client, args)
     except CDPError as e:

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -423,6 +423,46 @@ def cmd_wait(client, args):
         client.close()
 
 
+def cmd_cdp_call(client, args):
+    """Send a raw CDP method and print the result.
+
+    Escape hatch for CDP primitives not exposed by v1/v2/v3 commands.
+    """
+    if args.params_json and args.stdin:
+        print("Error: --params-json and --stdin are mutually exclusive", file=sys.stderr)
+        sys.exit(1)
+
+    params = None
+    if args.stdin:
+        raw = sys.stdin.read().strip()
+        if raw:
+            try:
+                params = json.loads(raw)
+            except json.JSONDecodeError as e:
+                print(f"Error: invalid JSON on stdin: {e}", file=sys.stderr)
+                sys.exit(1)
+    elif args.params_json:
+        try:
+            params = json.loads(args.params_json)
+        except json.JSONDecodeError as e:
+            print(f"Error: invalid JSON in --params-json: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    if params is not None and not isinstance(params, dict):
+        print(
+            f"Error: params must be a JSON object (got {type(params).__name__})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    client.connect()
+    try:
+        result = client.send(args.method, params=params)
+        print(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+    finally:
+        client.close()
+
+
 def cmd_error_list(client, args):
     """List recent error events from errors.jsonl."""
     if not os.path.exists(ERRORS_FILE):
@@ -542,6 +582,17 @@ def main():
     p_wait.add_argument("--timeout-ms", dest="timeout_ms", type=int, default=30000,
                         help="Timeout in milliseconds (default: 30000)")
 
+    # cdp_call
+    p_call = sub.add_parser(
+        "cdp_call",
+        help="Send a raw CDP method (escape hatch for primitives not exposed by v1/v2/v3)",
+    )
+    p_call.add_argument("method", help="CDP method, e.g. Page.captureScreenshot")
+    p_call.add_argument("--params-json", dest="params_json",
+                        help="JSON string with params object")
+    p_call.add_argument("--stdin", action="store_true",
+                        help="Read params JSON from stdin")
+
     # error_list
     p_err = sub.add_parser("error_list", help="List recent CDP error events from errors.jsonl")
     p_err.add_argument("--limit", type=int, default=50, help="Max entries to show (default: 50)")
@@ -561,6 +612,7 @@ def main():
         "evaluate": cmd_evaluate,
         "navigate": cmd_navigate,
         "wait": cmd_wait,
+        "cdp_call": cmd_cdp_call,
         "error_list": cmd_error_list,
     }
 

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 # Import shared client from same directory
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from cdp_client import CDPClient, CDPError, ERRORS_FILE
+from cdp_client import CDPClient, CDPError, ERRORS_FILE, STATE_DIR
 
 
 _TOP_LEVEL_CONST_LET_RE = re.compile(r'(?m)^(\s*)(const|let)\b')
@@ -423,6 +423,99 @@ def cmd_wait(client, args):
         client.close()
 
 
+def cmd_doctor(client, args):
+    """Diagnostic check for cdp-attach setup. Reports headless/headed status itself."""
+    fail_count = 0
+
+    def step(label, ok, detail=""):
+        nonlocal fail_count
+        if not ok:
+            fail_count += 1
+        marker = "PASS" if ok else "FAIL"
+        suffix = f" — {detail}" if detail else ""
+        print(f"  [{marker}] {label}{suffix}")
+
+    print(f"cdp-attach doctor — host={client.host} port={client.port}")
+
+    # Step 1: HTTP /json/version
+    try:
+        info = client.get_version()
+        browser = info.get("Browser", "?") if isinstance(info, dict) else "?"
+        step("HTTP /json/version reachable", True, browser)
+    except Exception as e:
+        step("HTTP /json/version reachable", False, str(e))
+        print(f"\n{fail_count} check(s) failed (cannot continue without HTTP).")
+        sys.exit(1)
+
+    # Step 2: headed/headless (informational; doctor does not require headed)
+    try:
+        is_h = client.is_headless()
+        step("Browser visible (not headless)", not is_h, "headless" if is_h else "headed")
+    except Exception as e:
+        step("Browser visible (not headless)", False, str(e))
+
+    # Step 3: /json/list non-empty
+    tabs = []
+    try:
+        tabs = client.list_tabs(type_filter="page")
+        step("Tab list non-empty", len(tabs) > 0, f"{len(tabs)} tab(s)")
+    except Exception as e:
+        step("Tab list non-empty", False, str(e))
+
+    # Step 4: selected_target valid
+    selected = client.get_selected_target()
+    target_ids = {t.get("id") for t in tabs}
+    if selected is None:
+        step("Selected target valid", True, "none selected (use 'select' first)")
+        ws_target = None
+    else:
+        valid = selected in target_ids
+        detail = f"{selected[:8]}..." + ("" if valid else " (not in tab list)")
+        step("Selected target valid", valid, detail)
+        ws_target = selected if valid else None
+
+    # Step 5/6: WebSocket handshake + Runtime.evaluate
+    if ws_target:
+        try:
+            client.connect(target_id=ws_target)
+            step("WebSocket handshake", True)
+            try:
+                result = client.send(
+                    "Runtime.evaluate",
+                    {"expression": "1+1", "returnByValue": True},
+                )
+                value = result.get("result", {}).get("value")
+                step("Runtime.evaluate 1+1 == 2", value == 2, str(value))
+            except Exception as e:
+                step("Runtime.evaluate 1+1 == 2", False, str(e))
+            finally:
+                client.close()
+        except Exception as e:
+            step("WebSocket handshake", False, str(e))
+            step("Runtime.evaluate 1+1 == 2", False, "skipped")
+    else:
+        step("WebSocket handshake", False, "no valid target")
+        step("Runtime.evaluate 1+1 == 2", False, "skipped")
+
+    # Step 7: cache dir writable
+    try:
+        os.makedirs(STATE_DIR, exist_ok=True)
+        test_path = os.path.join(STATE_DIR, ".doctor-write-test")
+        with open(test_path, "w") as f:
+            f.write("ok")
+        os.remove(test_path)
+        step("Cache dir writable", True, STATE_DIR)
+    except Exception as e:
+        step("Cache dir writable", False, f"{STATE_DIR}: {e}")
+
+    print()
+    if fail_count == 0:
+        print("All checks passed.")
+    else:
+        print(f"{fail_count} check(s) failed.")
+        sys.exit(1)
+
+
 def cmd_cdp_call(client, args):
     """Send a raw CDP method and print the result.
 
@@ -515,7 +608,8 @@ def cmd_error_list(client, args):
 # Commands that bypass the headless guard:
 # - version: diagnostic/info-only
 # - error_list: reads local JSONL file, no CDP commands
-LOCAL_COMMANDS = {"version", "error_list"}
+# - doctor: diagnostic, reports headless status itself
+LOCAL_COMMANDS = {"version", "error_list", "doctor"}
 
 
 def main():
@@ -582,6 +676,12 @@ def main():
     p_wait.add_argument("--timeout-ms", dest="timeout_ms", type=int, default=30000,
                         help="Timeout in milliseconds (default: 30000)")
 
+    # doctor
+    sub.add_parser(
+        "doctor",
+        help="Diagnostic check (HTTP, WebSocket, eval, cache writable)",
+    )
+
     # cdp_call
     p_call = sub.add_parser(
         "cdp_call",
@@ -612,6 +712,7 @@ def main():
         "evaluate": cmd_evaluate,
         "navigate": cmd_navigate,
         "wait": cmd_wait,
+        "doctor": cmd_doctor,
         "cdp_call": cmd_cdp_call,
         "error_list": cmd_error_list,
     }

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -89,9 +89,19 @@ $V1 wait --text "Order complete"                          # Text appears somewhe
 $V1 wait --url-contains "/dashboard"                      # URL navigation
 $V1 wait --load-state networkidle                         # Page lifecycle state
 $V1 wait --function "window.__APP_READY__ === true"       # Custom JS predicate
+
+$V1 doctor                                                # 7-step diagnostic (HTTP/WS/eval/cache)
+$V1 cdp_call Page.getLayoutMetrics                        # Raw CDP escape hatch (no params)
+$V1 cdp_call Storage.getCookies --params-json '{"urls":["https://example.com"]}'
+$V1 cdp_call DOM.getDocument --stdin <<< '{"depth":1}'    # Read params from stdin
+$V1 error_list                                            # Recent CDP errors (last 50)
+$V1 error_list --filter "Network" --limit 20              # Filter category/method/error
+$V1 error_list --since-seconds 300                        # Last 5 minutes only
 ```
 
 > **Note on `--frame`**: accepts a CSS selector matching a frame owner (e.g. `iframe`, `frame`, `object`, `embed`) or the literal `main` for the top-level document. Cross-origin frames resolve the same way because CDP exposes per-frame execution contexts regardless of origin.
+
+> **Note on `doctor`, `cdp_call`, `error_list`**: bypass the headless guard so they run on any reachable CDP endpoint. `doctor` reports headless state itself; `cdp_call` is the escape hatch for CDP methods not wrapped by v1/v2/v3; `error_list` reads `~/.cache/cdp-attach/errors.jsonl`, which `cdp_client.send()` populates automatically on every CDP failure (CDP error response, timeout, or WebSocket error). Disable error logging with `CDP_ATTACH_NO_ERROR_LOG=1`. The file rotates to `errors.jsonl.1` at 1MB.
 
 ### Common Mistakes
 


### PR DESCRIPTION
## 개요

cdp-attach 의 browser-harness 흡수 Phase 1 (3 task / 11):

- **#6** errors.jsonl 자동 기록 + `error_list` 커맨드
- **#5** `cdp_call` raw CDP escape hatch
- **#4** `doctor` 7-step 진단

분석 근거: Analogia (`/ground`) + Euporia (`/elicit`) 로 cdp-attach 의 정체성 (stateless × domain-free × tool-simple) 을 100% 보존하면서 흡수 가능한 후보를 식별. 8개 흡수 task 중 인프라 관통 변경(에러 로깅 wrap)을 포함하는 3개를 우선 안착. 자세한 계획: `~/.claude/plans/spicy-pondering-hedgehog.md`.

## 커밋 단위

### 1. `errors.jsonl` + `error_list` (ce5dbb0)
- `cdp_client.py`: `_log_error()` 모듈 함수 추가, `CDPClient.send()` 의 3 raise 지점 (CDP error / timeout / ws_error) 에 log-then-reraise 적용
- 포맷: `{"t", "category", "method", "params", "error", "kind"}`
- `v1_core.py`: `cmd_error_list` (`--limit`, `--filter`, `--since-seconds`), `LOCAL_COMMANDS` 셋 도입 (headless guard 우회)
- 1MB 시 `errors.jsonl.1` 로 rotate, `CDP_ATTACH_NO_ERROR_LOG=1` kill-switch

### 2. `cdp_call` (37c7fcb)
- `v1_core.py`: `cmd_cdp_call` — 3 입력 모드 (no-params / `--params-json` / `--stdin`)
- v1/v2/v3 미커버 CDP 메서드 (Storage.*, Animation.*, Memory.* 등) 즉시 사용 가능
- 도구 surface 확장 없이 능력 확장

### 3. `doctor` (2ab620a)
- `v1_core.py`: `cmd_doctor` — 7 단계 진단 (PASS/FAIL 한 줄씩)
  1. HTTP `/json/version` 응답
  2. headed/headless 표시
  3. `/json/list` 비어있지 않음
  4. `selected_target` 의 `state.json` 정합성
  5. WebSocket 핸드셰이크
  6. `Runtime.evaluate "1+1"` == 2
  7. `~/.cache/cdp-attach/` 쓰기 가능
- `LOCAL_COMMANDS` 에 doctor 추가 (자체가 headless 보고)
- step 1 실패 시 early exit

### 4. SKILL.md (ba4694b)
- v1 quick reference 에 신규 3 커맨드 사용 예시 + 동작 노트

## Manual Acceptance

```bash
V1="cdp-attach/scripts/v1_core.py"

# 정상 케이스
uv run $V1 doctor                                  # 모든 step PASS
uv run $V1 cdp_call Page.getLayoutMetrics          # JSON 결과
uv run $V1 cdp_call Storage.getCookies --params-json '{"urls":["https://example.com"]}'

# 에러 케이스 (errors.jsonl 자동 기록 검증)
uv run $V1 evaluate "throw new Error('test')"      # CDPError
uv run $V1 error_list --limit 5                    # 위 에러 항목 표시
uv run $V1 error_list --filter "Network"           # 카테고리/메서드 필터

# Kill-switch
CDP_ATTACH_NO_ERROR_LOG=1 uv run $V1 evaluate "throw 1"
# → ~/.cache/cdp-attach/errors.jsonl 미증가 확인

# Headless guard 우회
# (headless Chrome 인스턴스 대상)
uv run $V1 doctor                                  # 동작 (step 2 가 headless 보고)
uv run $V1 list                                    # 차단 (require_headed())
```

## 영향 범위

- **Breaking changes**: 없음 — 모든 변경은 추가, 기존 동작 보존
- **`send()` wrap (Risk High)**: 모든 v1/v2/v3 커맨드의 에러 경로에 영향
  - Mitigation: 단일 raise 지점 log-then-reraise / 예외 타입·메시지 보존 / kill-switch env var
  - 정상 동작에서는 `errors.jsonl` 미생성

## 다음 Phase

- **Phase 2** (`feat/cdp-attach-interact-extras`): #1 scroll, #2 upload_file, #9 click 파라미터 확장, #10 history nav, #11 evaluate `--frame-url`
- 1.3.0 → **1.4.0** 버전 bump 은 Phase 2 마지막 커밋에 포함
