### PR TITLE
style(codex-plus): 재유도 경계를 명시해 Context Classification 통합 (Reference over Copy)

### DIFF
--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -25,8 +25,10 @@ Before writing the prompt file, classify available context on two orthogonal axe
 | **AI-verifiable** | Extract paths, patterns, commands as **Pointers** — codex self-verifies | Provide search hints, entry points — codex self-explores |
 | **User-specific** | Summarize intent, constraints, preferences from current session — **reference-only** | **Blocked** — no collection requests or questions |
 
+**One boundary — Reference over Copy.** Both rows are two faces of the same partition: *re-derivability by the consumer*. Codex is the consumer that cannot re-derive the parent's session context, but CAN re-derive anything reachable by its own tools under `-C DIR`. The AI-verifiable row is what codex re-derives, so pass a **reference** (path / pattern / command); the User-specific row is what it cannot, so **copy** only that into the prompt. Operational test before each item: *"Can codex re-derive this from shared substrate with its own tools?"* — yes → pass a pointer; no → copy it in.
+
 **Rules**:
-- **Pointers**: Provide file paths, grep patterns, test commands. Do not inline file contents — codex has its own tools to read and verify.
+- **Pointers**: Provide file paths, grep patterns, test commands. Do not inline file contents — codex re-derives them with its own tools, so a pointer is sufficient (copying is what you reserve for what it cannot re-derive).
 - **Session Context**: Extract only what is already known from the current conversation. Organize as intent, constraints, and preferences.
 - **No collection requests**: Never embed questions or requests for additional user-specific information in the prompt. If codex needs more context, the user will resume with it. Blocked applies only to content written into `/tmp` prompt, not to pre-prompt orchestration (e.g., `AskUserQuestion` for model selection).
 


### PR DESCRIPTION
## 요약

codex-plus 스킬의 **Context Classification 2×2 표**가 암묵적으로 따르고 있던 단일 경계를 명시적으로 명명한다. 동작 변경 없는 문서 sharpen이다.

## 무엇을 바꿨나

기존 2×2 표(AI-verifiable / User-specific × Session / Exploration)와 "Do not inline file contents" 규칙은 사실 **하나의 경계**의 두 얼굴이었다: **소비자에 의한 재유도 가능성(re-derivability by the consumer)**. 이 경계를 명시적으로 서술했다.

- **통합 원리 (Reference over Copy)**: 두 행(row)이 같은 분할의 두 면임을 명시 — codex는 부모 세션 맥락은 재유도할 수 없지만 `-C DIR` 아래 자기 도구로 닿을 수 있는 것은 무엇이든 재유도할 수 있는 "재유도 못 하는 소비자"다.
- **운영 테스트**: 각 항목 작성 전 — *"codex가 이걸 공유 기질(shared substrate)에서 자기 도구로 재유도할 수 있는가?"* → 예면 포인터를 넘기고, 아니면 프롬프트에 복사해 넣는다.
- 기존 **Pointers / Session Context / Blocked** 구조와 "Do not inline file contents" 규칙은 그대로 보존 — 이미 그것들을 지배하던 원리에 이름을 붙였을 뿐, 교체가 아니다.

## 동작 영향

- **동작 불변(behavior unchanged)**: 분류 규칙·프롬프트 템플릿·실행 흐름은 그대로다. 표가 따르던 원리를 명문화한 prose 변경.
- `codex-plus` patch 버전 bump: `2.3.0` → `2.3.1`.

## 검증

cc-plugin에는 별도 검증 하니스(루트 `package.json` test script / `Makefile` / `.github/workflows` / verify 스킬)가 없다. 손댄 `plugin.json`의 JSON 유효성과 버전(`2.3.1`)만 best-effort로 확인했고 `marketplace.json`은 영향 없음.

## 관련

이 개념(Reference over Copy)은 sibling repo의 epistemic-protocols **PR #496**에서 결정화되어 프로젝트 규칙으로 인스크라이브되었고, 이 PR은 그 개념을 codex-plus에 적용한 것이다. 베이스 브랜치는 `main`(독립 PR — graph-sketch 등 무관 작업 누출 없음).
