### PR TITLE
fix(clawd-toggle): signature-based detection for electron tree (v1.0.1)

### DIFF
--- a/clawd-toggle/.claude-plugin/plugin.json
+++ b/clawd-toggle/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clawd-toggle",
   "description": "Toggle clawd-on-desk (Electron desktop pet) as a tracked background process",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/clawd-toggle/README.md
+++ b/clawd-toggle/README.md
@@ -3,9 +3,11 @@
 Toggle the clawd-on-desk Electron desktop pet for Claude Code.
 
 - `npm start`: clawd-on-desk를 백그라운드 프로세스로 실행
-- PID 파일(`/tmp/clawd-on-desk.pid`) 추적으로 토글 (caffeinate 방식과 동일)
-- 종료 시 `npm → node → electron` 프로세스 그룹 전체 정리
+- 실행 중인 electron 프로세스를 경로 시그니처(`$CLAWD_DIR/node_modules/electron`)로 `pgrep` 탐지해 토글
+- 종료 시 `pkill`로 main + helper 프로세스 트리 전체 정리
 - 로그: `/tmp/clawd-on-desk.log`
+
+> PID 파일 추적을 쓰지 않는 이유: `npm start`는 부트스트랩만 하고 node 런처는 electron이 뜨면 종료되며, electron은 자기만의 프로세스 그룹으로 재분리됩니다. 런처 PID를 저장하면 즉시 stale 포인터가 되어 실제 트리를 종료하지 못합니다.
 
 ## Config
 

--- a/clawd-toggle/scripts/toggle.sh
+++ b/clawd-toggle/scripts/toggle.sh
@@ -2,34 +2,33 @@
 # Toggle clawd-on-desk (Electron desktop pet) as a background process.
 # Output: STARTED or STOPPED
 #
-# `npm start` spawns a node -> electron child tree. We launch it in its own
-# process group (perl setpgrp) and track that PID, so STOP can kill the whole
-# group instead of orphaning the electron windows.
+# Detection is signature-based, not launcher-PID-based: `npm start` only
+# bootstraps the app — the node launcher exits once electron is up, and
+# electron re-parents into its own process group. Tracking the launcher PID
+# leaves a dead pointer and orphans the real electron tree, so we instead
+# pgrep/pkill the running electron processes by their on-disk path.
 #
 # Config: CLAWD_ON_DESK_DIR env var (default: repo path below)
 
 CLAWD_DIR="${CLAWD_ON_DESK_DIR:-/Users/choi/Downloads/github/oss/clawd-on-desk}"
-PIDFILE="/tmp/clawd-on-desk.pid"
 LOGFILE="/tmp/clawd-on-desk.log"
 
-# Check if our process is running (verify the tracked PID is still the launcher).
-PID=$(cat "$PIDFILE" 2>/dev/null)
-if [[ -n "$PID" ]] && ps -p "$PID" -o command= 2>/dev/null | grep -qiE 'npm|electron|clawd'; then
-  # Negative PID targets the whole process group; fall back to single PID.
-  kill -TERM "-$PID" 2>/dev/null || kill -TERM "$PID" 2>/dev/null
-  rm -f "$PIDFILE"
+# Path signature shared by the main electron process and all its helpers.
+SIG="$CLAWD_DIR/node_modules/electron"
+
+if pgrep -f "$SIG" >/dev/null 2>&1; then
+  # Terminate the whole tree (main + helpers); SIGKILL any stragglers.
+  pkill -TERM -f "$SIG" 2>/dev/null
+  sleep 1
+  pkill -KILL -f "$SIG" 2>/dev/null
   echo "STOPPED"
 else
-  rm -f "$PIDFILE"
   if [[ ! -d "$CLAWD_DIR" ]]; then
     echo "ERROR: clawd-on-desk dir not found: $CLAWD_DIR" >&2
     exit 1
   fi
   cd "$CLAWD_DIR" || exit 1
-  # setpgrp makes the launcher its own group leader (PID == PGID) so the entire
-  # npm -> node -> electron tree is killable via the negative-PID group signal.
-  nohup perl -e 'setpgrp; exec @ARGV' npm start </dev/null >"$LOGFILE" 2>&1 &
-  echo $! > "$PIDFILE"
+  nohup npm start </dev/null >"$LOGFILE" 2>&1 &
   disown 2>/dev/null
   echo "STARTED"
 fi


### PR DESCRIPTION
## 문제

`/clawd-toggle`을 두 번 실행했을 때 STOP 대신 STARTED가 다시 출력되고, electron 앱이 종료되지 않는 버그를 발견했습니다.

**근본 원인**: launcher-PID 추적 모델이 Electron 앱에 맞지 않습니다.
- `npm start`는 부트스트랩만 수행 — `node launch.js`가 electron을 띄우면 node 런처는 종료됩니다.
- electron은 자기만의 새 프로세스 그룹(PGID)으로 재분리됩니다.
- 따라서 저장된 런처 PID는 즉시 stale 포인터가 되고, toggle-off는 죽은 PID를 보고 "안 떠있음"으로 판단 → 중복 실행 + 실제 electron 트리 미종료.

진단 시 실제 트리: main electron PID와 PGID가 저장된 런처 PID와 완전히 단절(`kill -- -$PID` 그룹 종료가 닿지 않음).

## 수정

런처 PID 추적을 버리고 **실행 중 electron 시그니처 기반 탐지**로 전환:
- 탐지/종료: `pgrep`/`pkill -f "$CLAWD_DIR/node_modules/electron"` (main + helper 모두 매칭)
- PID 파일 완전 제거 (stale 위험 원천 차단)

## 검증

라이브 `start → 2초 후 탐지 → stop → 트리 전체 종료 → 재시작` 사이클 확인.

## 동반 변경 (이 PR 외)

statusline 인디케이터(`~/.claude/scripts/statusline-command.sh`, 로컬 전용)도 동일 시그니처 기반 `pgrep` 탐지로 전환했습니다 (repo 외부 파일).
