### PR TITLE
feat(voice-dictation): 푸시투토크 whisper.cpp 받아쓰기 데몬 플러그인

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,6 +63,11 @@
       "name": "graph-sketch",
       "source": "./graph-sketch",
       "description": "Render workflow/DAG graphs as layered ASCII box-art in the terminal"
+    },
+    {
+      "name": "voice-dictation",
+      "source": "./voice-dictation",
+      "description": "Push-to-talk voice dictation daemon (whisper.cpp) transcribing speech into the active window"
     }
   ]
 }

--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "voice-dictation",
+  "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/voice-dictation/README.md
+++ b/voice-dictation/README.md
@@ -1,0 +1,27 @@
+# voice-dictation-plugin
+
+Push-to-talk voice dictation for Claude Code, powered by whisper.cpp.
+
+- Hold **Right Option (⌥)** to record; release to transcribe and paste into the active window
+- 엔진: whisper.cpp `large-v3-turbo` (`whisper-cli`), 녹음은 `rec`
+- 받아쓴 텍스트는 클립보드 + `Cmd+V`로 frontmost 앱에 붙여넣기
+- 토글: 실행 중인 데몬을 스크립트 경로 시그니처(`dictation_daemon.py`)로 `pgrep` 탐지해 on/off
+- 로그: `/tmp/voice-dictation.log`
+
+> `uv run`은 자식 python 프로세스로 재분리되어 런처 PID가 stale 포인터가 되므로, PID 파일 대신 on-disk 스크립트 경로 시그니처로 `pgrep`/`pkill` 합니다 (clawd-toggle과 동일).
+
+## Permissions (macOS, one-time)
+
+토글을 실행하는 터미널 앱에 다음 권한을 부여하세요. 부여 후 데몬을 다시 토글합니다.
+
+- **Microphone** — 오디오 녹음
+- **Input Monitoring** — Right Option(⌥) hold 감지
+- **Accessibility** — 활성 창에 붙여넣기
+
+## Model
+
+모델 파일이 다음 경로에 있어야 합니다:
+
+```
+~/whisper-models/ggml-large-v3-turbo-q5_0.bin
+```

--- a/voice-dictation/README.md
+++ b/voice-dictation/README.md
@@ -10,6 +10,15 @@ Push-to-talk voice dictation for Claude Code, powered by whisper.cpp.
 
 > `uv run`은 자식 python 프로세스로 재분리되어 런처 PID가 stale 포인터가 되므로, PID 파일 대신 on-disk 스크립트 경로 시그니처로 `pgrep`/`pkill` 합니다 (clawd-toggle과 동일).
 
+## Requirements (CLI)
+
+데몬 실행 전 다음 CLI가 PATH에 있어야 합니다:
+
+- `whisper-cli` (brew `whisper-cpp`) — 전사
+- `rec` (brew `sox`) — 녹음
+- `ffprobe` (brew `ffmpeg`) — 녹음 길이 측정. **미설치 시 모든 녹음이 `무시: 0.00s`로 조용히 폐기**되니 주의
+- `uv` — 데몬 실행
+
 ## Permissions (macOS, one-time)
 
 토글을 실행하는 터미널 앱에 다음 권한을 부여하세요. 부여 후 데몬을 다시 토글합니다.

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -40,6 +40,12 @@ def _start_recording():
     if _recording:
         return
     _recording = True
+    # 이전 녹음 파일을 먼저 제거 — rec 가 새 파일을 못 쓰는 상황(장치 점유/권한 오류)
+    # 에서 직전 녹음을 stale 하게 전사·붙여넣기 하는 것을 방지.
+    try:
+        os.remove(WAV)
+    except FileNotFoundError:
+        pass
     # 16kHz mono. SIGINT 으로 종료해야 sox 가 WAV 헤더를 정상 finalize 함.
     _rec_proc = subprocess.Popen(
         ["rec", "-q", "-r", "16000", "-c", "1", WAV],

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env uv run --quiet --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = ["pynput>=1.7"]
+# ///
+"""voice-dictation 프로토타입 데몬 — 오른쪽 Option(⌥) 홀드 푸시투토크.
+
+누르는 동안 녹음 → 떼면 whisper.cpp 전사 → 현재 활성창에 클립보드 paste.
+
+필요 권한 (이 스크립트를 띄운 터미널 앱에 부여):
+- Microphone        : rec 녹음
+- Input Monitoring  : pynput 전역 키 감지
+- Accessibility     : osascript Cmd+V 합성
+
+중지: Ctrl+C
+"""
+import os
+import signal
+import subprocess
+import tempfile
+import time
+
+from pynput import keyboard
+
+# ── 설정 (벤치마크로 검증된 기본값) ──
+MODEL = os.path.expanduser("~/whisper-models/ggml-large-v3-turbo-q5_0.bin")
+WHISPER_CLI = "whisper-cli"
+LANG = "auto"          # ko / en / auto
+PROMPT = "whisper, hotkey, active window, transcription, paste, 데몬, 핫키, 단축키, 음성 전사"
+TRIGGER = keyboard.Key.alt_r   # 오른쪽 Option
+MIN_SEC = 0.3          # 이보다 짧은 녹음은 오발화로 간주, 무시
+WAV = os.path.join(tempfile.gettempdir(), "voice_dictation.wav")
+
+_rec_proc = None
+_recording = False
+
+
+def _start_recording():
+    global _rec_proc, _recording
+    if _recording:
+        return
+    _recording = True
+    # 16kHz mono. SIGINT 으로 종료해야 sox 가 WAV 헤더를 정상 finalize 함.
+    _rec_proc = subprocess.Popen(
+        ["rec", "-q", "-r", "16000", "-c", "1", WAV],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    print("● 녹음…", flush=True)
+
+
+def _stop_and_transcribe():
+    global _rec_proc, _recording
+    if not _recording:
+        return
+    _recording = False
+    if _rec_proc is not None:
+        _rec_proc.send_signal(signal.SIGINT)
+        try:
+            _rec_proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            _rec_proc.kill()
+        _rec_proc = None
+
+    dur = _wav_duration(WAV)
+    if dur < MIN_SEC:
+        print(f"  (무시: {dur:.2f}s)", flush=True)
+        return
+
+    print(f"  전사 중… ({dur:.1f}s)", flush=True)
+    t0 = time.time()
+    text = _transcribe(WAV)
+    dt = time.time() - t0
+    if not text:
+        print("  (빈 결과)", flush=True)
+        return
+    print(f"  ⤷ ({dt:.1f}s) {text}", flush=True)
+    _inject(text)
+
+
+def _wav_duration(path):
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "default=nw=1:nk=1", path],
+            capture_output=True, text=True,
+        ).stdout.strip()
+        return float(out)
+    except Exception:
+        return 0.0
+
+
+def _transcribe(path):
+    cmd = [WHISPER_CLI, "-m", MODEL, "-f", path, "-l", LANG, "-nt", "-np"]
+    if PROMPT:
+        cmd += ["--prompt", PROMPT]
+    out = subprocess.run(cmd, capture_output=True, text=True)
+    return " ".join(out.stdout.split()).strip()
+
+
+def _inject(text):
+    # 기존 클립보드 보존 → 새 텍스트 복사 → Cmd+V → 잠시 후 복원
+    old = subprocess.run(["pbpaste"], capture_output=True, text=True).stdout
+    subprocess.run(["pbcopy"], input=text, text=True)
+    subprocess.run([
+        "osascript", "-e",
+        'tell application "System Events" to keystroke "v" using command down',
+    ])
+    time.sleep(0.3)
+    subprocess.run(["pbcopy"], input=old, text=True)
+
+
+def _on_press(key):
+    if key == TRIGGER:
+        _start_recording()
+
+
+def _on_release(key):
+    if key == TRIGGER:
+        _stop_and_transcribe()
+
+
+def main():
+    if not os.path.exists(MODEL):
+        raise SystemExit(f"모델 없음: {MODEL}")
+    print("voice-dictation 프로토타입 — 오른쪽 Option(⌥) 홀드로 받아쓰기. 중지: Ctrl+C")
+    print(f"  모델: {os.path.basename(MODEL)} | 언어: {LANG}")
+    print("  (첫 전사는 모델 콜드 로드로 다소 느릴 수 있음)")
+    with keyboard.Listener(on_press=_on_press, on_release=_on_release) as listener:
+        listener.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/voice-dictation/scripts/toggle.sh
+++ b/voice-dictation/scripts/toggle.sh
@@ -8,13 +8,20 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DAEMON="$SCRIPT_DIR/dictation_daemon.py"
-SIG="dictation_daemon.py"
+# Full-path signature (matches clawd-toggle): the absolute $DAEMON path appears
+# in the `uv run "$DAEMON"` argv, so pgrep/pkill -f tracks exactly this plugin's
+# daemon and won't match an unrelated process that merely shares the basename.
+SIG="$DAEMON"
 LOGFILE="/tmp/voice-dictation.log"
 
 if pgrep -f "$SIG" >/dev/null 2>&1; then
   pkill -TERM -f "$SIG" 2>/dev/null
   sleep 1
   pkill -KILL -f "$SIG" 2>/dev/null
+  # The daemon spawns `rec` as a child writing voice_dictation.wav; that child's
+  # argv carries the WAV path, not $SIG, so reap it explicitly — otherwise it
+  # keeps holding the mic if the daemon is toggled off mid-recording.
+  pkill -f "voice_dictation.wav" 2>/dev/null
   echo "STOPPED"
 else
   if [[ ! -f "$DAEMON" ]]; then

--- a/voice-dictation/scripts/toggle.sh
+++ b/voice-dictation/scripts/toggle.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Toggle the voice-dictation push-to-talk daemon as a background process.
+# Output: STARTED or STOPPED
+#
+# Signature-based (not PID-based): `uv run` re-parents into a child python
+# process, so the uv launcher PID is a dead pointer. We pgrep/pkill by the
+# on-disk daemon script path signature instead, matching clawd-toggle.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DAEMON="$SCRIPT_DIR/dictation_daemon.py"
+SIG="dictation_daemon.py"
+LOGFILE="/tmp/voice-dictation.log"
+
+if pgrep -f "$SIG" >/dev/null 2>&1; then
+  pkill -TERM -f "$SIG" 2>/dev/null
+  sleep 1
+  pkill -KILL -f "$SIG" 2>/dev/null
+  echo "STOPPED"
+else
+  if [[ ! -f "$DAEMON" ]]; then
+    echo "ERROR: daemon not found: $DAEMON" >&2
+    exit 1
+  fi
+  nohup uv run "$DAEMON" </dev/null >"$LOGFILE" 2>&1 &
+  disown 2>/dev/null
+  echo "STARTED"
+fi

--- a/voice-dictation/skills/voice-dictation/SKILL.md
+++ b/voice-dictation/skills/voice-dictation/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: voice-dictation
+description: >
+  This skill should be used when the user asks to "start dictation", "stop dictation",
+  "toggle voice dictation", "받아쓰기 켜기", "받아쓰기 꺼기", "음성 받아쓰기 토글",
+  or mentions starting/stopping push-to-talk voice dictation.
+  Toggles the push-to-talk whisper.cpp dictation daemon as a tracked background process.
+---
+
+# Voice Dictation Toggle
+
+Run the toggle script and report the result:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/toggle.sh"
+```
+
+- Output `STARTED` → the dictation daemon launched in the background (logs at `/tmp/voice-dictation.log`).
+- Output `STOPPED` → the dictation daemon terminated.
+
+## Usage
+
+While the daemon is running, **HOLD Right Option (⌥)** to record. Release to
+transcribe via whisper.cpp and paste the text into the frontmost app.
+
+## Permissions (one-time)
+
+The daemon needs these macOS permissions, granted to the terminal app that
+launches the toggle:
+
+- **Microphone** — to record audio
+- **Input Monitoring** — to detect the Right Option (⌥) hold
+- **Accessibility** — to paste into the active window
+
+After granting any permission, re-toggle the daemon to pick up the new access.
+
+Respond concisely in one line with the current state (running/stopped).


### PR DESCRIPTION
## 요약

Whisper 기반 전역 푸시투토크 받아쓰기 데몬을 cc-plugin 플러그인으로 추가합니다. Codex 음성 전사와 유사하게, 오른쪽 Option(⌥)을 누르는 동안 녹음 → 로컬 whisper.cpp 전사 → 현재 활성 창에 paste 합니다.

## 설계

- **엔진**: whisper.cpp + `large-v3-turbo` (로컬, API 키 불필요, Metal 가속). 사용자 실제 목소리로 한/영 정확도 검증. 도메인 용어는 initial-prompt 용어집으로 보정(`하키→핫키` 실증).
- **주입**: 클립보드 + Cmd+V(osascript) + 이전 클립보드 복원 — 한글 유니코드 안전 경로.
- **트리거**: 오른쪽 Option(⌥) 홀드 푸시투토크 (pynput).
- **패키징**: `clawd-toggle` 미러링 — 시그니처 기반(pgrep/pkill on `dictation_daemon.py`) on-demand 토글. launchd 자동상주 없음.
- daemon은 PEP723 + `uv run`, 경량 의존(stdlib + pynput).

## 변경

- `voice-dictation/` 플러그인 신규 (plugin.json, scripts/toggle.sh, scripts/dictation_daemon.py, skills/voice-dictation/SKILL.md, README.md)
- `marketplace.json`에 등록

## 사전 요구

`whisper-cli`(brew whisper-cpp), `rec`(sox), `uv`, 모델 `~/whisper-models/ggml-large-v3-turbo-q5_0.bin`. 최초 1회 권한 3종: Microphone / Input Monitoring / Accessibility.

## Test plan

- [ ] `bash voice-dictation/scripts/toggle.sh` 실행 → `STARTED`/`STOPPED` 출력 + `pgrep -f dictation_daemon.py` 로 상태 일치 확인
- [ ] 오른쪽 Option(⌥) 홀드 → 한/영 발화 → 떼면 활성 창에 transcription paste 확인 (Microphone·Input Monitoring·Accessibility 권한 필요)
- [ ] statusline: 데몬 on 시 🎤 등장, off 시 공백(presence 토글) 확인
- [ ] 마켓플레이스 갱신·플러그인 리로드 후 새 세션에서 voice-dictation 스킬 토글 라우팅 확인
