### PR TITLE
feat(cdp-attach): Phase 2 — interaction extras + v1.4.0

### DIFF
--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/scripts/cdp_client.py
+++ b/cdp-attach/scripts/cdp_client.py
@@ -286,6 +286,33 @@ class CDPClient:
         self._event_buffer.clear()
         return events
 
+    def _context_id_for_frame(self, frame_id, timeout=1.5):
+        """Wait for executionContextCreated event matching frame_id.
+
+        Returns context id, or None if not found within timeout. Caller is
+        responsible for calling Runtime.enable beforehand.
+        """
+        import websocket
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            for ev in self.drain_events():
+                if ev.get("method") != "Runtime.executionContextCreated":
+                    continue
+                ctx = ev.get("params", {}).get("context", {})
+                aux = ctx.get("auxData", {})
+                if aux.get("frameId") == frame_id:
+                    return ctx.get("id")
+            try:
+                self._ws.settimeout(0.15)
+                raw = self._ws.recv()
+                self._event_buffer.append(json.loads(raw))
+            except websocket.WebSocketTimeoutException:
+                continue
+            except Exception:
+                break
+        return None
+
     def resolve_frame_context_id(self, frame_selector):
         """Resolve a CSS selector identifying a frame owner element
         (iframe/frame/object/embed) to the executionContextId of the
@@ -298,8 +325,6 @@ class CDPClient:
         """
         if not frame_selector or frame_selector == "main":
             return None
-
-        import websocket
 
         self.send("Runtime.enable")
         self.send("DOM.enable")
@@ -324,29 +349,55 @@ class CDPClient:
                 f"Element {frame_selector!r} is not a frame owner (no frameId)"
             )
 
-        deadline = time.time() + 1.5
-        while time.time() < deadline:
-            for ev in self.drain_events():
-                if ev.get("method") != "Runtime.executionContextCreated":
-                    continue
-                ctx = ev.get("params", {}).get("context", {})
-                aux = ctx.get("auxData", {})
-                if aux.get("frameId") == frame_id:
-                    return ctx.get("id")
-            try:
-                self._ws.settimeout(0.15)
-                raw = self._ws.recv()
-                self._event_buffer.append(json.loads(raw))
-            except websocket.WebSocketTimeoutException:
-                continue
-            except Exception:
-                break
+        ctx_id = self._context_id_for_frame(frame_id)
+        if ctx_id is None:
+            raise CDPError(
+                f"No execution context found for frame {frame_id} "
+                f"(selector={frame_selector!r}). Frame may be cross-origin isolated "
+                "or not yet loaded."
+            )
+        return ctx_id
 
-        raise CDPError(
-            f"No execution context found for frame {frame_id} "
-            f"(selector={frame_selector!r}). Frame may be cross-origin isolated "
-            "or not yet loaded."
-        )
+    def resolve_frame_context_id_by_url(self, url_substring):
+        """Resolve a URL substring to a frame's executionContextId.
+
+        Walks the frame tree (Page.getFrameTree), finds the first frame whose
+        URL contains the substring, and returns its execution context ID.
+        Useful for dynamic iframe targets where CSS selectors are unstable
+        (hashed classes, dynamic IDs) but URL patterns are stable.
+        """
+        if not url_substring:
+            return None
+
+        self.send("Runtime.enable")
+        self.send("Page.enable")
+
+        tree = self.send("Page.getFrameTree")
+        frame_id = self._find_frame_by_url(tree.get("frameTree", {}), url_substring)
+        if not frame_id:
+            raise CDPError(f"No frame URL contains: {url_substring!r}")
+
+        ctx_id = self._context_id_for_frame(frame_id)
+        if ctx_id is None:
+            raise CDPError(
+                f"No execution context found for frame {frame_id} "
+                f"(url substring={url_substring!r}). Frame may be cross-origin "
+                "isolated or not yet loaded."
+            )
+        return ctx_id
+
+    def _find_frame_by_url(self, frame_tree_node, url_substring):
+        """Walk frame tree DFS; return first frameId whose URL contains substring."""
+        frame = frame_tree_node.get("frame", {})
+        url = frame.get("url", "")
+        if url_substring in url:
+            return frame.get("id")
+
+        for child in frame_tree_node.get("childFrames", []):
+            result = self._find_frame_by_url(child, url_substring)
+            if result:
+                return result
+        return None
 
     # ── State persistence ─────────────────────────────────────────
 

--- a/cdp-attach/scripts/cdp_client.py
+++ b/cdp-attach/scripts/cdp_client.py
@@ -286,14 +286,57 @@ class CDPClient:
         self._event_buffer.clear()
         return events
 
+    def recv_one_event(self, timeout=1.0):
+        """Receive one CDP event from the WebSocket.
+
+        Returns the parsed event dict, or None on timeout. Raises CDPError
+        when the connection is closed or recv fails. Use this for polling
+        async events outside of send() — replaces direct `_ws.settimeout` /
+        `_ws.recv` calls in callers.
+        """
+        import websocket
+
+        if not self._ws:
+            raise CDPError("Not connected")
+        try:
+            self._ws.settimeout(timeout)
+            raw = self._ws.recv()
+            return json.loads(raw)
+        except websocket.WebSocketTimeoutException:
+            return None
+        except (websocket.WebSocketConnectionClosedException, ConnectionError) as e:
+            raise CDPError(f"WebSocket closed during recv: {e}")
+
+    def query_selector_node_id(self, selector):
+        """Resolve a CSS selector to a DOM nodeId.
+
+        Enables DOM domain (idempotent), fetches the document root with
+        depth=0 (root nodeId is all that is needed), and queries the
+        selector. Shared by callers that need a raw nodeId — for example
+        DOM.setFileInputFiles or DOM.describeNode.
+
+        Raises CDPError when the document root or selector match is missing.
+        """
+        self.send("DOM.enable")
+        doc = self.send("DOM.getDocument", {"depth": 0, "pierce": True})
+        root_node_id = doc.get("root", {}).get("nodeId", 0)
+        if not root_node_id:
+            raise CDPError("DOM.getDocument returned no root nodeId")
+        q = self.send("DOM.querySelector", {
+            "nodeId": root_node_id,
+            "selector": selector,
+        })
+        node_id = q.get("nodeId", 0)
+        if not node_id:
+            raise CDPError(f"No element matches selector: {selector!r}")
+        return node_id
+
     def _context_id_for_frame(self, frame_id, timeout=1.5):
         """Wait for executionContextCreated event matching frame_id.
 
         Returns context id, or None if not found within timeout. Caller is
         responsible for calling Runtime.enable beforehand.
         """
-        import websocket
-
         deadline = time.time() + timeout
         while time.time() < deadline:
             for ev in self.drain_events():
@@ -304,13 +347,11 @@ class CDPClient:
                 if aux.get("frameId") == frame_id:
                     return ctx.get("id")
             try:
-                self._ws.settimeout(0.15)
-                raw = self._ws.recv()
-                self._event_buffer.append(json.loads(raw))
-            except websocket.WebSocketTimeoutException:
-                continue
-            except Exception:
+                ev = self.recv_one_event(timeout=0.15)
+            except CDPError:
                 break
+            if ev is not None:
+                self._event_buffer.append(ev)
         return None
 
     def resolve_frame_context_id(self, frame_selector):
@@ -327,20 +368,8 @@ class CDPClient:
             return None
 
         self.send("Runtime.enable")
-        self.send("DOM.enable")
 
-        doc = self.send("DOM.getDocument", {"depth": 1, "pierce": True})
-        root_node_id = doc.get("root", {}).get("nodeId", 0)
-        if not root_node_id:
-            raise CDPError("DOM.getDocument returned no root nodeId")
-
-        q = self.send("DOM.querySelector", {
-            "nodeId": root_node_id,
-            "selector": frame_selector,
-        })
-        node_id = q.get("nodeId", 0)
-        if not node_id:
-            raise CDPError(f"No element matches frame selector: {frame_selector!r}")
+        node_id = self.query_selector_node_id(frame_selector)
 
         desc = self.send("DOM.describeNode", {"nodeId": node_id})
         frame_id = desc.get("node", {}).get("frameId")

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -223,9 +223,16 @@ def cmd_evaluate(client, args):
         else:
             expression = f"(async () => {{ {expression} }})()"
 
+    if args.frame and args.frame_url:
+        print("Error: --frame and --frame-url are mutually exclusive", file=sys.stderr)
+        sys.exit(1)
+
     client.connect()
     try:
-        context_id = client.resolve_frame_context_id(args.frame)
+        if args.frame_url:
+            context_id = client.resolve_frame_context_id_by_url(args.frame_url)
+        else:
+            context_id = client.resolve_frame_context_id(args.frame)
 
         params = {
             "expression": expression,
@@ -718,6 +725,8 @@ def main():
                         help="Await promise result")
     p_eval.add_argument("--frame", default=None,
                         help="CSS selector of a frame owner element, or 'main' for top frame")
+    p_eval.add_argument("--frame-url", dest="frame_url", default=None,
+                        help="URL substring to match a frame (use when selectors are unstable)")
 
     # navigate
     p_nav = sub.add_parser("navigate", help="Navigate to URL")

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -267,8 +267,6 @@ def cmd_evaluate(client, args):
 
 def cmd_navigate(client, args):
     """Navigate to a URL."""
-    import websocket
-
     client.connect()
     try:
         result = client.send("Page.navigate", {"url": args.url})
@@ -280,23 +278,11 @@ def cmd_navigate(client, args):
             sys.exit(1)
 
         if args.wait_for == "load":
-            # Wait for Page.loadEventFired
-            loaded = False
-            deadline = time.time() + 30
-            while time.time() < deadline:
-                try:
-                    client._ws.settimeout(1.0)
-                    raw = client._ws.recv()
-                    resp = json.loads(raw)
-                    if resp.get("method") == "Page.loadEventFired":
-                        loaded = True
-                        break
-                except websocket.WebSocketTimeoutException:
-                    continue
-                except (websocket.WebSocketConnectionClosedException, ConnectionError):
-                    break
-            if not loaded:
-                print("Warning: Page load event not received within 30s — page may not be fully loaded", file=sys.stderr)
+            if not _wait_for_load_event(client):
+                print(
+                    "Warning: Page load event not received within 30s — page may not be fully loaded",
+                    file=sys.stderr,
+                )
 
         frame_id = result.get("frameId", "")
         print(f"Navigated to: {args.url}")
@@ -305,11 +291,92 @@ def cmd_navigate(client, args):
         client.close()
 
 
+def cmd_reload(client, args):
+    """Reload the current page. --hard bypasses cache."""
+    client.connect()
+    try:
+        client.send("Page.reload", {"ignoreCache": args.hard})
+
+        if args.wait_for == "load":
+            if not _wait_for_load_event(client):
+                print(
+                    "Warning: Page load event not received within 30s",
+                    file=sys.stderr,
+                )
+
+        print(f"Reloaded{' (cache bypassed)' if args.hard else ''}")
+    finally:
+        client.close()
+
+
+def _history_nav(client, wait_for, direction, label):
+    """Shared back/forward navigation via Page.navigateToHistoryEntry."""
+    client.connect()
+    try:
+        hist = client.send("Page.getNavigationHistory")
+        entries = hist.get("entries", [])
+        current = hist.get("currentIndex", 0)
+        target = current + direction
+
+        if target < 0:
+            raise CDPError("No further history (already at first entry)")
+        if target >= len(entries):
+            raise CDPError("No further history (already at last entry)")
+
+        entry = entries[target]
+        client.send("Page.navigateToHistoryEntry", {"entryId": entry.get("id")})
+
+        if wait_for == "load":
+            if not _wait_for_load_event(client):
+                print(
+                    "Warning: Page load event not received within 30s",
+                    file=sys.stderr,
+                )
+
+        print(f"Navigated {label} to: {entry.get('url', '')}")
+    finally:
+        client.close()
+
+
+def cmd_back(client, args):
+    """Navigate back in history."""
+    _history_nav(client, args.wait_for, direction=-1, label="back")
+
+
+def cmd_forward(client, args):
+    """Navigate forward in history."""
+    _history_nav(client, args.wait_for, direction=+1, label="forward")
+
+
 _WAIT_LIFECYCLE_NAMES = {
     "load": "load",
     "domcontentloaded": "DOMContentLoaded",
     "networkidle": "networkIdle",
 }
+
+
+def _wait_for_load_event(client, timeout=30):
+    """Wait for Page.loadEventFired event. Returns True if received before timeout.
+
+    Used by navigate / reload / history navigation to provide a uniform
+    --wait-for load behavior. Does not pre-enable Page domain — relies on
+    the event firing regardless (matches existing cmd_navigate behavior).
+    """
+    import websocket
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            client._ws.settimeout(1.0)
+            raw = client._ws.recv()
+            resp = json.loads(raw)
+            if resp.get("method") == "Page.loadEventFired":
+                return True
+        except websocket.WebSocketTimeoutException:
+            continue
+        except (websocket.WebSocketConnectionClosedException, ConnectionError):
+            break
+    return False
 
 
 def _wait_poll(client, expression, label, deadline):
@@ -658,6 +725,23 @@ def main():
     p_nav.add_argument("--wait-for", choices=["load", "none"], default="load",
                        help="Wait condition (default: load)")
 
+    # reload
+    p_reload = sub.add_parser("reload", help="Reload current page")
+    p_reload.add_argument("--hard", action="store_true",
+                          help="Bypass cache (Page.reload ignoreCache=true)")
+    p_reload.add_argument("--wait-for", choices=["load", "none"], default="load",
+                          help="Wait condition (default: load)")
+
+    # back
+    p_back = sub.add_parser("back", help="Navigate back in history")
+    p_back.add_argument("--wait-for", choices=["load", "none"], default="load",
+                        help="Wait condition (default: load)")
+
+    # forward
+    p_forward = sub.add_parser("forward", help="Navigate forward in history")
+    p_forward.add_argument("--wait-for", choices=["load", "none"], default="load",
+                           help="Wait condition (default: load)")
+
     # wait
     p_wait = sub.add_parser("wait", help="Wait for a readiness condition")
     p_wait.add_argument("--selector", help="CSS selector to appear in DOM")
@@ -706,6 +790,9 @@ def main():
         "snapshot": cmd_snapshot,
         "evaluate": cmd_evaluate,
         "navigate": cmd_navigate,
+        "reload": cmd_reload,
+        "back": cmd_back,
+        "forward": cmd_forward,
         "wait": cmd_wait,
         "doctor": cmd_doctor,
         "cdp_call": cmd_cdp_call,

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -276,6 +276,9 @@ def cmd_navigate(client, args):
     """Navigate to a URL."""
     client.connect()
     try:
+        if args.wait_for == "load":
+            _enable_page_subscription(client)
+
         result = client.send("Page.navigate", {"url": args.url})
 
         # Check navigation error before entering wait loop
@@ -302,6 +305,9 @@ def cmd_reload(client, args):
     """Reload the current page. --hard bypasses cache."""
     client.connect()
     try:
+        if args.wait_for == "load":
+            _enable_page_subscription(client)
+
         client.send("Page.reload", {"ignoreCache": args.hard})
 
         if args.wait_for == "load":
@@ -317,9 +323,18 @@ def cmd_reload(client, args):
 
 
 def _history_nav(client, wait_for, direction, label):
-    """Shared back/forward navigation via Page.navigateToHistoryEntry."""
+    """Shared back/forward navigation via Page.navigateToHistoryEntry.
+
+    Note: bfcache restore may skip Page.loadEventFired entirely. Default
+    --wait-for is 'none' for back/forward to avoid 30s timeouts on cached
+    restores. Use 'load' explicitly only when you know the navigation
+    triggers a fresh load.
+    """
     client.connect()
     try:
+        if wait_for == "load":
+            _enable_page_subscription(client)
+
         hist = client.send("Page.getNavigationHistory")
         entries = hist.get("entries", [])
         current = hist.get("currentIndex", 0)
@@ -365,11 +380,20 @@ _WAIT_LIFECYCLE_NAMES = {
 def _wait_for_load_event(client, timeout=30):
     """Wait for Page.loadEventFired event. Returns True if received before timeout.
 
-    Used by navigate / reload / history navigation to provide a uniform
-    --wait-for load behavior. Does not pre-enable Page domain — relies on
-    the event firing regardless (matches existing cmd_navigate behavior).
+    Drains the client event buffer first — Page.loadEventFired often arrives
+    during the preceding navigation method's response wait (especially for
+    fast operations like reload), so checking the buffer first prevents
+    false 30s timeouts.
+
+    Caller should call _enable_page_subscription() before the navigation
+    method to ensure Page.loadEventFired is delivered.
     """
     import websocket
+
+    # Catch events buffered during preceding send() calls
+    for ev in client.drain_events():
+        if ev.get("method") == "Page.loadEventFired":
+            return True
 
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -384,6 +408,18 @@ def _wait_for_load_event(client, timeout=30):
         except (websocket.WebSocketConnectionClosedException, ConnectionError):
             break
     return False
+
+
+def _enable_page_subscription(client):
+    """Call before a navigation method when --wait-for load is requested.
+
+    Idempotent. Ensures Page.loadEventFired events are delivered to the
+    WebSocket connection.
+    """
+    try:
+        client.send("Page.enable")
+    except Exception:
+        pass
 
 
 def _wait_poll(client, expression, label, deadline):
@@ -743,13 +779,13 @@ def main():
 
     # back
     p_back = sub.add_parser("back", help="Navigate back in history")
-    p_back.add_argument("--wait-for", choices=["load", "none"], default="load",
-                        help="Wait condition (default: load)")
+    p_back.add_argument("--wait-for", choices=["load", "none"], default="none",
+                        help="Wait condition (default: none — bfcache may skip load event)")
 
     # forward
     p_forward = sub.add_parser("forward", help="Navigate forward in history")
-    p_forward.add_argument("--wait-for", choices=["load", "none"], default="load",
-                           help="Wait condition (default: load)")
+    p_forward.add_argument("--wait-for", choices=["load", "none"], default="none",
+                           help="Wait condition (default: none — bfcache may skip load event)")
 
     # wait
     p_wait = sub.add_parser("wait", help="Wait for a readiness condition")

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -388,38 +388,40 @@ def _wait_for_load_event(client, timeout=30):
     Caller should call _enable_page_subscription() before the navigation
     method to ensure Page.loadEventFired is delivered.
     """
-    import websocket
-
-    # Catch events buffered during preceding send() calls
     for ev in client.drain_events():
         if ev.get("method") == "Page.loadEventFired":
             return True
 
     deadline = time.time() + timeout
     while time.time() < deadline:
-        try:
-            client._ws.settimeout(1.0)
-            raw = client._ws.recv()
-            resp = json.loads(raw)
-            if resp.get("method") == "Page.loadEventFired":
-                return True
-        except websocket.WebSocketTimeoutException:
-            continue
-        except (websocket.WebSocketConnectionClosedException, ConnectionError):
+        remaining = min(deadline - time.time(), 1.0)
+        if remaining <= 0:
             break
+        try:
+            ev = client.recv_one_event(timeout=remaining)
+        except CDPError:
+            break
+        if ev is None:
+            continue
+        if ev.get("method") == "Page.loadEventFired":
+            return True
     return False
 
 
 def _enable_page_subscription(client):
     """Call before a navigation method when --wait-for load is requested.
 
-    Idempotent. Ensures Page.loadEventFired events are delivered to the
-    WebSocket connection.
+    Idempotent on the CDP side. CDPError (e.g., connection drop) is logged
+    to stderr — silent swallow would mask connection issues as opaque 30s
+    timeouts in the subsequent _wait_for_load_event call.
     """
     try:
         client.send("Page.enable")
-    except Exception:
-        pass
+    except CDPError as e:
+        print(
+            f"Warning: Page.enable failed ({e}) — load wait may time out",
+            file=sys.stderr,
+        )
 
 
 def _wait_poll(client, expression, label, deadline):

--- a/cdp-attach/scripts/v2_interact.py
+++ b/cdp-attach/scripts/v2_interact.py
@@ -304,6 +304,45 @@ def cmd_click(client, args):
         client.close()
 
 
+def cmd_scroll(client, args):
+    """Scroll the page (or at specific coordinates) via mouseWheel.
+
+    Coordinates default to viewport center if neither x/y nor --selector given.
+    Positive delta_y scrolls down; negative scrolls up.
+    """
+    if (args.x is None) != (args.y is None):
+        print("Error: provide both x and y, or neither", file=sys.stderr)
+        sys.exit(1)
+
+    client.connect()
+    try:
+        if args.selector:
+            info = _resolve_selector(client, args.selector)
+            x, y = info["x"], info["y"]
+        elif args.x is not None:
+            x, y = args.x, args.y
+        else:
+            # Default: viewport center
+            metrics = client.send("Page.getLayoutMetrics")
+            vp = metrics.get("layoutViewport") or metrics.get("visualViewport") or {}
+            x = vp.get("clientWidth", 800) / 2
+            y = vp.get("clientHeight", 600) / 2
+
+        client.send("Input.dispatchMouseEvent", {
+            "type": "mouseWheel",
+            "x": x,
+            "y": y,
+            "deltaX": args.delta_x,
+            "deltaY": args.delta_y,
+        })
+
+        direction = "down" if args.delta_y > 0 else ("up" if args.delta_y < 0 else "")
+        suffix = f" ({direction})" if direction else ""
+        print(f"Scrolled at ({x:.0f}, {y:.0f}) dx={args.delta_x} dy={args.delta_y}{suffix}")
+    finally:
+        client.close()
+
+
 def cmd_fill(client, args):
     """Fill text into an element."""
     client.connect()
@@ -684,6 +723,16 @@ def main():
     p_click.add_argument("--modifiers", "-m",
                          help="Comma-separated: ctrl,shift,alt,meta (e.g., 'ctrl' = new-tab click)")
 
+    # scroll
+    p_scroll = sub.add_parser("scroll", help="Scroll via mouseWheel (page or at coordinates)")
+    p_scroll.add_argument("x", nargs="?", type=float, help="X coordinate (default: viewport center)")
+    p_scroll.add_argument("y", nargs="?", type=float, help="Y coordinate (default: viewport center)")
+    p_scroll.add_argument("--selector", "-s", help="CSS selector (alternative to x,y)")
+    p_scroll.add_argument("--delta-y", dest="delta_y", type=float, default=300,
+                          help="Vertical scroll delta px (positive=down, default: 300)")
+    p_scroll.add_argument("--delta-x", dest="delta_x", type=float, default=0,
+                          help="Horizontal scroll delta px (positive=right, default: 0)")
+
     # fill
     p_fill = sub.add_parser("fill", help="Fill text into element")
     p_fill.add_argument("--selector", "-s", required=True, help="CSS selector")
@@ -735,6 +784,7 @@ def main():
 
     commands = {
         "click": cmd_click,
+        "scroll": cmd_scroll,
         "fill": cmd_fill,
         "press_key": cmd_press_key,
         "hover": cmd_hover,

--- a/cdp-attach/scripts/v2_interact.py
+++ b/cdp-attach/scripts/v2_interact.py
@@ -11,6 +11,7 @@ v2_interact — Browser interaction: click, fill, press_key, hover, new_page, cl
 
 import argparse
 import json
+import os
 import sys
 import time
 from pathlib import Path
@@ -339,6 +340,72 @@ def cmd_scroll(client, args):
         direction = "down" if args.delta_y > 0 else ("up" if args.delta_y < 0 else "")
         suffix = f" ({direction})" if direction else ""
         print(f"Scrolled at ({x:.0f}, {y:.0f}) dx={args.delta_x} dy={args.delta_y}{suffix}")
+    finally:
+        client.close()
+
+
+def cmd_upload_file(client, args):
+    """Upload file(s) to an <input type=file> element via DOM.setFileInputFiles.
+
+    Paths are expanded (~), resolved to absolute, and verified to exist.
+    Element type is pre-validated to fail fast on wrong target.
+    """
+    abs_paths = []
+    for path in args.files:
+        expanded = os.path.expanduser(path)
+        abs_path = os.path.abspath(expanded)
+        if not os.path.exists(abs_path):
+            print(f"Error: file not found: {abs_path}", file=sys.stderr)
+            sys.exit(1)
+        if not os.path.isfile(abs_path):
+            print(f"Error: not a regular file: {abs_path}", file=sys.stderr)
+            sys.exit(1)
+        abs_paths.append(abs_path)
+
+    client.connect()
+    try:
+        _ensure_dom(client)
+
+        doc = client.send("DOM.getDocument", {"depth": 1, "pierce": True})
+        root_node_id = doc.get("root", {}).get("nodeId", 0)
+        if not root_node_id:
+            raise CDPError("DOM.getDocument returned no root nodeId")
+
+        q = client.send("DOM.querySelector", {
+            "nodeId": root_node_id,
+            "selector": args.selector,
+        })
+        node_id = q.get("nodeId", 0)
+        if not node_id:
+            raise CDPError(f"No element matches selector: {args.selector!r}")
+
+        # Pre-validate element is <input type=file>; setFileInputFiles silently
+        # no-ops on other elements, which would mask user mistakes.
+        desc = client.send("DOM.describeNode", {"nodeId": node_id})
+        node = desc.get("node", {})
+        node_name = node.get("nodeName", "").lower()
+        # CDP returns attributes as a flat list: [k1, v1, k2, v2, ...]
+        attrs = node.get("attributes") or []
+        attr_map = dict(zip(attrs[::2], attrs[1::2]))
+
+        if node_name != "input":
+            raise CDPError(
+                f"Element {args.selector!r} is <{node_name}>, expected <input>. "
+                "upload_file targets <input type=\"file\"> only."
+            )
+        if attr_map.get("type", "").lower() != "file":
+            raise CDPError(
+                f"Element <input> has type={attr_map.get('type', 'text')!r}, "
+                "expected type=\"file\". upload_file targets <input type=\"file\"> only."
+            )
+
+        client.send("DOM.setFileInputFiles", {
+            "nodeId": node_id,
+            "files": abs_paths,
+        })
+
+        label = abs_paths[0] if len(abs_paths) == 1 else f"{len(abs_paths)} files"
+        print(f"Uploaded to {args.selector!r}: {label}")
     finally:
         client.close()
 
@@ -733,6 +800,15 @@ def main():
     p_scroll.add_argument("--delta-x", dest="delta_x", type=float, default=0,
                           help="Horizontal scroll delta px (positive=right, default: 0)")
 
+    # upload_file
+    p_upload = sub.add_parser(
+        "upload_file",
+        help="Upload file(s) to <input type=file> via DOM.setFileInputFiles",
+    )
+    p_upload.add_argument("--selector", "-s", required=True,
+                          help="CSS selector for <input type=file>")
+    p_upload.add_argument("files", nargs="+", help="One or more file paths (absolute or ~)")
+
     # fill
     p_fill = sub.add_parser("fill", help="Fill text into element")
     p_fill.add_argument("--selector", "-s", required=True, help="CSS selector")
@@ -785,6 +861,7 @@ def main():
     commands = {
         "click": cmd_click,
         "scroll": cmd_scroll,
+        "upload_file": cmd_upload_file,
         "fill": cmd_fill,
         "press_key": cmd_press_key,
         "hover": cmd_hover,

--- a/cdp-attach/scripts/v2_interact.py
+++ b/cdp-attach/scripts/v2_interact.py
@@ -70,8 +70,9 @@ def _dispatch_mouse(client, x, y, event_type, button="left", click_count=1, modi
 def _parse_modifiers(spec):
     """Parse comma-separated modifier names to CDP bitmask.
 
-    Returns int bitmask: 1=Alt, 2=Ctrl, 4=Shift, 8=Meta. Empty/None returns 0.
-    Unknown names are silently skipped.
+    Per CDP spec (Input.dispatchMouseEvent / dispatchKeyEvent):
+        Alt=1, Ctrl=2, Meta/Command=4, Shift=8.
+    Empty/None returns 0. Unknown names are silently skipped.
     """
     if not spec:
         return 0
@@ -82,9 +83,9 @@ def _parse_modifiers(spec):
             bitmask |= 1
         elif name == "ctrl":
             bitmask |= 2
-        elif name == "shift":
-            bitmask |= 4
         elif name in ("meta", "cmd"):
+            bitmask |= 4
+        elif name == "shift":
             bitmask |= 8
     return bitmask
 
@@ -422,12 +423,13 @@ def cmd_fill(client, args):
         _dispatch_mouse(client, x, y, "mouseReleased")
         time.sleep(0.05)
 
-        # Select all existing text (Ctrl+A / Cmd+A)
+        # Select all existing text (Cmd+A on macOS, Ctrl+A elsewhere).
+        # CDP modifiers bitmask: Meta=4, Ctrl=2 (per Input.dispatchKeyEvent spec).
         client.send("Input.dispatchKeyEvent", {
             "type": "keyDown",
             "key": "a",
             "code": "KeyA",
-            "modifiers": 8 if sys.platform == "darwin" else 2,  # meta or ctrl
+            "modifiers": 4 if sys.platform == "darwin" else 2,  # meta or ctrl
         })
         client.send("Input.dispatchKeyEvent", {
             "type": "keyUp",

--- a/cdp-attach/scripts/v2_interact.py
+++ b/cdp-attach/scripts/v2_interact.py
@@ -54,7 +54,7 @@ def _resolve_selector(client, selector):
     return obj
 
 
-def _dispatch_mouse(client, x, y, event_type, button="left", click_count=1):
+def _dispatch_mouse(client, x, y, event_type, button="left", click_count=1, modifiers=0):
     """Send mouse event at coordinates."""
     client.send("Input.dispatchMouseEvent", {
         "type": event_type,
@@ -62,7 +62,30 @@ def _dispatch_mouse(client, x, y, event_type, button="left", click_count=1):
         "y": y,
         "button": button,
         "clickCount": click_count,
+        "modifiers": modifiers,
     })
+
+
+def _parse_modifiers(spec):
+    """Parse comma-separated modifier names to CDP bitmask.
+
+    Returns int bitmask: 1=Alt, 2=Ctrl, 4=Shift, 8=Meta. Empty/None returns 0.
+    Unknown names are silently skipped.
+    """
+    if not spec:
+        return 0
+    bitmask = 0
+    for m in spec.split(","):
+        name = m.strip().lower()
+        if name == "alt":
+            bitmask |= 1
+        elif name == "ctrl":
+            bitmask |= 2
+        elif name == "shift":
+            bitmask |= 4
+        elif name in ("meta", "cmd"):
+            bitmask |= 8
+    return bitmask
 
 
 # ── CDP DOM/Accessibility helpers ──────────────────────────────
@@ -237,10 +260,18 @@ def _dom_search(client, query, include_shadow_dom=False, limit=20):
 
 
 def cmd_click(client, args):
-    """Click at coordinates or CSS selector."""
+    """Click at coordinates or CSS selector.
+
+    Supports button (left/right/middle), multi-click (double/triple), and modifier keys.
+    Defaults preserve original single-left-click behavior.
+    """
     if not args.selector and (args.x is None or args.y is None):
         print("Error: Provide --selector or both x y coordinates", file=sys.stderr)
         sys.exit(1)
+    if args.clicks < 1:
+        print(f"Error: --clicks must be >= 1 (got {args.clicks})", file=sys.stderr)
+        sys.exit(1)
+
     client.connect()
     try:
         if args.selector:
@@ -250,9 +281,25 @@ def cmd_click(client, args):
         else:
             x, y = args.x, args.y
 
-        _dispatch_mouse(client, x, y, "mousePressed")
-        _dispatch_mouse(client, x, y, "mouseReleased")
-        print(f"Clicked at ({x:.0f}, {y:.0f})")
+        modifiers = _parse_modifiers(args.modifiers)
+
+        # CDP convention: clickCount increments within a click sequence.
+        # Single: cc=1. Double: cc=1 then cc=2. Triple: cc=1, cc=2, cc=3.
+        for i in range(1, args.clicks + 1):
+            _dispatch_mouse(client, x, y, "mousePressed",
+                            button=args.button, click_count=i, modifiers=modifiers)
+            _dispatch_mouse(client, x, y, "mouseReleased",
+                            button=args.button, click_count=i, modifiers=modifiers)
+
+        detail = []
+        if args.button != "left":
+            detail.append(args.button)
+        if args.clicks > 1:
+            detail.append(f"x{args.clicks}")
+        if args.modifiers:
+            detail.append(f"mod={args.modifiers}")
+        suffix = f" [{' '.join(detail)}]" if detail else ""
+        print(f"Clicked at ({x:.0f}, {y:.0f}){suffix}")
     finally:
         client.close()
 
@@ -293,19 +340,7 @@ def cmd_press_key(client, args):
     """Press a keyboard key."""
     client.connect()
     try:
-        # Build modifiers bitmask: 1=Alt, 2=Ctrl, 4=Shift, 8=Meta
-        modifiers = 0
-        if args.modifiers:
-            mod_parts = [m.strip().lower() for m in args.modifiers.split(",")]
-            for m in mod_parts:
-                if m == "alt":
-                    modifiers |= 1
-                elif m == "ctrl":
-                    modifiers |= 2
-                elif m == "shift":
-                    modifiers |= 4
-                elif m in ("meta", "cmd"):
-                    modifiers |= 8
+        modifiers = _parse_modifiers(args.modifiers)
 
         key = args.key
         # Map common key names
@@ -642,6 +677,12 @@ def main():
     p_click.add_argument("x", nargs="?", type=float, help="X coordinate")
     p_click.add_argument("y", nargs="?", type=float, help="Y coordinate")
     p_click.add_argument("--selector", "-s", help="CSS selector (alternative to x,y)")
+    p_click.add_argument("--button", choices=["left", "right", "middle"], default="left",
+                         help="Mouse button (default: left)")
+    p_click.add_argument("--clicks", type=int, default=1,
+                         help="Click count: 1=single, 2=double, 3=triple (default: 1)")
+    p_click.add_argument("--modifiers", "-m",
+                         help="Comma-separated: ctrl,shift,alt,meta (e.g., 'ctrl' = new-tab click)")
 
     # fill
     p_fill = sub.add_parser("fill", help="Fill text into element")

--- a/cdp-attach/scripts/v2_interact.py
+++ b/cdp-attach/scripts/v2_interact.py
@@ -348,37 +348,30 @@ def cmd_scroll(client, args):
 def cmd_upload_file(client, args):
     """Upload file(s) to an <input type=file> element via DOM.setFileInputFiles.
 
-    Paths are expanded (~), resolved to absolute, and verified to exist.
-    Element type is pre-validated to fail fast on wrong target.
+    Paths are expanded (~), resolved to absolute, and validated by attempting
+    open() — single syscall handles existence + regular-file in one shot
+    without TOCTOU between stat and use.
     """
     abs_paths = []
     for path in args.files:
-        expanded = os.path.expanduser(path)
-        abs_path = os.path.abspath(expanded)
-        if not os.path.exists(abs_path):
+        abs_path = os.path.abspath(os.path.expanduser(path))
+        try:
+            with open(abs_path, "rb"):
+                pass
+        except FileNotFoundError:
             print(f"Error: file not found: {abs_path}", file=sys.stderr)
             sys.exit(1)
-        if not os.path.isfile(abs_path):
+        except IsADirectoryError:
             print(f"Error: not a regular file: {abs_path}", file=sys.stderr)
+            sys.exit(1)
+        except PermissionError as e:
+            print(f"Error: cannot read file: {abs_path} ({e})", file=sys.stderr)
             sys.exit(1)
         abs_paths.append(abs_path)
 
     client.connect()
     try:
-        _ensure_dom(client)
-
-        doc = client.send("DOM.getDocument", {"depth": 1, "pierce": True})
-        root_node_id = doc.get("root", {}).get("nodeId", 0)
-        if not root_node_id:
-            raise CDPError("DOM.getDocument returned no root nodeId")
-
-        q = client.send("DOM.querySelector", {
-            "nodeId": root_node_id,
-            "selector": args.selector,
-        })
-        node_id = q.get("nodeId", 0)
-        if not node_id:
-            raise CDPError(f"No element matches selector: {args.selector!r}")
+        node_id = client.query_selector_node_id(args.selector)
 
         # Pre-validate element is <input type=file>; setFileInputFiles silently
         # no-ops on other elements, which would mask user mistakes.

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -165,6 +165,8 @@ $V2 close_page                                 # Close selected tab
 
 > **Note on `--frame-url`**: walks the frame tree with `Page.getFrameTree`, matches the first frame whose URL contains the substring. Useful when CSS selectors are unstable (hashed classes, dynamic IDs) but URL patterns are stable. Mutually exclusive with `--frame`.
 
+> **Note on cross-origin iframes (OOPIF)**: cross-origin iframes (different origin from the parent page) run in separate processes and are not visible in the parent target's `Page.getFrameTree`. Both `--frame` (CSS selector) and `--frame-url` reach **same-origin** iframes only. Cross-origin iframe debugging requires attaching to the iframe's own target via `Target.attachToTarget` (not currently exposed by v1/v2/v3).
+
 ### v2 — Element Discovery (`v2_interact.py`)
 
 When CSS selectors fail (collapsed SPA panels, shadow DOM, hashed classes), use CDP DOM/Accessibility API.

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -82,9 +82,9 @@ $V1 navigate "https://example.com"             # Navigate
 $V1 navigate "https://example.com" --wait-for none
 $V1 reload                                     # Reload current page (wait for load)
 $V1 reload --hard                              # Bypass cache (Page.reload ignoreCache=true)
-$V1 back                                       # Navigate back in history
-$V1 forward                                    # Navigate forward in history
-$V1 back --wait-for none                       # Fire-and-forget mode
+$V1 back                                       # Navigate back (default: no wait — bfcache may skip load event)
+$V1 forward                                    # Navigate forward (default: no wait)
+$V1 back --wait-for load                       # Opt-in load wait (use when fresh load expected)
 
 $V1 evaluate "document.title" --frame "iframe.embedded"   # Evaluate inside an iframe
 $V1 evaluate --frame main "location.href"                 # Explicit top frame

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -80,9 +80,15 @@ $V1 evaluate --stdin <<< 'var x = document.title; x'  # Stdin mode
 $V1 evaluate --no-rewrite "const x = 1"       # Skip var rewriting
 $V1 navigate "https://example.com"             # Navigate
 $V1 navigate "https://example.com" --wait-for none
+$V1 reload                                     # Reload current page (wait for load)
+$V1 reload --hard                              # Bypass cache (Page.reload ignoreCache=true)
+$V1 back                                       # Navigate back in history
+$V1 forward                                    # Navigate forward in history
+$V1 back --wait-for none                       # Fire-and-forget mode
 
 $V1 evaluate "document.title" --frame "iframe.embedded"   # Evaluate inside an iframe
 $V1 evaluate --frame main "location.href"                 # Explicit top frame
+$V1 evaluate --frame-url "youtube" "location.href"        # Match frame by URL substring
 
 $V1 wait --selector "div.loaded" --timeout-ms 10000       # Element appears
 $V1 wait --text "Order complete"                          # Text appears somewhere
@@ -136,13 +142,28 @@ V2="${CLAUDE_PLUGIN_ROOT}/scripts/v2_interact.py"
 
 $V2 click 100 200                              # Click at coordinates
 $V2 click --selector "button.submit"           # Click CSS selector
+$V2 click 100 200 --button right               # Right-click (context menu)
+$V2 click 100 200 --clicks 2                   # Double-click (text selection)
+$V2 click --selector "a" --modifiers ctrl      # Ctrl+click (new tab on link)
+$V2 scroll                                     # Scroll page down 300px (viewport center)
+$V2 scroll --delta-y -500                      # Scroll up 500px
+$V2 scroll 100 400 --delta-y 200               # Scroll at specific coordinates
+$V2 scroll --selector "div.scrollable" --delta-y 100
 $V2 fill --selector "input[name=q]" "search query"
+$V2 upload_file --selector "input[type=file]" /path/to/file.pdf
+$V2 upload_file --selector "input[type=file]" /tmp/a.txt /tmp/b.txt   # multiple
 $V2 press_key Enter                            # Press key
 $V2 press_key a --modifiers ctrl               # Ctrl+A
 $V2 hover --selector "a.nav-link"
 $V2 new_page "https://example.com"             # Open new tab
 $V2 close_page                                 # Close selected tab
 ```
+
+> **Note on click variants**: `--button right` triggers contextmenu events. `--clicks 2` follows CDP convention (clickCount increments within a click sequence — single/double/triple). `--modifiers` accepts comma-separated names: `ctrl,shift,alt,meta` (or `cmd` as an alias for `meta`).
+
+> **Note on `upload_file`**: targets `<input type="file">` only — pre-validated via `DOM.describeNode` to fail fast on wrong selectors. Paths expand `~` and resolve to absolute. Multiple files via positional args (e.g., for `<input multiple>`).
+
+> **Note on `--frame-url`**: walks the frame tree with `Page.getFrameTree`, matches the first frame whose URL contains the substring. Useful when CSS selectors are unstable (hashed classes, dynamic IDs) but URL patterns are stable. Mutually exclusive with `--frame`.
 
 ### v2 — Element Discovery (`v2_interact.py`)
 


### PR DESCRIPTION
## 개요

cdp-attach 의 browser-harness 흡수 **Phase 2** (5 task / 11) — interaction extras.

- **#9** v2 `click` 파라미터 확장 (button / clicks / modifiers)
- **#1** v2 `scroll` 커맨드 (mouseWheel)
- **#2** v2 `upload_file` 커맨드 (`DOM.setFileInputFiles`)
- **#10** v1 history navigation (`reload` / `back` / `forward`)
- **#11** v1 `evaluate --frame-url` URL substring 매치 모드

Phase 1 의 인프라 (errors.jsonl 자동 기록) 위에 사용자 가시 기능 확장. 버전 bump 1.3.0 → 1.4.0. 자세한 계획: `~/.claude/plans/spicy-pondering-hedgehog.md`.

## 커밋 단위

### 1. `click` 파라미터 확장 (b7b42c5)
- `_parse_modifiers(spec) -> int` 모듈 함수 추출 (CDP 비트마스크: Alt=1/Ctrl=2/Shift=4/Meta=8)
- `_dispatch_mouse`: `modifiers` 인자 추가 (default 0, backward compat)
- `cmd_click` 확장:
  - `--button left|right|middle` (default: left)
  - `--clicks N` (CDP clickCount — double/triple click)
  - `--modifiers ctrl,shift,alt,meta`
- `cmd_press_key`: 인라인 모디파이어 파싱 → `_parse_modifiers` 호출로 단순화
- 모든 신규 인자 default = 현재 동작 → **backward compatible**

### 2. `scroll` (2e30fbc)
- `cmd_scroll`: CDP `Input.dispatchMouseEvent` `type=mouseWheel`
  - 좌표 모드 (positional `x y`)
  - 셀렉터 모드 (`--selector "css"`)
  - 기본: viewport center (`Page.getLayoutMetrics`)
- `--delta-y N` (default 300, positive=down)
- `--delta-x N` (default 0)

### 3. `upload_file` (3a76f77)
- `cmd_upload_file`: `DOM.setFileInputFiles`
  - `--selector` (required, `<input type=file>`)
  - `files` (`nargs='+'`, 1+ 경로) — `~` 확장, 절대경로 변환, 존재/regular file 검증
  - **사전 element 검증**: `DOM.describeNode` 로 `nodeName == INPUT` + `type=file` 확인 → 잘못된 타겟 시 즉시 CDPError (CDP 의 silent no-op 회피)

### 4. history navigation (ae6d652)
- `_wait_for_load_event(client, timeout=30)` 모듈 함수 추출 (Page.loadEventFired 대기 통합)
- `cmd_navigate`: 인라인 wait → `_wait_for_load_event` 호출로 단순화 (외부 동작 동일)
- `cmd_reload`: `Page.reload({ignoreCache: args.hard})`, `--hard` 플래그, `--wait-for load|none`
- `cmd_back` / `cmd_forward`: `Page.getNavigationHistory` → bounds check → `Page.navigateToHistoryEntry`
  - 경계 초과 시 CDPError ("already at first/last entry")
  - `_history_nav` helper 로 공유

### 5. `evaluate --frame-url` (7a3dfb0)
- `cdp_client.py` refactor:
  - `_context_id_for_frame(frame_id, timeout)` 추출 — `executionContextCreated` 대기 통합
  - `resolve_frame_context_id`: 내부 wait 루프를 helper 호출로 단순화 (외부 동작 동일)
  - `resolve_frame_context_id_by_url(url_substring)` 신규: `Page.getFrameTree` DFS → URL contains 매치 → contextId
  - `_find_frame_by_url` 재귀 helper
- `v1_core.py`:
  - `cmd_evaluate`: `--frame-url` 처리 분기
  - `--frame` / `--frame-url` mutually exclusive (인라인 체크, 명확한 에러)
- 사용 시나리오: dynamic selector (해시드 CSS class, React 동적 id) 환경

### 6. SKILL.md + version bump (54acce1)
- v1/v2 quick reference 에 신규 커맨드 예시
- 노트 3개 (click variants, upload_file, --frame-url)
- `plugin.json` 1.3.0 → **1.4.0**

## Manual Acceptance

```bash
V1="cdp-attach/scripts/v1_core.py"
V2="cdp-attach/scripts/v2_interact.py"

# v2 click 변형
uv run $V2 click 100 200 --button right                      # context menu
uv run $V2 click 100 200 --clicks 2                          # double-click
uv run $V2 click --selector "a" --modifiers ctrl             # Ctrl+click

# v2 scroll
uv run $V2 scroll                                            # 기본 down 300px
uv run $V2 scroll --delta-y -500                             # up 500px
uv run $V2 scroll 100 400 --delta-y 200                      # 특정 좌표

# v2 upload (테스트 HTML 또는 실제 file input 페이지)
echo "test content" > /tmp/upload-test.txt
uv run $V2 upload_file --selector "input[type=file]" /tmp/upload-test.txt

# v1 history navigation
uv run $V1 reload
uv run $V1 reload --hard
uv run $V1 back
uv run $V1 forward

# v1 evaluate --frame-url (iframe 임베드 페이지)
uv run $V1 evaluate --frame-url "youtube" "location.href"

# Edge cases
uv run $V1 evaluate --frame foo --frame-url bar "1+1"        # mutually exclusive 에러
uv run $V2 click 100 200 --clicks 0                          # >= 1 에러
uv run $V2 upload_file --selector "button" /tmp/x.txt        # wrong element 에러
```

## 영향 범위

- **Breaking changes**: 없음
  - `click` 신규 인자 default = 현재 동작 (single left)
  - `cmd_navigate` 내부 리팩토링 (외부 동작 동일)
  - `resolve_frame_context_id` 내부 리팩토링 (시그니처/동작 동일)
- **Refactor (외부 무영향)**:
  - `_wait_for_load_event` 모듈 함수 추출 (navigate / reload / history nav 공유)
  - `_context_id_for_frame` 추출 (selector / url 양 경로 공유)
  - `_parse_modifiers` 모듈 함수 추출 (click / press_key 공유)

## 버전 정책

`1.3.0` → `1.4.0` — Phase 1+2 통합 minor bump (feature surface 확장).
Phase 1+2 합산: 8 task 흡수, ~410 LOC 추가, 3 helper 추출.

## 다음 (Phase 3 보류)

`#3 type` / `#7 page_state` / `#8 references/ docs` 는 plan 의 "머지 후 보류 결정 재진입" 정책에 따라 Phase 2 머지 + 1-2주 실사용 후 가치 재평가. 별도 의사결정.
