### PR TITLE
feat(codex-plus): deterministic session resume via -S, drop --last

### DIFF
--- a/codex-plus/scripts/codex-run.sh
+++ b/codex-plus/scripts/codex-run.sh
@@ -13,7 +13,7 @@ MODEL="$DEFAULT_MODEL"
 EFFORT="$DEFAULT_EFFORT"
 SANDBOX="$DEFAULT_SANDBOX"
 FULL_AUTO=false
-RESUME=false
+SESSION_ID=""
 CWD=""
 
 usage() {
@@ -25,14 +25,20 @@ Options:
   -r, --effort EFFORT    Reasoning effort: medium|high|xhigh (default: xhigh)
   -s, --sandbox SANDBOX  Sandbox: read-only|workspace-write|danger-full-access (default: read-only)
   -C, --cwd DIR          Working directory for codex
-  --resume               Resume last codex session
+  -S, --session-id ID    Resume a specific session by UUID (deterministic;
+                         the only resume path — there is no --last fallback)
   --full-auto            Enable full auto mode
   -h, --help             Show this help
+
+codex prints "session id: <uuid>" to stderr on every run. stderr is not
+suppressed, so the caller (a subagent) reads that line directly and resumes
+that exact session later with -S. Resume is always by explicit id — there is
+no most-recent fallback, so it is never a race under parallel sessions.
 
 Examples:
   codex-run.sh /tmp/codex_prompt_a3f9.txt
   codex-run.sh -m gpt-5.4 -r high /tmp/codex_prompt_a3f9.txt
-  codex-run.sh --resume /tmp/codex_prompt_a3f9.txt
+  codex-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 /tmp/codex_prompt_a3f9.txt
   codex-run.sh -s workspace-write --full-auto /tmp/codex_prompt_a3f9.txt
 USAGE
   exit "${1:-0}"
@@ -45,7 +51,7 @@ while [[ $# -gt 0 ]]; do
     -r|--effort) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; EFFORT="$2"; shift 2 ;;
     -s|--sandbox) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; SANDBOX="$2"; shift 2 ;;
     -C|--cwd) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; CWD="$2"; shift 2 ;;
-    --resume) RESUME=true; shift ;;
+    -S|--session-id) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; SESSION_ID="$2"; shift 2 ;;
     --full-auto) FULL_AUTO=true; shift ;;
     -h|--help) usage 0 ;;
     -*) echo "Unknown option: $1" >&2; usage 1 ;;
@@ -64,9 +70,11 @@ if [[ ! -f "$PROMPT_FILE" ]]; then
   exit 1
 fi
 
-# Execute
-if [[ "$RESUME" == true ]]; then
-  # Warn if non-default options are passed with --resume (they are ignored)
+# Build codex argv. Resume iff a session id was given.
+CODEX_ARGS=(exec --skip-git-repo-check)
+if [[ -n "$SESSION_ID" ]]; then
+  # Warn if non-default options are passed with resume (they are ignored —
+  # the session keeps its original settings).
   IGNORED=()
   [[ "$MODEL" != "$DEFAULT_MODEL" ]] && IGNORED+=("-m $MODEL")
   [[ "$EFFORT" != "$DEFAULT_EFFORT" ]] && IGNORED+=("-r $EFFORT")
@@ -74,16 +82,18 @@ if [[ "$RESUME" == true ]]; then
   [[ "$FULL_AUTO" == true ]] && IGNORED+=("--full-auto")
   [[ -n "$CWD" ]] && IGNORED+=("-C $CWD")
   if [[ ${#IGNORED[@]} -gt 0 ]]; then
-    echo "Warning: --resume ignores options: ${IGNORED[*]} (uses last session settings)" >&2
+    echo "Warning: resume ignores options: ${IGNORED[*]} (uses session settings)" >&2
   fi
-  codex exec --skip-git-repo-check resume --last 2>/dev/null < "$PROMPT_FILE"
+  CODEX_ARGS+=(resume "$SESSION_ID")
 else
-  EXTRA_ARGS=()
-  [[ "$FULL_AUTO" == true ]] && EXTRA_ARGS+=(--full-auto)
-  [[ -n "$CWD" ]] && EXTRA_ARGS+=(-C "$CWD")
-  codex exec --skip-git-repo-check \
-    -m "$MODEL" \
-    --config model_reasoning_effort="$EFFORT" \
-    --sandbox "$SANDBOX" \
-    ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} 2>/dev/null < "$PROMPT_FILE"
+  CODEX_ARGS+=(-m "$MODEL" --config "model_reasoning_effort=$EFFORT" --sandbox "$SANDBOX")
+  [[ "$FULL_AUTO" == true ]] && CODEX_ARGS+=(--full-auto)
+  [[ -n "$CWD" ]] && CODEX_ARGS+=(-C "$CWD")
 fi
+
+# Hand off to codex. stdout = readable agent answer; stderr = codex banner,
+# which includes "session id: <uuid>". Neither is suppressed: the calling
+# subagent reads the session id (and any failure) straight from the output,
+# so no in-script regex extraction is needed. exec propagates codex's exit
+# code unchanged.
+exec codex "${CODEX_ARGS[@]}" < "$PROMPT_FILE"

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -70,20 +70,24 @@ When the delegated task is image generation or image editing:
 
 2. Select sandbox mode; default to `--sandbox read-only` unless edits or network access are necessary.
 3. Craft prompt per Context Classification and Prompt Template — classify context, write to `/tmp/codex_prompt_<suffix>.txt`.
-4. Execute via `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh` with appropriate options:
-   - `-m MODEL` / `-r EFFORT` / `-s SANDBOX` / `--full-auto` / `-C DIR`
-   - **Single model**: run one Bash call as usual.
-   - **Multiple models**: issue parallel Bash tool calls (one per model) in a single response. Each call uses the same prompt, sandbox, and reasoning effort but a different `-m` value.
-5. Resume: Write new instructions to a fresh `/tmp/codex_prompt_<suffix>.txt`, then `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh --resume /tmp/codex_prompt_<suffix>.txt`. Resume applies to the last single session only. Codex tracks sessions internally — no external session ID needed.
-6. Run command(s), summarize each outcome, inform user: "Resume anytime with 'codex resume'."
+4. Delegate execution to a Bash subagent (Task tool) — never run `codex-run.sh` directly in the main session. This keeps codex's verbose banner and full output out of the main context. Give the subagent:
+   - the exact command: `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh [options] /tmp/codex_prompt_<suffix>.txt` with `-m MODEL` / `-r EFFORT` / `-s SANDBOX` / `--full-auto` / `-C DIR`, or `-S <SESSION_ID>` to resume.
+   - return contract: run the command and return ONLY (a) a concise outcome summary and (b) the session id. codex prints `session id: <uuid>` to stderr; the subagent extracts that line verbatim and returns it as `SESSION_ID: <uuid>`. The wrapper does no parsing — stderr is left unsuppressed precisely so the subagent can read the session id and any failure straight from the output.
+   - **Single model**: one subagent call.
+   - **Multiple models**: issue parallel subagent calls (one per model) in a single response — same prompt, sandbox, and effort, different `-m`. Each returns its own `SESSION_ID`.
+5. Record each returned `SESSION_ID` against its purpose/model. This {purpose → SESSION_ID} map is the only resume handle — there is no most-recent fallback.
+6. Resume: write new instructions to a fresh `/tmp/codex_prompt_<suffix>.txt`, then delegate to a Bash subagent running `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> /tmp/codex_prompt_<suffix>.txt`. Resume is always by explicit id — deterministic, never a race under parallel sessions. Model/effort/sandbox/`-C` are ignored on resume (the session keeps its original settings).
+7. Summarize each outcome to the user; for parallel work, surface which `SESSION_ID` maps to which branch. Inform the user: "Resume anytime with 'codex resume'."
 
 ### Quick Reference
+Each command below runs **inside a Bash subagent**, which returns the outcome summary plus the `session id: <uuid>` line as `SESSION_ID: <uuid>`.
+
 | Use case | Command pattern |
 | --- | --- |
 | Read-only analysis | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -m MODEL /tmp/codex_prompt_<suffix>.txt` |
 | Apply edits | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s workspace-write --full-auto /tmp/codex_prompt_<suffix>.txt` |
 | Network access | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s danger-full-access --full-auto /tmp/codex_prompt_<suffix>.txt` |
-| Resume session | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh --resume /tmp/codex_prompt_<suffix>.txt` (options like -m, -r, -s are ignored; uses last session settings) |
+| Resume a session | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> /tmp/codex_prompt_<suffix>.txt` (only resume path; deterministic, no --last) |
 | Different dir | Add `-C <DIR>` to non-resume patterns above |
 | Custom model | Add `-m gpt-5.4 -r high` to any pattern above |
 


### PR DESCRIPTION
## 배경

`codex-run.sh`의 `--resume`는 `codex exec resume --last`로 가장 최근 세션을 잡습니다. codex-plus가 병렬/팀 에이전트로 여러 세션을 띄우면 `--last`는 어느 세션이 잡힐지 모르는 race입니다. 또한 매 실행이 `2>/dev/null`로 codex가 stderr에 찍는 `session id: <uuid>`를 버려, 특정 세션을 결정적으로 지목할 방법이 없었습니다.

ephemeral/prune도 검토했으나 기각: resume은 첫 실행이 끝난 뒤 결정되는 emergent 결정이라 invocation 시점에 ephemeral 여부를 신뢰성 있게 정할 수 없습니다(한 번 비영구화하면 사후 승격 불가).

## 변경

- **codex-run.sh**
  - `--resume`/`--last` 제거 → resume은 오직 `-S <UUID>` (완전 결정적, 병렬에서도 race 없음)
  - 스크립트 내 session-id 정규식 추출 및 `SESSION_ID:` 재출력 삭제
  - `exec codex …`로 위임 — stdout(가독 답변)/stderr(codex 네이티브 `session id:` 배너)/exit code 무가공 전파
- **skills/codex/SKILL.md**
  - 실행을 Bash 서브에이전트(Task)에 위임하도록 의무화 — codex 배너가 메인 컨텍스트를 오염시키지 않음
  - 서브에이전트가 codex 네이티브 `session id:` 줄을 직독해 `{요약 + SESSION_ID}`만 반환
  - 메인 세션이 `{용도 → SESSION_ID}` 맵 보유, 병렬 모델 = 병렬 서브에이전트 호출

## 검증

- `bash -n` 통과 / `--resume` → `Unknown option` (제거 확인)
- nonce 라운드트립: 비-resume 실행 → codex 네이티브 `session id:` 포착 → `-S <id>` resume 시 동일 세션 id 반환 + nonce 회수(연속성 입증, `--last` 우연 아님)
- 래퍼 `SESSION_ID:` 재출력 0줄 (스크립트 파싱 제거 확인)
- Bash 서브에이전트 smoke test PASS: exit 0, stdout=하이쿠, 네이티브 session id 존재, 컨텍스트 격리 동작

## 호환성

`--resume` 플래그 제거는 breaking — codex-plus 내부 진입점(SKILL.md)만 사용하므로 영향 범위는 플러그인 내부로 한정. SKILL.md 동시 갱신됨.
