### PR TITLE
feat(graph-sketch): 계층형 ASCII 박스아트 DAG 렌더러 플러그인

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -58,6 +58,11 @@
       "name": "dallem",
       "source": "./dallem",
       "description": "Therapy reservation assistant with CDP automation and Google Calendar conflict checking"
+    },
+    {
+      "name": "graph-sketch",
+      "source": "./graph-sketch",
+      "description": "Render workflow/DAG graphs as layered ASCII box-art in the terminal"
     }
   ]
 }

--- a/graph-sketch/.claude-plugin/plugin.json
+++ b/graph-sketch/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "graph-sketch",
+  "description": "Render workflow/DAG graphs as layered ASCII box-art in the terminal",
+  "version": "0.1.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/graph-sketch/skills/graph-sketch/SKILL.md
+++ b/graph-sketch/skills/graph-sketch/SKILL.md
@@ -45,7 +45,7 @@ principle: a skill must work even when an optional external tool is absent).
 Feed it an edge list on stdin (or pass a file path):
 
 ```bash
-uv run ~/.claude/skills/graph-sketch/scripts/render.py <<'EOF'
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/graph-sketch/scripts/render.py <<'EOF'
 diff/fate -> Category, Type, OpSem, Gap
 Category, Type, OpSem, Gap -> verify
 verify -> Synthesize -> report
@@ -136,6 +136,21 @@ than hidden:
 If a graph has cycles, the renderer still lays it out (back-edges are treated as layer-0
 contributions) but the result reads better as a tree than as a faithful cyclic graph; note
 this to the user and offer graph-easy.
+
+### Input envelope
+
+The renderer targets graphs small enough to read in a terminal — the kind you can specify
+inline — so a few input boundaries are accepted rather than engineered around:
+
+- **Labels are measured by character count, not display width.** Wide glyphs (CJK, emoji)
+  drift the boxes and connectors, because box width is `len(label) + 4`. Stick to ASCII/Latin
+  labels, or pad manually, when alignment matters.
+- **Very deep chains recurse.** Layering is computed recursively, so a single chain longer
+  than Python's recursion limit (~1000 nodes) raises `RecursionError`. Graphs that fit in a
+  terminal never approach this; for machine-scale DAGs, use graphviz.
+- **DOT wrappers must be multi-line.** `digraph foo {` and `}` are stripped only when each is
+  on its own line; a one-line `digraph G { A -> B }` is parsed literally and yields junk nodes.
+  Split the wrapper across lines, or drop it and feed the bare edges.
 
 ## Files
 

--- a/graph-sketch/skills/graph-sketch/SKILL.md
+++ b/graph-sketch/skills/graph-sketch/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: graph-sketch
+description: |
+  This skill should be used when the user wants to SEE THE SHAPE of a graph, DAG,
+  workflow, pipeline, dependency tree, or fan-out/fan-in flow in the terminal — phrases
+  like "draw this graph", "show the workflow structure", "sketch the DAG", "visualize
+  the pipeline", "diagram these dependencies", "render this as ASCII", or when translating
+  a Workflow script's pipeline()/parallel() structure into a picture. Renders directed
+  graphs as layered box-art/ASCII with zero dependencies (bundled Python), and upgrades
+  to graph-easy when it is installed. Use it whenever someone wants a plain-text picture
+  of a multi-step or branching process, even if they never say the word "ASCII".
+---
+
+# Graph Sketch
+
+Turn a directed graph — most often a workflow or DAG — into a layered box-art diagram you
+can read straight in the terminal. The whole point is to make a branching process *legible
+at a glance* without reaching for an image renderer or a browser.
+
+## Choosing a rendering path
+
+There are three ways to render, in priority order. The first works on any machine and is
+the default; the others are situational. Prefer the bundled script unless you have a
+specific reason not to — it is environment-neutral, which matters because a teammate
+running this skill may not have graph-easy installed (cc-plugin's Environment-neutrality
+principle: a skill must work even when an optional external tool is absent).
+
+1. **Bundled `render.py` (default).** Pure Python stdlib via uv — no external packages.
+   Lays a graph out top-to-bottom by longest-path layers. Best for the common workflow
+   shape: one source fanning out to N parallel stages that fan back into one.
+
+2. **graph-easy (optional upgrade).** If `graph-easy` is on PATH, it produces nicer
+   automatic routing for dense or heavily-crossing graphs. Detect it first
+   (`command -v graph-easy`); only suggest installing it when the graph is genuinely too
+   tangled for the layered renderer (see *Limits* below). It is a Perl module
+   (`cpanm Graph::Easy`, or `apt install libgraph-easy-perl`), so installation is a real
+   cost — do not push it for simple graphs.
+
+3. **Hand-ASCII heredoc (one-off).** For a three- or four-node sketch you will never reuse,
+   just write the boxes by hand in a `cat <<'EOF'` block. Faster than any tool when the
+   graph is trivial and disposable.
+
+## Default path: render.py
+
+Feed it an edge list on stdin (or pass a file path):
+
+```bash
+uv run ~/.claude/skills/graph-sketch/scripts/render.py <<'EOF'
+diff/fate -> Category, Type, OpSem, Gap
+Category, Type, OpSem, Gap -> verify
+verify -> Synthesize -> report
+EOF
+```
+
+### Input grammar
+
+One edge statement per line. The grammar is deliberately small so it is quick to type and
+also tolerant of pasted DOT.
+
+- `A -> B` — a single edge.
+- `A -> B -> C` — a chain; expands to `A->B` and `B->C`.
+- `A, B -> C` — comma groups on either side; expands to the cross product (`A->C`, `B->C`).
+- `LoneNode` — a bare token with no arrow declares an isolated node.
+- DOT noise is stripped: surrounding quotes, a trailing `;`, `[label=...]` attribute
+  blocks, and `digraph foo {` / `}` wrappers are all ignored, so you can paste a `.dot`
+  body directly.
+- Blank lines and `#` comments are ignored.
+
+### Flags
+
+| Flag | Effect |
+|------|--------|
+| `--ascii` | Use `+ - |` instead of unicode box characters — for terminals that mangle UTF-8. |
+| `--gutter N` | Horizontal space between sibling boxes (default `3`). Widen it if labels look cramped. |
+
+### What the output looks like
+
+The fan-out / fan-in example above renders as:
+
+```
+                ┌───────────┐
+                │ diff/fate │
+                └───────────┘
+      ┌────────────┬──┴───────┬──────────┐
+      │            │          │          │
+┌──────────┐   ┌──────┐   ┌───────┐   ┌─────┐
+│ Category │   │ Type │   │ OpSem │   │ Gap │
+└──────────┘   └──────┘   └───────┘   └─────┘
+      └────────────┴──┬───────┴──────────┘
+                      │
+                 ┌────────┐
+                 │ verify │
+                 └────────┘
+                      │
+               ┌────────────┐
+               │ Synthesize │
+               └────────────┘
+                      │
+                 ┌────────┐
+                 │ report │
+                 └────────┘
+```
+
+## Translating a Workflow script into an edge list
+
+A frequent use is picturing the control flow of a `Workflow` script (the `pipeline()` /
+`parallel()` orchestration primitives). Map the primitives to edges like this, then pipe
+the result into `render.py`:
+
+- **`pipeline(items, stageA, stageB, ...)`** is a chain per item: `item -> stageA -> stageB`.
+  When every item flows through the same named stages, collapse to one chain of stage names.
+- **`parallel([f1, f2, f3])`** is a fan-out from the node that spawned it to each thunk, then
+  (if the results are later combined) a fan-in to the consuming node.
+- A **barrier** (results awaited together before the next stage) is a fan-in: `s1, s2, s3 -> next`.
+- Name nodes after what they *do* (`review:bugs`, `verify`, `synthesize`), not the variable
+  that holds them — the picture is for a human.
+
+Read the script's `phase()` calls and the shape of its `parallel`/`pipeline` calls, write the
+edges, and render. This recovers the fan-out → verify → fan-in skeleton that the prose of a
+script hides.
+
+## Limits — and when to escalate
+
+The layered renderer optimises for hub-style graphs. Two honest limitations, surfaced rather
+than hidden:
+
+- **Cross-layer edges are listed, not drawn.** An edge that skips a layer (e.g. `start -> end`
+  when `end` is three layers down) is printed in a `cross-layer edges (not drawn above)` note
+  beneath the diagram. This keeps the picture truthful instead of routing a misleading line.
+- **Dense crossings are approximate.** Between two layers the connectors are drawn as a single
+  shared bus, which is exactly right for fan-out/fan-in but only indicative when many edges
+  cross each other. If the graph is a tangle rather than a hierarchy, switch to graph-easy
+  (`graph-easy --as_boxart`) or graphviz (`dot -Tplain` rasterised, or just `dot -Tpng` for an
+  image) — both do real edge routing.
+
+If a graph has cycles, the renderer still lays it out (back-edges are treated as layer-0
+contributions) but the result reads better as a tree than as a faithful cyclic graph; note
+this to the user and offer graph-easy.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/render.py` | Layered box-art / ASCII renderer. Stdlib-only, runs via `uv run`. Reads an edge list from stdin or a file. |

--- a/graph-sketch/skills/graph-sketch/SKILL.md
+++ b/graph-sketch/skills/graph-sketch/SKILL.md
@@ -1,14 +1,11 @@
 ---
 name: graph-sketch
 description: |
-  This skill should be used when the user wants to SEE THE SHAPE of a graph, DAG,
-  workflow, pipeline, dependency tree, or fan-out/fan-in flow in the terminal — phrases
-  like "draw this graph", "show the workflow structure", "sketch the DAG", "visualize
-  the pipeline", "diagram these dependencies", "render this as ASCII", or when translating
-  a Workflow script's pipeline()/parallel() structure into a picture. Renders directed
-  graphs as layered box-art/ASCII with zero dependencies (bundled Python), and upgrades
-  to graph-easy when it is installed. Use it whenever someone wants a plain-text picture
-  of a multi-step or branching process, even if they never say the word "ASCII".
+  This skill should be used when the user wants a directed graph — a DAG, workflow,
+  pipeline, or dependency tree — drawn as a plain-text terminal picture: "draw this graph",
+  "sketch the DAG", "diagram these dependencies", "render as ASCII", or turning a Workflow
+  script's pipeline()/parallel() structure into a diagram (even when "ASCII" is never said).
+  Renders layered box-art, zero-dependency, upgrading to graph-easy when installed.
 ---
 
 # Graph Sketch

--- a/graph-sketch/skills/graph-sketch/scripts/render.py
+++ b/graph-sketch/skills/graph-sketch/scripts/render.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env uv run --quiet --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = []
+# ///
+"""Render a directed graph (DAG) as a layered box-art / ASCII diagram in the terminal.
+
+Zero external dependencies — pure stdlib, so it works on any machine with uv/python.
+Best for hub-style fan-out / fan-in (the common workflow shape: one source feeding N
+parallel stages that fan back into one). For dense crossing graphs, graph-easy or
+graphviz `dot` give nicer routing — this tool stays honest by listing cross-layer
+edges below the diagram instead of mis-routing them.
+
+Input — edges, one per line, on stdin or from a file given as a positional arg:
+
+    A -> B
+    A -> B -> C          # chains expand to A->B and B->C
+    A, B -> C            # comma groups: A->C and B->C
+    LoneNode             # a bare token declares an isolated node
+
+DOT-style lines are tolerated: surrounding quotes, trailing `;`, `[...]` attribute
+blocks, and `digraph foo {` / `}` wrappers are stripped. Blank lines and `#` comments
+are ignored.
+
+Flags:
+    --ascii     use +-|  instead of unicode box characters (for non-UTF8 terminals)
+    --gutter N  horizontal space between sibling boxes (default 3)
+"""
+import sys
+import argparse
+
+
+def parse_edges(text):
+    """Return (nodes_in_first_seen_order, edges) from the edge-list text."""
+    nodes, seen, edges = [], set(), []
+
+    def add(n):
+        if n and n not in seen:
+            seen.add(n)
+            nodes.append(n)
+
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # drop DOT wrappers: `digraph x {`, standalone `{` / `}`
+        if line in ("{", "}") or line.endswith("{"):
+            continue
+        if "[" in line:                       # strip attribute block
+            line = line[: line.index("[")]
+        line = line.rstrip(";").strip()
+        if not line:
+            continue
+        if "->" not in line:                  # bare node declaration
+            add(line.strip('"').strip())
+            continue
+        groups = []
+        for part in line.split("->"):
+            members = [m.strip().strip('"').strip() for m in part.split(",") if m.strip()]
+            for m in members:
+                add(m)
+            groups.append(members)
+        for i in range(len(groups) - 1):
+            for a in groups[i]:
+                for b in groups[i + 1]:
+                    edges.append((a, b))
+    return nodes, edges
+
+
+def compute_layers(nodes, edges):
+    """Longest-path layering from sources. Cycle-safe (back-edges contribute 0)."""
+    preds = {n: [] for n in nodes}
+    for a, b in edges:
+        preds[b].append(a)
+    layer, visiting = {}, set()
+
+    def lay(n):
+        if n in layer:
+            return layer[n]
+        if n in visiting:                     # cycle guard
+            return 0
+        visiting.add(n)
+        layer[n] = 1 + max((lay(p) for p in preds[n]), default=-1)
+        visiting.discard(n)
+        return layer[n]
+
+    for n in nodes:
+        lay(n)
+    return layer
+
+
+def junction(up, down, left, right, ascii_mode):
+    if ascii_mode:
+        return "+"
+    return {
+        (1, 0, 1, 1): "┴", (1, 0, 1, 0): "┘", (1, 0, 0, 1): "└",
+        (0, 1, 1, 1): "┬", (0, 1, 1, 0): "┐", (0, 1, 0, 1): "┌",
+        (1, 1, 1, 1): "┼", (1, 1, 1, 0): "┤", (1, 1, 0, 1): "├",
+        (1, 1, 0, 0): "│", (1, 0, 0, 0): "│", (0, 1, 0, 0): "│",
+        (0, 0, 1, 1): "─", (0, 0, 1, 0): "─", (0, 0, 0, 1): "─",
+    }.get((up, down, left, right), "┼")
+
+
+def render(nodes, edges, ascii_mode=False, gutter=3):
+    if not nodes:
+        return "(empty graph)"
+    layer = compute_layers(nodes, edges)
+    n_layers = max(layer.values()) + 1
+    rows = [[] for _ in range(n_layers)]      # nodes per layer, first-seen order
+    for n in nodes:
+        rows[layer[n]].append(n)
+
+    # box width includes borders + one space of padding each side: "│ label │"
+    bw = {n: len(n) + 4 for n in nodes}
+    line_w = lambda layer_nodes: sum(bw[n] for n in layer_nodes) + gutter * max(len(layer_nodes) - 1, 0)
+    canvas_w = max(line_w(r) for r in rows)
+
+    # assign absolute column of each box's left edge, then its center
+    left, center = {}, {}
+    for r in rows:
+        x = (canvas_w - line_w(r)) // 2
+        for n in r:
+            left[n] = x
+            center[n] = x + bw[n] // 2
+            x += bw[n] + gutter
+
+    BOX_H, BAND_H = 3, 2
+    height = n_layers * BOX_H + (n_layers - 1) * BAND_H
+    grid = [[" "] * canvas_w for _ in range(height)]
+
+    def put(row, col, ch):
+        if 0 <= row < height and 0 <= col < canvas_w:
+            grid[row][col] = ch
+
+    top_row = lambda L: L * (BOX_H + BAND_H)
+
+    # draw boxes
+    h, v = ("-", "|") if ascii_mode else ("─", "│")
+    tl, tr, bl, br = ("+", "+", "+", "+") if ascii_mode else ("┌", "┐", "└", "┘")
+    for L, r in enumerate(rows):
+        t = top_row(L)
+        for n in r:
+            x, w = left[n], bw[n]
+            for c in range(1, w - 1):
+                put(t, x + c, h)
+                put(t + 2, x + c, h)
+            put(t, x, tl); put(t, x + w - 1, tr)
+            put(t + 2, x, bl); put(t + 2, x + w - 1, br)
+            put(t + 1, x, v); put(t + 1, x + w - 1, v)
+            for i, ch in enumerate(" " + n + " "):
+                put(t + 1, x + 1 + i, ch)
+
+    # draw connectors gap by gap, using only adjacent-layer edges (comb bus)
+    adj = {}                                  # (L) -> list of (parent, child)
+    cross = []                                # edges skipping a layer
+    for a, b in edges:
+        if layer[b] == layer[a] + 1:
+            adj.setdefault(layer[a], []).append((a, b))
+        elif layer[b] != layer[a]:
+            cross.append((a, b))
+    for L, pairs in adj.items():
+        bus = top_row(L) + BOX_H              # bus row (band row 0)
+        drop = bus + 1                        # child-drop row (band row 1)
+        parents = {center[a] for a, _ in pairs}
+        children = {center[b] for _, b in pairs}
+        involved = parents | children
+        lo, hi = min(involved), max(involved)
+        for c in range(lo, hi + 1):
+            up = c in parents
+            down = c in children
+            grid[bus][c] = junction(up, down, c > lo, c < hi, ascii_mode)
+        for c in children:
+            put(drop, c, v)
+
+    out = "\n".join("".join(row).rstrip() for row in grid)
+    out = "\n".join(line for line in out.split("\n"))  # keep internal blanks
+    if cross:
+        arrow = "-->" if ascii_mode else "⇢"
+        note = "\n".join(f"  {a} {arrow} {b}" for a, b in cross)
+        out += f"\n\ncross-layer edges (not drawn above):\n{note}"
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Render a DAG as layered box-art ASCII.")
+    ap.add_argument("file", nargs="?", help="edge-list file (default: stdin)")
+    ap.add_argument("--ascii", action="store_true", help="use +-| instead of box chars")
+    ap.add_argument("--gutter", type=int, default=3, help="space between sibling boxes")
+    args = ap.parse_args()
+    text = open(args.file, encoding="utf-8").read() if args.file else sys.stdin.read()
+    nodes, edges = parse_edges(text)
+    print(render(nodes, edges, ascii_mode=args.ascii, gutter=args.gutter))
+
+
+if __name__ == "__main__":
+    main()

--- a/graph-sketch/skills/graph-sketch/scripts/render.py
+++ b/graph-sketch/skills/graph-sketch/scripts/render.py
@@ -91,6 +91,10 @@ def compute_layers(nodes, edges):
 
 def junction(up, down, left, right, ascii_mode):
     if ascii_mode:
+        if not up and not down:
+            return "-"
+        if not left and not right:
+            return "|"
         return "+"
     return {
         (1, 0, 1, 1): "┴", (1, 0, 1, 0): "┘", (1, 0, 0, 1): "└",
@@ -173,7 +177,6 @@ def render(nodes, edges, ascii_mode=False, gutter=3):
             put(drop, c, v)
 
     out = "\n".join("".join(row).rstrip() for row in grid)
-    out = "\n".join(line for line in out.split("\n"))  # keep internal blanks
     if cross:
         arrow = "-->" if ascii_mode else "⇢"
         note = "\n".join(f"  {a} {arrow} {b}" for a, b in cross)


### PR DESCRIPTION
## 요약

워크플로/DAG/파이프라인 같은 방향 그래프를 터미널에서 바로 읽을 수 있는 **계층형 박스아트(ASCII)** 로 그려주는 `graph-sketch` 플러그인을 추가합니다. 외부 의존성 없이(stdlib + uv) 동작하며, `graph-easy`가 설치돼 있으면 선택적으로 업그레이드합니다.

## 구조

```
graph-sketch/
├── .claude-plugin/plugin.json
└── skills/graph-sketch/
    ├── SKILL.md
    └── scripts/render.py
```

`marketplace.json`에 `dallem` 다음 항목으로 등록합니다.

## 설계 포인트

- **환경 중립성**: 기본 경로는 번들된 `render.py`(순수 stdlib). `graph-easy` 미설치 환경에서도 동작 — cc-plugin의 Environment-neutrality 원칙 준수.
- **정직한 렌더링**: 계층을 건너뛰는 cross-layer 엣지는 잘못 라우팅하지 않고 다이어그램 하단에 별도 목록으로 표기.
- **DOT 관용 입력**: 따옴표/`;`/`[label=...]`/`digraph {}` 래퍼를 흡수해 `.dot` 본문을 그대로 붙여넣어도 파싱.
- **Workflow 스크립트 → 엣지 변환 가이드**: `pipeline()`/`parallel()` 제어 흐름을 엣지 리스트로 옮기는 매핑을 SKILL.md에 문서화.

## Test plan

- [ ] `printf 'A -> B, C\nB, C -> D\n' | uv run graph-sketch/skills/graph-sketch/scripts/render.py` 실행 → fan-out/fan-in 박스아트 출력 확인
- [ ] `printf 'A -> B, C\nB, C -> D\n' | uv run graph-sketch/skills/graph-sketch/scripts/render.py --ascii` 로 ASCII 폴백(`+ - |`) 렌더링 확인
- [ ] `printf 'A -> B -> C\nA -> C\n' | uv run graph-sketch/skills/graph-sketch/scripts/render.py` 로 cross-layer 엣지가 다이어그램 하단에 별도 목록으로 표기되는지 확인
- [ ] 마켓플레이스 갱신 후 새 세션에서 `/plugin install graph-sketch` → `/graph-sketch` 호출 라우팅 확인 (플러그인 리로드 필요)
