### PR TITLE
docs(cdp-attach): inscribe Triage-Gated Vendor Harness realization

### DIFF
--- a/.claude/rules/cdp-attach.md
+++ b/.claude/rules/cdp-attach.md
@@ -1,0 +1,30 @@
+# cdp-attach — Triage-Gated Vendor Harness Realization
+
+`cdp-attach` realizes the **Triage-Gated Vendor Harness** pattern for the Chrome DevTools Protocol vendor. The pattern body and its instance-parameter slots live at `~/.claude/rules/triage-gated-vendor-harness.md`; this rule inscribes CDP-specific parameter values and design notes.
+
+## Instance parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Vendor target | Chrome / CDP (debug-port WebSocket protocol) |
+| Discovery scope | errors only — CDP method failures, WebSocket errors, `network_body` capture path |
+| Trigger timing | on-error during PreToolUse-scoped invocation; the hook injects `additionalContext` so the agent files the issue mid-turn |
+| Submitter set | agent in-session only (extensible to humans / Devin / Pryden as adoption grows) |
+| Concrete substrate | GitHub Issues + `gh` CLI in `jongwony/cc-plugin` |
+| Daemon? | **NO** — Chrome itself is the daemon; the wrapper does not add a second layer |
+
+## Two-tier substrate
+
+- **Intra-session** — `state.json` + `~/.cache/cdp-attach/*` (events, bodies, errors). Each foreground command opens a short-lived WebSocket, attaches, acts, detaches. Background collectors are bounded leases (e.g., `network_start` / `network_body` pair), never a permanent process.
+- **Inter-session** — GitHub Issues + PRs in `jongwony/cc-plugin`. A PreToolUse hook (`cdp-attach/hooks/hooks.json` → `hooks/pretooluse_context.sh`) injects a one-line `additionalContext` reminder whenever the cdp-attach skill or one of its scripts is about to run; the agent files the issue itself via `gh` if an error occurs during use. Discrimination in the script: matcher covers `Skill|Bash`; script checks `tool_input.skill == "cdp-attach:cdp-attach"` or `tool_input.command` contains `cdp-attach/scripts/`. Triage is a separate session.
+
+## Why CDP-specific design choices
+
+- **No daemon**: a host process would buy WebSocket-handshake latency back but couple the plugin to a permanent runtime and dilute the agent-editable property. Chrome itself is the daemon; the plugin should not add a second layer.
+- **Issues over in-session auto-fix**: in-session edits commit the agent's first interpretation without a review gate; across sessions the same root cause produced two distinct cdp-attach bugs over 21 days before triage. The issue gate separates interpretation from commit. Accumulated issues become the learning signal for plugin evolution.
+
+## Extending cdp-attach
+
+- **New tool bugs encountered during use**: rely on the hook to auto-file. If filing manually (different harness or disabled hook), match the title format `[cdp-attach] <category>|<method>|<code-or-kind>` so the dedupe finds it.
+- **New primitives holding a CDP-session contract** (like `Network.enable`): follow the `network_body` pattern — fork holds the session, filesystem is the synthesis substrate, foreground commands read filesystem. This is the intra-session realization of the same structure (CDP target ≈ subagent, substrate = filesystem).
+- **OOPIF / worker / service-worker absorption**: same intra-session pattern with `Target.attachToTarget(flatten:true)` + recursive `setAutoAttach`. `sessionId` is volatile (per invocation); durable handle is `targetId + type + url`.

--- a/.claude/rules/cdp-attach.md
+++ b/.claude/rules/cdp-attach.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "cdp-attach/**"
+---
+
 # cdp-attach — Triage-Gated Vendor Harness Realization
 
 `cdp-attach` realizes the **Triage-Gated Vendor Harness** pattern for the Chrome DevTools Protocol vendor. The pattern body and its instance-parameter slots live at `~/.claude/rules/triage-gated-vendor-harness.md`; this rule inscribes CDP-specific parameter values and design notes.

--- a/.claude/rules/cdp-attach.md
+++ b/.claude/rules/cdp-attach.md
@@ -12,7 +12,7 @@ paths:
 | Parameter | Value |
 |-----------|-------|
 | Vendor target | Chrome / CDP (debug-port WebSocket protocol) |
-| Discovery scope | errors only — CDP method failures, WebSocket errors, `network_body` capture path |
+| Discovery scope | errors only — CDP method failures + WebSocket errors (logged to `~/.cache/cdp-attach/errors.jsonl` via `cdp_client.send()`). Body capture (`network_body`) is a separate concern, not a discovery channel |
 | Trigger timing | on-error during PreToolUse-scoped invocation; the hook injects `additionalContext` so the agent files the issue mid-turn |
 | Submitter set | agent in-session only (extensible to humans / Devin / Pryden as adoption grows) |
 | Concrete substrate | GitHub Issues + `gh` CLI in `jongwony/cc-plugin` |
@@ -32,4 +32,4 @@ paths:
 
 - **New tool bugs encountered during use**: rely on the hook to auto-file. If filing manually (different harness or disabled hook), match the title format `[cdp-attach] <category>|<method>|<code-or-kind>` so the dedupe finds it.
 - **New primitives holding a CDP-session contract** (like `Network.enable`): follow the `network_body` pattern — fork holds the session, filesystem is the synthesis substrate, foreground commands read filesystem. This is the intra-session realization of the same structure (CDP target ≈ subagent, substrate = filesystem).
-- **OOPIF / worker / service-worker absorption**: same intra-session pattern with `Target.attachToTarget(flatten:true)` + recursive `setAutoAttach`. `sessionId` is volatile (per invocation); durable handle is `targetId + type + url`.
+- **OOPIF / worker / service-worker absorption** (planned, not yet exposed in v1/v2/v3 — see `SKILL.md` note on cross-origin iframe debugging): when added, follow the same intra-session pattern with `Target.attachToTarget(flatten:true)` + recursive `setAutoAttach`. At that point `sessionId` will be volatile (per invocation), so a durable handle composed of `targetId + type + url` will be required — current code persists bare `targetId` only, via `state.json`.

--- a/cdp-attach/hooks/hooks.json
+++ b/cdp-attach/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "cdp-attach plugin hooks. On PreToolUse, when the cdp-attach skill or one of its scripts is about to run, inject a one-line additionalContext asking the agent to file a GitHub issue with detailed context if an error occurs during use. Inter-session triage decides the permanent fix — see plugin-bug-triage.md.",
+  "description": "cdp-attach plugin hooks. On PreToolUse, when the cdp-attach skill or one of its scripts is about to run, inject a one-line additionalContext asking the agent to file a GitHub issue with detailed context if an error occurs during use. Inter-session triage decides the permanent fix — see triage-gated-vendor-harness.md.",
   "hooks": {
     "PreToolUse": [
       {

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -361,7 +361,7 @@ When a CDP method or skill behaviour breaks (Chrome version drift, new edge case
 
 The injected guidance says, in effect: file at `https://github.com/jongwony/cc-plugin/issues` with the failing command, verbatim error output, environment (Chrome version, OS), and a one-line first-interpretation. Labels: `cdp-attach,triage-needed`. The agent is the issue filer (via `gh`), not the harness — this keeps the mechanism free of background daemons or per-session Python.
 
-Triage decisions (`wontfix`, redirect, patch via PR) belong to the triage session, not the session that hit the bug. See `~/.claude/rules/plugin-bug-triage.md` for the principle.
+Triage decisions (`wontfix`, redirect, patch via PR) belong to the triage session, not the session that hit the bug. See `~/.claude/rules/triage-gated-vendor-harness.md` for the principle.
 
 ### Fallback Strategy
 


### PR DESCRIPTION
## 변경 요약

`cdp-attach` 가 **Triage-Gated Vendor Harness** 패턴 — CDP / 외부 spec 진화형 vendor 를 LLM-coded self-healing wrapper + 인간 triage gate 로 감싸는 메타 패턴 — 의 첫 reference realization 임을 cc-plugin 내부에 inscribe.

## 주요 변경

### 신규 — `.claude/rules/cdp-attach.md`

cdp-attach 의 instance-specific 파라미터 + CDP design 노트:

| Parameter | Value |
|-----------|-------|
| Vendor target | Chrome / CDP (debug-port WebSocket protocol) |
| Discovery scope | errors only — CDP method failures + WebSocket errors + `network_body` capture |
| Trigger timing | on-error during PreToolUse-scoped invocation |
| Submitter set | agent in-session only (extensible) |
| Concrete substrate | GitHub Issues + `gh` CLI in `jongwony/cc-plugin` |
| Daemon? | NO — Chrome 이 daemon, wrapper 는 두 번째 layer 추가 거절 |

- Two-tier substrate (intra-session filesystem journal + inter-session GitHub Issues)
- 왜 daemon 거절인가 (CDP 의 agent-editable 속성 보존)
- 왜 in-session 자동 수정보다 issue gate 인가 (interpretation 과 commit 분리, 21 일에 걸친 동일 root cause 의 2 distinct cdp-attach bug 사례)
- 확장 가이드 — 새 CDP-session 의존 primitive (network_body 패턴) + OOPIF/worker/service-worker 흡수

### 정합 — cross-reference 업데이트

- `cdp-attach/hooks/hooks.json` description: `plugin-bug-triage.md` → `triage-gated-vendor-harness.md`
- `cdp-attach/skills/cdp-attach/SKILL.md` line 364 (Bug Triage 절): 동일 경로 업데이트

## 배경

본 PR 의 외부 context — 사용자 home (`~/.claude/rules/`) 의 글로벌 rule:

- 기존 `plugin-bug-triage.md` (bug capture operational rule) 가 Periagoge `/induce` 세션을 통해 **meta-pattern 으로 결정화**
- 결정화된 형태: prescriptive core (6 축: Vendor / Wrapper / Substrate-as-capability-interface / Triage gate / Daemon refusal by default / Cross-cutting concerns) + instance parameters (4 slot: Discovery / Trigger / Submitter / Concrete substrate)
- 결정화 과정의 외부 자문 — Codex `/goal-research` 가 prior-art (Martin Fowler harness engineering, autonomic computing, anti-corruption layer, SRE postmortem) 와 design critique (daemon 거절 wording 완화, substrate 의 capability interface, multi-submitter defenses, spec-gap 4-category) 제공
- 결정화 결과 글로벌 rule 파일을 `triage-gated-vendor-harness.md` 로 rename (사용자 home repo)
- cc-plugin 측은 본 PR 로 cross-ref path 정합 + cdp-attach realization 명시

## Test plan

- [ ] `cdp-attach` 의 hook 발화 시 `additionalContext` 가 새 cross-ref 를 노출하는지 확인 (사용자 환경에서 cdp-attach 호출 시점)
- [ ] `.claude/rules/cdp-attach.md` 의 Instance parameter 표가 실제 현 cdp-attach 동작과 일치하는지 검토 (특히 Discovery=errors only — `network_body` 가 errors 범주에 포함되는지 의미적 확인)
- [ ] cross-ref 경로 (`~/.claude/rules/triage-gated-vendor-harness.md`) 의 절대 경로 표기가 portable 한지 — 다른 contributor 의 home 에서도 의미가 동일한지 (zero-shot portability)

## 관련

- 글로벌 rule 본문 (사용자 home, 본 repo 외): `~/.claude/rules/triage-gated-vendor-harness.md`
- 동일 패턴의 후보 future realization: DataDog API, Amplitude API, LSP, MCP server (각 vendor 의 instance parameter 는 첫 구현 시 결정 + 검증, inter-version 학습 신호)
