### PR TITLE
fix(voice-dictation): paste via key code 9 to survive Korean IME

### DIFF
--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -108,9 +108,12 @@ def _inject(text):
     # 기존 클립보드 보존 → 새 텍스트 복사 → Cmd+V → 잠시 후 복원
     old = subprocess.run(["pbpaste"], capture_output=True, text=True).stdout
     subprocess.run(["pbcopy"], input=text, text=True)
+    # key code 9 (물리 V 키)로 Cmd+V 합성. keystroke "v" 는 문자 'v'를 현재 입력
+    # 소스를 통해 키코드로 번역하는데, 한글 IME 활성 시 'v' 매핑이 없어 키스트로크가
+    # 드롭되어 붙여넣기가 실패함. key code 는 물리 키를 직접 지정해 입력 소스에 무관.
     subprocess.run([
         "osascript", "-e",
-        'tell application "System Events" to keystroke "v" using command down',
+        'tell application "System Events" to key code 9 using command down',
     ])
     time.sleep(0.3)
     subprocess.run(["pbcopy"], input=old, text=True)


### PR DESCRIPTION
## Symptom

When the Korean 2-set IME is the active input source, the voice-dictation daemon transcribes audio correctly but the result never gets pasted into the active window. Paste silently fails with no error.

## Root cause

The daemon pasted via AppleScript `keystroke "v" using command down`. `keystroke` translates the character `'v'` through the **active input source**. The Korean 2-set IME has no `'v'` mapping, so the synthetic Cmd+V keystroke is dropped and the paste never fires.

## Fix

Replace `keystroke "v"` with `key code 9 using command down`. `key code 9` is the **physical V key**, sent independent of the active input source, so Cmd+V works regardless of IME state.

Bumps version `1.0.0` -> `1.0.1`.

## Verification

Verified end-to-end in real 2-set Korean usage: dictation now pastes correctly with the Korean IME active.
