### PR TITLE
chore(codex-plus): bump version to 2.3.2

### DIFF
--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"


### PR DESCRIPTION
## 요약

`codex-plus` 버전을 `2.3.1` → `2.3.2` (patch)로 올립니다.

## 맥락

직전 머지된 #52(`reference-only` → `copy-only` 컨텍스트 표 정합성 수정)를 patch 릴리스로 반영합니다. 동작 변경 없는 문서 정합성 수정이라 patch.
