### PR TITLE
fix(codex): align context table with "Reference over Copy" boundary

### DIFF
--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -23,7 +23,7 @@ Before writing the prompt file, classify available context on two orthogonal axe
 | | Session (already available) | Exploration (needs collection) |
 |---|---|---|
 | **AI-verifiable** | Extract paths, patterns, commands as **Pointers** — codex self-verifies | Provide search hints, entry points — codex self-explores |
-| **User-specific** | Summarize intent, constraints, preferences from current session — **reference-only** | **Blocked** — no collection requests or questions |
+| **User-specific** | Summarize intent, constraints, preferences from current session — **copy-only** | **Blocked** — no collection requests or questions |
 
 **One boundary — Reference over Copy.** Both rows are two faces of the same partition: *re-derivability by the consumer*. Codex is the consumer that cannot re-derive the parent's session context, but CAN re-derive anything reachable by its own tools under `-C DIR`. The AI-verifiable row is what codex re-derives, so pass a **reference** (path / pattern / command); the User-specific row is what it cannot, so **copy** only that into the prompt. Operational test before each item: *"Can codex re-derive this from shared substrate with its own tools?"* — yes → pass a pointer; no → copy it in.
 
@@ -49,7 +49,7 @@ Structure `/tmp/codex_prompt_<suffix>.txt` with these sections:
     - constraints: [limitations, compatibility requirements]
     - preferences: [coding style, library choices, conventions]
 
-Omit empty sections. `## Pointers` enables codex to self-verify; `## Session Context` provides reference-only background without requiring follow-up.
+Omit empty sections. `## Pointers` enables codex to self-verify; `## Session Context` provides copy-only background without requiring follow-up.
 
 ## Image Generation Requests
 


### PR DESCRIPTION
## 요약

브랜치 정리(`clean_gone`) 중 merged `refactor/codex-rederivability-boundary` 워크트리에 남아 있던 **미커밋 수정**을 발견해 정식 반영합니다. "잊은 작업"을 폐기 대신 PR로 복구.

## 변경

`codex-plus/skills/codex/SKILL.md`의 Context Classification 표(User-specific 행)와 Session Context 설명이 `reference-only`로 되어 있었으나, 바로 아래 본문과 모순됩니다:

> the User-specific row is what it cannot [re-derive], so **copy** only that into the prompt

문서가 정의한 경계 용어("Reference over Copy")에 맞춰 두 곳을 `copy-only`로 정합화:

- User-specific 행: `reference-only` → `copy-only`
- Session Context 설명: `reference-only` → `copy-only`

## 맥락

`refactor/codex-rederivability-boundary`(이미 main 병합)의 후속 정합성 수정이었으나 커밋되지 않은 채 워크트리에 잔류. 브랜치 정리 시 force-remove로 손실될 뻔한 것을 살림.
