### PR TITLE
chore(marketplace): register clawd-toggle plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -45,6 +45,11 @@
       "description": "macOS sleep prevention toggle with battery and network monitoring"
     },
     {
+      "name": "clawd-toggle",
+      "source": "./clawd-toggle",
+      "description": "Toggle clawd-on-desk (Electron desktop pet) as a tracked background process"
+    },
+    {
       "name": "safe-uninstall",
       "source": "./safe-uninstall",
       "description": "Safely identify, investigate, and remove macOS programs with risk-assessed execution"


### PR DESCRIPTION
PR #44에서 `clawd-toggle` 플러그인 폴더는 추가됐지만 `.claude-plugin/marketplace.json` 등록이 누락되어 마켓플레이스에 노출되지 않았습니다. caffeinate 다음에 항목을 추가합니다.