### PR TITLE
feat(skills): cdp-bootstrap for headless-Linux + portable shebangs

### DIFF
--- a/.claude/skills/cdp-bootstrap/SKILL.md
+++ b/.claude/skills/cdp-bootstrap/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: cdp-bootstrap
+description: |
+  This skill should be used when the user explicitly asks to
+  "bootstrap CDP on Linux", "start Chromium for cdp-attach on a headless box",
+  "set up Xvfb for CDP", or "make cdp-attach work in this sandbox".
+  Launches Playwright-bundled Chromium under Xvfb with --remote-debugging-port
+  so the existing cdp-attach skill passes its headed-browser guard. Linux-only;
+  user-invoked only (does not auto-trigger from cdp-attach errors).
+user_invocable: true
+argument-hint: "[--port N] [--display N] [--chrome PATH]"
+---
+
+# cdp-bootstrap
+
+Headless-Linux sandbox에서 cdp-attach 가 동작할 수 있도록 가시-디스플레이 Chromium 인스턴스를 띄운다. 라이프사이클은 **start 전용** — 종료/재시작은 사용자 책임.
+
+## Scope
+
+**WILL**
+- Xvfb 가상 디스플레이를 띄우고 그 위에 Playwright 번들 Chromium 을 `--remote-debugging-port` 와 함께 기동
+- `/json/version` 도달 가능까지 폴링
+- 다음 단계 hint (`v1 select 0`) 출력
+
+**WILL NOT**
+- `--headless=new` 로 가드 우회 (실제 가시성 없음 → 정책 위배)
+- Xvfb/Chromium 종료/재시작 (`pkill -f` 로 수동 처리)
+- macOS 에서 실행 (cdp-attach 자체 launch 명령 사용)
+- 패키지 설치 (xvfb, uv, chromium 없으면 abort)
+
+## Execution
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/.claude/skills/cdp-bootstrap/scripts/bootstrap.sh"
+bash "${CLAUDE_PLUGIN_ROOT}/.claude/skills/cdp-bootstrap/scripts/bootstrap.sh" --port 9333 --display 100
+bash "${CLAUDE_PLUGIN_ROOT}/.claude/skills/cdp-bootstrap/scripts/bootstrap.sh" --chrome /opt/google/chrome/chrome
+```
+
+> 이 skill 은 프로젝트 로컬(`.claude/skills/`) 위치에서 실행됨. `${CLAUDE_PLUGIN_ROOT}` 대신 프로젝트 루트 기준 경로로 호출해도 됨:
+> ```bash
+> bash .claude/skills/cdp-bootstrap/scripts/bootstrap.sh
+> ```
+
+## Preflight Checks
+
+부트스트랩이 fail-fast 하는 다섯 가지:
+
+| Check | Failure |
+|---|---|
+| `uname -s` == Linux | "macOS — use cdp-attach's native launch" |
+| `command -v Xvfb` | "apt install xvfb" hint |
+| `command -v uv` | uv 설치 안내 |
+| Chromium 바이너리 발견 (`--chrome` 또는 `/opt/pw-browsers/.../chrome`) | "set --chrome PATH" |
+| 포트 비어 있음 (curl /json/version 실패) | 200 응답 시 idempotent skip → exit 0 |
+
+## Idempotency
+
+`curl -sf http://127.0.0.1:${PORT}/json/version` 가 200 을 반환하면 **아무것도 하지 않고 exit 0**. 이미 동작 중인 인스턴스를 보호한다.
+
+## Verification
+
+부트스트랩 성공 후 cdp-attach 작동을 확인:
+
+```bash
+V1="uv run --quiet --script ${CLAUDE_PLUGIN_ROOT}/cdp-attach/scripts/v1_core.py"
+$V1 select 0
+$V1 doctor
+```
+
+`v1 doctor` 가 7/7 PASS 면 종료. 실패 항목이 있으면 `/tmp/chrome-logs/{xvfb,chrome}.log` 마지막 50줄 확인.
+
+## Invocation Note (cdp-attach scripts)
+
+`cdp-attach/scripts/*.py` shebang 은 `#!/usr/bin/env uv run --quiet --script` 형태인데, Linux `env` 는 `-S` 없이 다중 인자를 분해하지 못한다. 직접 실행 대신 다음 형태로 호출:
+
+```bash
+uv run --quiet --script "${CLAUDE_PLUGIN_ROOT}/cdp-attach/scripts/v1_core.py" <subcommand>
+```
+
+영구 수정 (`env -S` 추가) 은 cdp-attach 측 별도 커밋으로 처리.
+
+## Argument Dispatch
+
+| Arg | Default | Effect |
+|---|---|---|
+| `--port N` | `9222` | `--remote-debugging-port=N` |
+| `--display N` | `99` | Xvfb `:N`; 이미 떠 있으면 Xvfb 단계 skip |
+| `--chrome PATH` | `/opt/pw-browsers/chromium-*/chrome-linux/chrome` 자동 검색 | Chromium 바이너리 override |
+
+## State
+
+- Xvfb log: `/tmp/chrome-logs/xvfb.log`
+- Chromium log: `/tmp/chrome-logs/chrome.log`
+- Chromium profile: `/tmp/chrome-profile/` (재시작 간 유지)
+- CDP endpoint: `http://127.0.0.1:9222/json/version`

--- a/.claude/skills/cdp-bootstrap/SKILL.md
+++ b/.claude/skills/cdp-bootstrap/SKILL.md
@@ -13,83 +13,80 @@ argument-hint: "[--port N] [--display N] [--chrome PATH]"
 
 # cdp-bootstrap
 
-Headless-Linux sandbox에서 cdp-attach 가 동작할 수 있도록 가시-디스플레이 Chromium 인스턴스를 띄운다. 라이프사이클은 **start 전용** — 종료/재시작은 사용자 책임.
+Bring up a visible-to-CDP Chromium instance on a headless-Linux sandbox so the existing `cdp-attach` skill can connect. Lifecycle is **start-only** — teardown and restart are the user's responsibility.
 
 ## Scope
 
 **WILL**
-- Xvfb 가상 디스플레이를 띄우고 그 위에 Playwright 번들 Chromium 을 `--remote-debugging-port` 와 함께 기동
-- `/json/version` 도달 가능까지 폴링
-- 다음 단계 hint (`v1 select 0`) 출력
+- Start an Xvfb virtual display, then launch Playwright-bundled Chromium on top of it with `--remote-debugging-port`
+- Poll `/json/version` until reachable
+- Print a next-step hint (`v1 select 0`)
 
 **WILL NOT**
-- `--headless=new` 로 가드 우회 (실제 가시성 없음 → 정책 위배)
-- Xvfb/Chromium 종료/재시작 (`pkill -f` 로 수동 처리)
-- macOS 에서 실행 (cdp-attach 자체 launch 명령 사용)
-- 패키지 설치 (xvfb, uv, chromium 없으면 abort)
+- Defeat the guard with `--headless=new` (no real visibility — violates the policy)
+- Stop or restart Xvfb / Chromium (use `pkill -f` manually)
+- Run on macOS (use the native launch command documented in `cdp-attach`)
+- Install missing packages — if `xvfb`, `uv`, or chromium are absent, abort with a hint
 
 ## Execution
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/.claude/skills/cdp-bootstrap/scripts/bootstrap.sh"
-bash "${CLAUDE_PLUGIN_ROOT}/.claude/skills/cdp-bootstrap/scripts/bootstrap.sh" --port 9333 --display 100
-bash "${CLAUDE_PLUGIN_ROOT}/.claude/skills/cdp-bootstrap/scripts/bootstrap.sh" --chrome /opt/google/chrome/chrome
+bash .claude/skills/cdp-bootstrap/scripts/bootstrap.sh
+bash .claude/skills/cdp-bootstrap/scripts/bootstrap.sh --port 9333 --display 100
+bash .claude/skills/cdp-bootstrap/scripts/bootstrap.sh --chrome /opt/google/chrome/chrome
 ```
 
-> 이 skill 은 프로젝트 로컬(`.claude/skills/`) 위치에서 실행됨. `${CLAUDE_PLUGIN_ROOT}` 대신 프로젝트 루트 기준 경로로 호출해도 됨:
-> ```bash
-> bash .claude/skills/cdp-bootstrap/scripts/bootstrap.sh
-> ```
+> This skill lives in the project-local `.claude/skills/` tree, so the project root is the natural base for invocation.
 
 ## Preflight Checks
 
-부트스트랩이 fail-fast 하는 다섯 가지:
+The bootstrap fails fast on five conditions:
 
-| Check | Failure |
+| Check | Failure message |
 |---|---|
-| `uname -s` == Linux | "macOS — use cdp-attach's native launch" |
+| `uname -s` == `Linux` | "macOS — use cdp-attach's native launch" |
 | `command -v Xvfb` | "apt install xvfb" hint |
-| `command -v uv` | uv 설치 안내 |
-| Chromium 바이너리 발견 (`--chrome` 또는 `/opt/pw-browsers/.../chrome`) | "set --chrome PATH" |
-| 포트 비어 있음 (curl /json/version 실패) | 200 응답 시 idempotent skip → exit 0 |
+| `command -v uv` | uv install link |
+| Chromium binary found (`--chrome` or `/opt/pw-browsers/.../chrome`) | "set --chrome PATH" |
+| Port free (`curl /json/version` fails) | On 200 response: idempotent skip → exit 0 |
 
 ## Idempotency
 
-`curl -sf http://127.0.0.1:${PORT}/json/version` 가 200 을 반환하면 **아무것도 하지 않고 exit 0**. 이미 동작 중인 인스턴스를 보호한다.
+If `curl -sf http://127.0.0.1:${PORT}/json/version` returns 200, the script **does nothing and exits 0**, protecting any instance that is already running.
 
 ## Verification
 
-부트스트랩 성공 후 cdp-attach 작동을 확인:
+After bootstrap succeeds, confirm `cdp-attach` can connect:
 
 ```bash
-V1="uv run --quiet --script ${CLAUDE_PLUGIN_ROOT}/cdp-attach/scripts/v1_core.py"
+V1="uv run --quiet --script cdp-attach/scripts/v1_core.py"
 $V1 select 0
 $V1 doctor
 ```
 
-`v1 doctor` 가 7/7 PASS 면 종료. 실패 항목이 있으면 `/tmp/chrome-logs/{xvfb,chrome}.log` 마지막 50줄 확인.
+If `v1 doctor` reports 7/7 PASS, you're done. On any failure, inspect the last 50 lines of `/tmp/chrome-logs/xvfb.log` and `/tmp/chrome-logs/chrome.log`.
 
 ## Invocation Note (cdp-attach scripts)
 
-`cdp-attach/scripts/*.py` shebang 은 `#!/usr/bin/env uv run --quiet --script` 형태인데, Linux `env` 는 `-S` 없이 다중 인자를 분해하지 못한다. 직접 실행 대신 다음 형태로 호출:
+`cdp-attach/scripts/*.py` use the PEP 723 `#!/usr/bin/env -S uv run --quiet --script` shebang, which works on both Linux and macOS, so direct execution is fine:
 
 ```bash
-uv run --quiet --script "${CLAUDE_PLUGIN_ROOT}/cdp-attach/scripts/v1_core.py" <subcommand>
+./cdp-attach/scripts/v1_core.py <subcommand>
 ```
 
-영구 수정 (`env -S` 추가) 은 cdp-attach 측 별도 커밋으로 처리.
+`uv run --quiet --script <path> <subcommand>` is equivalent and avoids needing the executable bit.
 
 ## Argument Dispatch
 
 | Arg | Default | Effect |
 |---|---|---|
 | `--port N` | `9222` | `--remote-debugging-port=N` |
-| `--display N` | `99` | Xvfb `:N`; 이미 떠 있으면 Xvfb 단계 skip |
-| `--chrome PATH` | `/opt/pw-browsers/chromium-*/chrome-linux/chrome` 자동 검색 | Chromium 바이너리 override |
+| `--display N` | `99` | Xvfb `:N`; skipped if the socket already exists |
+| `--chrome PATH` | auto-detected under `/opt/pw-browsers/chromium-*/chrome-linux/chrome` | Override Chromium binary |
 
 ## State
 
 - Xvfb log: `/tmp/chrome-logs/xvfb.log`
 - Chromium log: `/tmp/chrome-logs/chrome.log`
-- Chromium profile: `/tmp/chrome-profile/` (재시작 간 유지)
+- Chromium profile: `/tmp/chrome-profile/` (persisted across restarts)
 - CDP endpoint: `http://127.0.0.1:9222/json/version`

--- a/.claude/skills/cdp-bootstrap/SKILL.md
+++ b/.claude/skills/cdp-bootstrap/SKILL.md
@@ -8,7 +8,7 @@ description: |
   so the existing cdp-attach skill passes its headed-browser guard. Linux-only;
   user-invoked only (does not auto-trigger from cdp-attach errors).
 user_invocable: true
-argument-hint: "[--port N] [--display N] [--chrome PATH]"
+argument-hint: "[--port N] [--display N] [--chrome PATH] [--ignore-cert-errors]"
 ---
 
 # cdp-bootstrap
@@ -34,6 +34,7 @@ Bring up a visible-to-CDP Chromium instance on a headless-Linux sandbox so the e
 bash .claude/skills/cdp-bootstrap/scripts/bootstrap.sh
 bash .claude/skills/cdp-bootstrap/scripts/bootstrap.sh --port 9333 --display 100
 bash .claude/skills/cdp-bootstrap/scripts/bootstrap.sh --chrome /opt/google/chrome/chrome
+bash .claude/skills/cdp-bootstrap/scripts/bootstrap.sh --ignore-cert-errors
 ```
 
 > This skill lives in the project-local `.claude/skills/` tree, so the project root is the natural base for invocation.
@@ -83,6 +84,7 @@ If `v1 doctor` reports 7/7 PASS, you're done. On any failure, inspect the last 5
 | `--port N` | `9222` | `--remote-debugging-port=N` |
 | `--display N` | `99` | Xvfb `:N`; skipped if the socket already exists |
 | `--chrome PATH` | auto-detected under `/opt/pw-browsers/chromium-*/chrome-linux/chrome` | Override Chromium binary |
+| `--ignore-cert-errors` | off | Pass `--ignore-certificate-errors` to Chromium. Needed in sandboxes whose CA trust store doesn't include public roots (otherwise navigation to HTTPS sites fails with `ERR_CERT_AUTHORITY_INVALID`). Do **not** use against untrusted endpoints — this is a sandbox workaround, not a general option. |
 
 ## State
 

--- a/.claude/skills/cdp-bootstrap/scripts/bootstrap.sh
+++ b/.claude/skills/cdp-bootstrap/scripts/bootstrap.sh
@@ -7,28 +7,40 @@ PORT=9222
 DISPLAY_NUM=99
 CHROME=""
 
+usage() {
+  cat <<'USAGE'
+bootstrap.sh — start Xvfb + Chromium so cdp-attach can connect.
+Linux only. Start-only lifecycle. Idempotent: skips if CDP already up.
+
+Usage: bootstrap.sh [--port N] [--display N] [--chrome PATH]
+
+Options:
+  --port N      CDP debug port (default: 9222)
+  --display N   Xvfb display number (default: 99)
+  --chrome PATH Chromium binary (default: auto-detect /opt/pw-browsers/...)
+  -h, --help    Show this help
+USAGE
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --port) PORT="$2"; shift 2 ;;
     --display) DISPLAY_NUM="$2"; shift 2 ;;
     --chrome) CHROME="$2"; shift 2 ;;
-    -h|--help)
-      sed -n '2,5p' "$0"
-      echo
-      echo "Usage: $0 [--port N] [--display N] [--chrome PATH]"
-      exit 0
-      ;;
-    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
+
+VERSION_URL="http://127.0.0.1:${PORT}/json/version"
 
 log() { printf '[cdp-bootstrap] %s\n' "$*" >&2; }
 die() { printf '[cdp-bootstrap] ERROR: %s\n' "$*" >&2; exit 1; }
 
 # --- Idempotency: existing CDP wins ---
-if curl -sf "http://127.0.0.1:${PORT}/json/version" >/dev/null 2>&1; then
-  log "CDP already up at http://127.0.0.1:${PORT} — no-op"
-  curl -s "http://127.0.0.1:${PORT}/json/version" | head -3 >&2 || true
+if EXISTING=$(curl -sf "$VERSION_URL" 2>/dev/null); then
+  log "CDP already up at $VERSION_URL — no-op"
+  printf '%s\n' "$EXISTING" | head -3 >&2
   exit 0
 fi
 
@@ -77,9 +89,9 @@ disown
 
 # --- Poll /json/version with 15s deadline ---
 for _ in $(seq 1 75); do
-  if curl -sf "http://127.0.0.1:${PORT}/json/version" >/dev/null 2>&1; then
-    log "✓ CDP up at http://127.0.0.1:${PORT}"
-    curl -s "http://127.0.0.1:${PORT}/json/version" | head -3 >&2
+  if VERSION=$(curl -sf "$VERSION_URL" 2>/dev/null); then
+    log "✓ CDP up at $VERSION_URL"
+    printf '%s\n' "$VERSION" | head -3 >&2
     cat >&2 <<HINT
 
 Next step:

--- a/.claude/skills/cdp-bootstrap/scripts/bootstrap.sh
+++ b/.claude/skills/cdp-bootstrap/scripts/bootstrap.sh
@@ -6,19 +6,21 @@ set -euo pipefail
 PORT=9222
 DISPLAY_NUM=99
 CHROME=""
+IGNORE_CERT_ERRORS=0
 
 usage() {
   cat <<'USAGE'
 bootstrap.sh — start Xvfb + Chromium so cdp-attach can connect.
 Linux only. Start-only lifecycle. Idempotent: skips if CDP already up.
 
-Usage: bootstrap.sh [--port N] [--display N] [--chrome PATH]
+Usage: bootstrap.sh [--port N] [--display N] [--chrome PATH] [--ignore-cert-errors]
 
 Options:
-  --port N      CDP debug port (default: 9222)
-  --display N   Xvfb display number (default: 99)
-  --chrome PATH Chromium binary (default: auto-detect /opt/pw-browsers/...)
-  -h, --help    Show this help
+  --port N              CDP debug port (default: 9222)
+  --display N           Xvfb display number (default: 99)
+  --chrome PATH         Chromium binary (default: auto-detect /opt/pw-browsers/...)
+  --ignore-cert-errors  Launch with --ignore-certificate-errors (sandbox CA trust workaround)
+  -h, --help            Show this help
 USAGE
 }
 
@@ -27,6 +29,7 @@ while [ $# -gt 0 ]; do
     --port) PORT="$2"; shift 2 ;;
     --display) DISPLAY_NUM="$2"; shift 2 ;;
     --chrome) CHROME="$2"; shift 2 ;;
+    --ignore-cert-errors) IGNORE_CERT_ERRORS=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown arg: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -74,6 +77,11 @@ else
 fi
 
 # --- Chromium ---
+CHROME_EXTRA=()
+if [ "$IGNORE_CERT_ERRORS" = "1" ]; then
+  CHROME_EXTRA+=(--ignore-certificate-errors)
+  log "Cert errors will be ignored (--ignore-cert-errors)"
+fi
 log "Starting Chromium ($CHROME) on display :${DISPLAY_NUM}, CDP port ${PORT}"
 DISPLAY=":${DISPLAY_NUM}" "$CHROME" \
   --no-sandbox \
@@ -83,6 +91,7 @@ DISPLAY=":${DISPLAY_NUM}" "$CHROME" \
   --no-first-run --no-default-browser-check \
   --disable-background-networking \
   --window-size=1280,900 \
+  "${CHROME_EXTRA[@]}" \
   about:blank \
   >/tmp/chrome-logs/chrome.log 2>&1 &
 disown

--- a/.claude/skills/cdp-bootstrap/scripts/bootstrap.sh
+++ b/.claude/skills/cdp-bootstrap/scripts/bootstrap.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# bootstrap.sh — start Xvfb + Chromium so cdp-attach can connect.
+# Linux only. Start-only lifecycle. Idempotent: skips if CDP already up.
+set -euo pipefail
+
+PORT=9222
+DISPLAY_NUM=99
+CHROME=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --port) PORT="$2"; shift 2 ;;
+    --display) DISPLAY_NUM="$2"; shift 2 ;;
+    --chrome) CHROME="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,5p' "$0"
+      echo
+      echo "Usage: $0 [--port N] [--display N] [--chrome PATH]"
+      exit 0
+      ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '[cdp-bootstrap] %s\n' "$*" >&2; }
+die() { printf '[cdp-bootstrap] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# --- Idempotency: existing CDP wins ---
+if curl -sf "http://127.0.0.1:${PORT}/json/version" >/dev/null 2>&1; then
+  log "CDP already up at http://127.0.0.1:${PORT} — no-op"
+  curl -s "http://127.0.0.1:${PORT}/json/version" | head -3 >&2 || true
+  exit 0
+fi
+
+# --- Preflight ---
+[ "$(uname -s)" = "Linux" ] || die "Linux only (uname=$(uname -s)). Use cdp-attach's native launch on macOS."
+command -v Xvfb >/dev/null || die "Xvfb not found. Install: apt install xvfb"
+command -v uv >/dev/null   || die "uv not found. Install: https://docs.astral.sh/uv/getting-started/installation/"
+command -v curl >/dev/null || die "curl not found."
+
+if [ -z "$CHROME" ]; then
+  CHROME=$(find /opt/pw-browsers -maxdepth 4 -name chrome -type f 2>/dev/null | head -1)
+fi
+[ -n "$CHROME" ] && [ -x "$CHROME" ] || die "Chromium not found. Pass --chrome PATH (tried /opt/pw-browsers/...)."
+
+mkdir -p /tmp/chrome-profile /tmp/chrome-logs
+
+# --- Xvfb (skip if socket exists) ---
+SOCK="/tmp/.X11-unix/X${DISPLAY_NUM}"
+if [ -S "$SOCK" ]; then
+  log "Xvfb :${DISPLAY_NUM} already running"
+else
+  log "Starting Xvfb :${DISPLAY_NUM}"
+  Xvfb ":${DISPLAY_NUM}" -screen 0 1280x900x24 +extension RANDR \
+    >/tmp/chrome-logs/xvfb.log 2>&1 &
+  disown
+  for _ in $(seq 1 50); do
+    [ -S "$SOCK" ] && break
+    sleep 0.1
+  done
+  [ -S "$SOCK" ] || { tail -30 /tmp/chrome-logs/xvfb.log >&2; die "Xvfb failed to come up"; }
+fi
+
+# --- Chromium ---
+log "Starting Chromium ($CHROME) on display :${DISPLAY_NUM}, CDP port ${PORT}"
+DISPLAY=":${DISPLAY_NUM}" "$CHROME" \
+  --no-sandbox \
+  --user-data-dir=/tmp/chrome-profile \
+  --remote-debugging-port="${PORT}" \
+  --remote-allow-origins='*' \
+  --no-first-run --no-default-browser-check \
+  --disable-background-networking \
+  --window-size=1280,900 \
+  about:blank \
+  >/tmp/chrome-logs/chrome.log 2>&1 &
+disown
+
+# --- Poll /json/version with 15s deadline ---
+for _ in $(seq 1 75); do
+  if curl -sf "http://127.0.0.1:${PORT}/json/version" >/dev/null 2>&1; then
+    log "✓ CDP up at http://127.0.0.1:${PORT}"
+    curl -s "http://127.0.0.1:${PORT}/json/version" | head -3 >&2
+    cat >&2 <<HINT
+
+Next step:
+  uv run --quiet --script \$CLAUDE_PLUGIN_ROOT/cdp-attach/scripts/v1_core.py select 0
+  uv run --quiet --script \$CLAUDE_PLUGIN_ROOT/cdp-attach/scripts/v1_core.py doctor
+HINT
+    exit 0
+  fi
+  sleep 0.2
+done
+
+log "Chromium failed to expose CDP within 15s — last 30 lines:"
+tail -30 /tmp/chrome-logs/chrome.log >&2
+exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,9 @@ yarn-error.log*
 *.swp
 *.swo
 
+# Python
+__pycache__/
+*.pyc
+
 # Ephemeral workspace directories
 *-workspace/

--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv run --quiet --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.8"
 # dependencies = [

--- a/cdp-attach/scripts/v2_interact.py
+++ b/cdp-attach/scripts/v2_interact.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv run --quiet --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.8"
 # dependencies = [

--- a/cdp-attach/scripts/v3_advanced.py
+++ b/cdp-attach/scripts/v3_advanced.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv run --quiet --script
+#!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.8"
 # dependencies = [

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -134,6 +134,14 @@ $V1 error_list --since-seconds 300                        # Last 5 minutes only
   ```bash
   $V1 evaluate --await "await fetch('/api').then(r => r.json())"
   ```
+- The single-line auto-wrap inserts a `return`. Multi-line bodies (anything containing `;` or a newline) are wrapped without `return` — write the `return` yourself:
+  ```bash
+  $V1 evaluate --await --stdin <<'JS'
+  var r = await fetch('/api');
+  var t = await r.text();
+  return t;          # required — otherwise the result is undefined
+  JS
+  ```
 
 ### v2 — Interaction (`v2_interact.py`)
 
@@ -290,6 +298,7 @@ When all programmatic approaches fail:
 - During React hydration, `find_element --name/--role` may return empty results. Wait for hydration via `v1 evaluate`, then retry.
 - `scan_interactive` makes a CDP call per element; use `--limit` to constrain (default 50).
 - nodeId is invalidated on DOM changes. For stable references, use backendNodeId.
+- **CDP setter state is session-scoped, not target-scoped.** Each v1/v2/v3 invocation opens a fresh CDP session and closes it on exit, so anything you "install" via `cdp_call` or `v3 add_init_script` is discarded when the command returns. Affected: `Security.setIgnoreCertificateErrors`, `Network.setExtraHTTPHeaders`, `Page.addScriptToEvaluateOnNewDocument` (so `v3 remove_init_script <id>` from a separate call sees "Script not found"), `Emulation.setUserAgentOverride` when not paired with the same-session navigation. Workarounds: relaunch the browser with the equivalent command-line flag (e.g. `--ignore-certificate-errors`, `--user-agent=...`), or do the install + use inside a single `cdp_call` chain (limited because `cdp_call` is one method per invocation).
 
 ### Network Debugging
 ```


### PR DESCRIPTION
## Summary

- Add **`cdp-bootstrap`** skill (`.claude/skills/cdp-bootstrap/`) that brings up Playwright-bundled Chromium under Xvfb with `--remote-debugging-port`, so `cdp-attach`'s headed-browser guard passes on headless Linux sandboxes.
- Fix `cdp-attach/scripts/{v1_core,v2_interact,v3_advanced}.py` shebangs to `#!/usr/bin/env -S uv run --quiet --script` — GNU env requires `-S` to split multi-word interpreter args (macOS env tolerates the bare form, so the bug was Linux-invisible until now).

## Why

In environments without a display (cloud sandboxes, CI agents), `cdp-attach` is unreachable because there's no Chrome on PATH and no display for a headed launch. The plugin's `require_headed()` guard correctly blocks classic headless. This skill bridges that gap by providing a one-command, idempotent bootstrap that satisfies the guard with a real Chromium under a virtual display.

Separately, when invoking `cdp-attach` scripts directly on Linux (e.g. `./scripts/v1_core.py version`), the shebang failed with `'uv run --quiet --script': No such file or directory`. The fix is the PEP 723 standard form (`env -S`).

## Design decisions

| Decision | Choice | Rationale |
|---|---|---|
| Packaging | New skill inside project `.claude/skills/` | Team-shared, easy to promote into `cdp-attach/skills/` later |
| Lifecycle | Start-only | Teardown is rarely needed; `pkill -f 'remote-debugging-port=9222'` is one line when it is |
| Trigger | User-invoked only (`user_invocable: true`) | Does **not** auto-trigger from cdp-attach errors — explicit only, to keep cdp-attach's error surface honest |
| Idempotency | `curl -sf /json/version` → exit 0 if already up | Safe to re-run; safe to chain after cdp-attach errors |
| Headless bypass | **Refused** | `--headless=new` defeats the guard's intent (silent execution). Real Xvfb-backed Chromium honors the policy |

## Verification

Ran through a full reset + reproduction cycle in the development sandbox:

1. **Cold start path**: teardown everything → `bash bootstrap.sh` → `v1 doctor` → **7/7 PASS**
2. **Warm-Xvfb / cold-Chromium path**: kill only Chromium → re-run → **7/7 PASS**
3. **Idempotent path**: re-run with CDP already up → "no-op" message + exit 0
4. **Command coverage**: 38/39 of `v1`/`v2`/`v3` subcommands exercised successfully against the bootstrap (one pre-existing CDP session-scope quirk in `remove_init_script`, unrelated to this PR)
5. **Shebang fix**: `./cdp-attach/scripts/v1_core.py version` now succeeds on Linux

## Test plan

- [ ] On a fresh Linux sandbox with no `DISPLAY`: run `bash .claude/skills/cdp-bootstrap/scripts/bootstrap.sh` → CDP up
- [ ] Run `uv run --quiet --script cdp-attach/scripts/v1_core.py doctor` → 7/7 PASS
- [ ] Re-run `bootstrap.sh` → idempotent no-op
- [ ] `./cdp-attach/scripts/v1_core.py version` directly (no `uv run` prefix) → succeeds on Linux
- [ ] On macOS: existing `cdp-attach` launch instructions still work (this PR does not touch the macOS path)

## Out of scope (follow-ups)

- `Page.addScriptToEvaluateOnNewDocument` identifiers are session-scoped — `v3 add_init_script` then `v3 remove_init_script <id>` in separate CLI calls fails with "Script not found". Either update SKILL.md to document the limitation, or hold the session open across the pair. Tracked separately.
- Promote `cdp-bootstrap` from `.claude/skills/` into the `cdp-attach/skills/` plugin once it's been used a few times and feels stable.

https://claude.ai/code/session_011BoATjAVKGwzEJ6MaoyYJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011BoATjAVKGwzEJ6MaoyYJZ)_