### PR TITLE
feat(clawd-toggle): background toggle skill for clawd-on-desk

### DIFF
--- a/clawd-toggle/.claude-plugin/plugin.json
+++ b/clawd-toggle/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "clawd-toggle",
+  "description": "Toggle clawd-on-desk (Electron desktop pet) as a tracked background process",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/clawd-toggle/README.md
+++ b/clawd-toggle/README.md
@@ -1,0 +1,18 @@
+# clawd-toggle-plugin
+
+Toggle the clawd-on-desk Electron desktop pet for Claude Code.
+
+- `npm start`: clawd-on-desk를 백그라운드 프로세스로 실행
+- PID 파일(`/tmp/clawd-on-desk.pid`) 추적으로 토글 (caffeinate 방식과 동일)
+- 종료 시 `npm → node → electron` 프로세스 그룹 전체 정리
+- 로그: `/tmp/clawd-on-desk.log`
+
+## Config
+
+repo가 다른 경로에 있으면 환경변수로 지정:
+
+```bash
+export CLAWD_ON_DESK_DIR=/path/to/clawd-on-desk
+```
+
+기본값: `/Users/choi/Downloads/github/oss/clawd-on-desk`

--- a/clawd-toggle/scripts/toggle.sh
+++ b/clawd-toggle/scripts/toggle.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Toggle clawd-on-desk (Electron desktop pet) as a background process.
+# Output: STARTED or STOPPED
+#
+# `npm start` spawns a node -> electron child tree. We launch it in its own
+# process group (perl setpgrp) and track that PID, so STOP can kill the whole
+# group instead of orphaning the electron windows.
+#
+# Config: CLAWD_ON_DESK_DIR env var (default: repo path below)
+
+CLAWD_DIR="${CLAWD_ON_DESK_DIR:-/Users/choi/Downloads/github/oss/clawd-on-desk}"
+PIDFILE="/tmp/clawd-on-desk.pid"
+LOGFILE="/tmp/clawd-on-desk.log"
+
+# Check if our process is running (verify the tracked PID is still the launcher).
+PID=$(cat "$PIDFILE" 2>/dev/null)
+if [[ -n "$PID" ]] && ps -p "$PID" -o command= 2>/dev/null | grep -qiE 'npm|electron|clawd'; then
+  # Negative PID targets the whole process group; fall back to single PID.
+  kill -TERM "-$PID" 2>/dev/null || kill -TERM "$PID" 2>/dev/null
+  rm -f "$PIDFILE"
+  echo "STOPPED"
+else
+  rm -f "$PIDFILE"
+  if [[ ! -d "$CLAWD_DIR" ]]; then
+    echo "ERROR: clawd-on-desk dir not found: $CLAWD_DIR" >&2
+    exit 1
+  fi
+  cd "$CLAWD_DIR" || exit 1
+  # setpgrp makes the launcher its own group leader (PID == PGID) so the entire
+  # npm -> node -> electron tree is killable via the negative-PID group signal.
+  nohup perl -e 'setpgrp; exec @ARGV' npm start </dev/null >"$LOGFILE" 2>&1 &
+  echo $! > "$PIDFILE"
+  disown 2>/dev/null
+  echo "STARTED"
+fi

--- a/clawd-toggle/skills/clawd-toggle/SKILL.md
+++ b/clawd-toggle/skills/clawd-toggle/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: clawd-toggle
+description: >
+  This skill should be used when the user asks to "start clawd", "stop clawd",
+  "toggle clawd", "launch clawd on desk", "kill clawd", "run the desktop pet",
+  or mentions starting/stopping the clawd-on-desk Electron app.
+  Toggles `npm start` for clawd-on-desk as a tracked background process.
+---
+
+# Clawd on Desk Toggle
+
+Run the toggle script and report the result:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/toggle.sh"
+```
+
+- Output `STARTED` → clawd-on-desk launched in the background (logs at `/tmp/clawd-on-desk.log`).
+- Output `STOPPED` → the background process tree (npm → node → electron) terminated.
+
+Override the repo location with the `CLAWD_ON_DESK_DIR` env var when the project
+lives elsewhere.
+
+Respond concisely in one line with the current state (running/stopped).


### PR DESCRIPTION
## Summary

caffeinate 스킬과 동일한 방식(PID 파일 추적 + `nohup` 백그라운드 실행 + `ps` 검증 토글)으로 clawd-on-desk Electron 데스크톱 펫을 토글하는 `clawd-toggle` 스킬을 추가합니다.

## 구조

```
clawd-toggle/
├── .claude-plugin/plugin.json
├── skills/clawd-toggle/SKILL.md
├── scripts/toggle.sh
└── README.md
```

## caffeinate와의 차이

`npm start`는 `node → electron` 자식 트리를 생성하므로 npm PID만 종료하면 electron 창이 남습니다. 이를 막기 위해:

- `perl setpgrp`로 런처를 프로세스 그룹 리더로 실행 (PID == PGID)
- 종료 시 `kill -TERM -$PID`로 그룹 전체를 정리

## Config

- `CLAWD_ON_DESK_DIR` 환경변수로 repo 경로 오버라이드 (기본값: `/Users/choi/Downloads/github/oss/clawd-on-desk`)
- 로그: `/tmp/clawd-on-desk.log`

## 검증

- `bash -n` 문법 검사 통과
- `perl setpgrp` 가용성 확인 (macOS)
- 라이브 토글(실제 앱 실행)은 GUI가 떠서 미실행 — 머지 후 사용자가 직접 확인 예정
