### PR TITLE
feat(remote-spawn): 임의 cwd에 claude --remote-control 백그라운드 spawn 플러그인

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -68,6 +68,11 @@
       "name": "voice-dictation",
       "source": "./voice-dictation",
       "description": "Push-to-talk voice dictation daemon (whisper.cpp) transcribing speech into the active window"
+    },
+    {
+      "name": "remote-spawn",
+      "source": "./remote-spawn",
+      "description": "Spawn a backgrounded `claude --remote-control` session in any directory (tmux-tracked), reachable from the Claude app"
     }
   ]
 }

--- a/remote-spawn/.claude-plugin/plugin.json
+++ b/remote-spawn/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "remote-spawn",
+  "description": "Spawn a backgrounded `claude --remote-control` session in any directory (tmux-tracked), reachable from the Claude app",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/remote-spawn/README.md
+++ b/remote-spawn/README.md
@@ -1,0 +1,28 @@
+# remote-spawn
+
+Spawn a backgrounded `claude --remote-control` session in **any directory**, tracked as a
+tmux session and reachable from the Claude app (claude.ai/code + mobile). No Telegram, no
+bridge — the running session *is* the aperture; voice input comes from the app's own
+dictation.
+
+```bash
+bash scripts/rc-spawn.sh spawn ~/projects/foo        # -> rc-foo, now in the app
+bash scripts/rc-spawn.sh spawn ~/projects/foo api    # custom name -> rc-api
+bash scripts/rc-spawn.sh list                        # running rc-* sessions + dirs
+bash scripts/rc-spawn.sh kill foo                     # SIGTERM + drop tmux session
+```
+
+One tmux session per name (`rc-<name>`), idempotent. The session lives until its claude
+exits (no auto-restart by design).
+
+## Why tmux + ps/SIGTERM
+- **tmux, not nohup/launchd** — `claude --remote-control` is an interactive TUI that wants
+  a PTY, and a tmux server launched from your terminal inherits its TCC grant, so sessions
+  work under TCC-protected dirs (`~/Downloads`, `~/Documents`, `~/Desktop`) where launchd
+  gets `Operation not permitted`.
+- **`ps` + SIGTERM on kill, not `pkill`** — on macOS `pkill -f` can't read claude's full
+  arg string and silently no-ops; `ps -o command` sees it. SIGTERM (not `-9`) lets
+  SessionEnd hooks (e.g. anamnesis memory) flush before exit.
+
+First launch in a never-opened directory may show a one-time folder-trust prompt inside the
+session — `tmux attach -t rc-<name>`, press Enter, detach with `Ctrl-b d`.

--- a/remote-spawn/scripts/rc-spawn.sh
+++ b/remote-spawn/scripts/rc-spawn.sh
@@ -32,9 +32,14 @@ spawn() {
   dir="$(cd "$dir" 2>/dev/null && pwd)" || { echo "ERROR: no such dir: $1" >&2; return 1; }
   [ -n "$name" ] || name="$(basename "$dir")"
   name="$(sanitize "$name")"
+  [ -n "$name" ] || { echo "ERROR: name resolves to empty (dir basename has no usable chars) — pass an explicit name" >&2; return 2; }
   local sess="rc-$name"
   if tmux has-session -t "$sess" 2>/dev/null; then
-    echo "ALREADY-RUNNING $name  (dir: $dir)  attach: tmux attach -t $sess"
+    # report the dir the session is ACTUALLY running in (not the one just asked for),
+    # and flag a basename collision so it isn't a silent no-op.
+    local rdir; rdir="$(tmux display-message -p -t "$sess" '#{session_path}' 2>/dev/null)"
+    echo "ALREADY-RUNNING $name  (running in: ${rdir:-?})  attach: tmux attach -t $sess"
+    [ "$rdir" = "$dir" ] || echo "  note: requested $dir but rc-$name already runs in ${rdir:-?} — pass an explicit name to run a second session"
     return 0
   fi
   # Detached tmux session running claude directly; when claude exits the session ends.
@@ -60,10 +65,24 @@ list() {
 kill_one() {
   local name; name="$(sanitize "$1")"
   [ -n "$name" ] || { echo "usage: rc-spawn.sh kill <name>" >&2; return 2; }
-  local sess="rc-$name" pid found=0
-  pid="$(ps -Ao pid=,command= | grep -E "remote-control --name ${name}([[:space:]]|\$)" | grep -v grep | awk '{print $1}' | head -1)"
-  if [ -n "$pid" ]; then
-    kill "$pid" 2>/dev/null && { echo "SIGTERM -> claude pid $pid ($name)"; found=1; sleep 1; }
+  local sess="rc-$name" pids pid found=0 i
+  # sanitize() allows '.', the only ERE metachar a name can carry — escape it so
+  # `kill my.proj` can't also match `--name myXproj` (a different session).
+  local rname="${name//./\\.}"
+  # SIGTERM every matching claude, not just the first: a collision or a half-finished
+  # earlier teardown can leave more than one process on the same name.
+  pids="$(ps -Ao pid=,command= | grep -E "remote-control --name ${rname}([[:space:]]|\$)" | grep -v grep | awk '{print $1}')"
+  for pid in $pids; do
+    kill "$pid" 2>/dev/null && { echo "SIGTERM -> claude pid $pid ($name)"; found=1; }
+  done
+  # claude exiting cleanly ends its own tmux session (see spawn), so wait for that
+  # instead of racing it — gives SessionEnd hooks (anamnesis) time to flush. Only
+  # hard-drop the session if it outlives the bounded wait (~15s).
+  if [ "$found" = 1 ]; then
+    for i in $(seq 1 30); do
+      tmux has-session -t "$sess" 2>/dev/null || break
+      sleep 0.5
+    done
   fi
   if tmux has-session -t "$sess" 2>/dev/null; then
     tmux kill-session -t "$sess" 2>/dev/null && { echo "dropped tmux $sess"; found=1; }

--- a/remote-spawn/scripts/rc-spawn.sh
+++ b/remote-spawn/scripts/rc-spawn.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Spawn / list / kill backgrounded `claude --remote-control` sessions — one per
+# directory, each tracked as a tmux session `rc-<name>` and reachable from the
+# Claude app (claude.ai/code + mobile). No Telegram, no bridge.
+#
+# Subcommands:
+#   spawn <dir> [name]   start a remote-control session in <dir> (idempotent)
+#   list                 list running rc-* sessions and their dirs
+#   kill  <name>         SIGTERM the claude session, then drop its tmux session
+#
+# WHY tmux (not nohup/launchd): claude --remote-control runs an interactive TUI
+# that wants a PTY, and a tmux server launched from the user's terminal inherits
+# that terminal's TCC grant — so a session can live under TCC-protected dirs
+# (~/Downloads, ~/Documents, ~/Desktop) where launchd/nohup gets
+# "Operation not permitted". (Lesson carried over from the martin supervisor.)
+#
+# WHY ps+SIGTERM on kill (not pkill): on macOS pkill/pgrep can't read claude's
+# full arg string (KERN_PROCARGS), so `pkill -f "remote-control --name X"`
+# silently matches nothing. `ps -o command` does see it. SIGTERM (not -9) lets
+# SessionEnd hooks (e.g. anamnesis memory write) flush before exit.
+
+export TMUX_TMPDIR="${TMUX_TMPDIR:-$HOME/.tmux-sockets}"
+mkdir -p "$TMUX_TMPDIR"
+unset TMUX  # target the tmux daemon, not a nested client, if invoked from inside tmux
+
+# Reduce a path/name to a tmux- and shell-safe token: [A-Za-z0-9._-], no runs of '-'.
+sanitize() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-' | sed 's/--*/-/g; s/^-//; s/-$//'; }
+
+spawn() {
+  local dir="$1" name="$2"
+  [ -n "$dir" ] || { echo "usage: rc-spawn.sh spawn <dir> [name]" >&2; return 2; }
+  dir="$(cd "$dir" 2>/dev/null && pwd)" || { echo "ERROR: no such dir: $1" >&2; return 1; }
+  [ -n "$name" ] || name="$(basename "$dir")"
+  name="$(sanitize "$name")"
+  local sess="rc-$name"
+  if tmux has-session -t "$sess" 2>/dev/null; then
+    echo "ALREADY-RUNNING $name  (dir: $dir)  attach: tmux attach -t $sess"
+    return 0
+  fi
+  # Detached tmux session running claude directly; when claude exits the session ends.
+  tmux new-session -d -s "$sess" -x 220 -y 55 -c "$dir" "claude --remote-control --name $name"
+  echo "STARTED $name  (dir: $dir)"
+  echo "  -> now reachable in the Claude app (claude.ai/code + mobile)"
+  echo "  -> attach: tmux attach -t $sess   |   kill: rc-spawn.sh kill $name"
+  echo "  note: first launch in a never-opened dir may show a one-time folder-trust"
+  echo "        prompt inside the session — attach once, press Enter, detach (Ctrl-b d)."
+}
+
+list() {
+  local out
+  out="$(tmux list-sessions -F '#{session_name}'$'\t''#{session_path}' 2>/dev/null \
+        | awk -F'\t' '$1 ~ /^rc-/ {printf "  %-22s %s\n", substr($1,4), $2}')"
+  if [ -n "$out" ]; then
+    echo "running remote-control sessions:"; printf '%s\n' "$out"
+  else
+    echo "(no rc-* sessions running)"
+  fi
+}
+
+kill_one() {
+  local name; name="$(sanitize "$1")"
+  [ -n "$name" ] || { echo "usage: rc-spawn.sh kill <name>" >&2; return 2; }
+  local sess="rc-$name" pid found=0
+  pid="$(ps -Ao pid=,command= | grep -E "remote-control --name ${name}([[:space:]]|\$)" | grep -v grep | awk '{print $1}' | head -1)"
+  if [ -n "$pid" ]; then
+    kill "$pid" 2>/dev/null && { echo "SIGTERM -> claude pid $pid ($name)"; found=1; sleep 1; }
+  fi
+  if tmux has-session -t "$sess" 2>/dev/null; then
+    tmux kill-session -t "$sess" 2>/dev/null && { echo "dropped tmux $sess"; found=1; }
+  fi
+  [ "$found" = 0 ] && echo "NOT-FOUND $name"
+  return 0
+}
+
+case "${1:-}" in
+  spawn) spawn "${2:-}" "${3:-}";;
+  list)  list;;
+  kill)  kill_one "${2:-}";;
+  *) echo "usage: rc-spawn.sh {spawn <dir> [name] | list | kill <name>}" >&2; exit 2;;
+esac

--- a/remote-spawn/skills/remote-spawn/SKILL.md
+++ b/remote-spawn/skills/remote-spawn/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: remote-spawn
+description: >
+  This skill should be used when the user asks to "spawn a remote-control session",
+  "open this repo/folder in the Claude app", "remote control here", "띄워줘",
+  "이 디렉터리에서 remote-control 켜줘", or to list/kill those sessions. It launches
+  `claude --remote-control` in a chosen directory as a backgrounded tmux session
+  (`rc-<name>`) reachable from claude.ai/code and the mobile app — no Telegram bridge.
+---
+
+# Remote-Control Spawner
+
+Spawn, list, and kill backgrounded `claude --remote-control` sessions — one per
+directory, each a tmux session `rc-<name>` reachable from the Claude app.
+
+Run the script and report the result concisely:
+
+```bash
+# Spawn in a directory (name defaults to the dir's basename)
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> [name]
+
+# List running sessions
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" list
+
+# Kill one by name
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" kill <name>
+```
+
+- `STARTED <name>` → a remote-control session is now live in `<dir>` and appears in
+  the Claude app. Relay the attach/kill hints from the output.
+- `ALREADY-RUNNING <name>` → idempotent; a session for that name already exists.
+- `NOT-FOUND <name>` → nothing matched on kill.
+
+Notes to pass on when relevant:
+- The session lives until its claude exits (no auto-restart by design).
+- First launch in a directory Claude has never opened may show a one-time
+  folder-trust prompt **inside** the tmux session — `tmux attach -t rc-<name>`,
+  press Enter, then detach with `Ctrl-b d`.
+- tmux is used (not nohup/launchd) so sessions work under TCC-protected dirs
+  (`~/Downloads`, `~/Documents`, `~/Desktop`); kill uses `ps`+SIGTERM so SessionEnd
+  hooks (e.g. anamnesis memory) flush before exit.


### PR DESCRIPTION
## 요약
지정한 디렉터리에서 `claude --remote-control` 세션을 tmux로 백그라운드 기동/조회/종료하는 cc-plugin 플러그인. 텔레그램 브리지 없이 세션 자체가 앱(claude.ai/code + 모바일)에서 잡히는 입력 구멍이 된다.

## 설계 근거
- **tmux (nohup/launchd 아님)** — `claude --remote-control`은 PTY를 원하는 TUI이고, 터미널에서 띄운 tmux 서버는 TCC 권한을 상속하므로 `~/Downloads`·`~/Documents` 등 보호 디렉터리에서도 동작 (martin supervisor의 launchd 실패 교훈).
- **kill은 ps+SIGTERM (pkill 아님)** — macOS `pkill -f`가 claude 풀 cmdline을 못 봐 no-op 되는 함정 회피. SIGTERM이라야 SessionEnd 훅(anamnesis 메모리)이 flush된 뒤 종료.
- **멱등** — cwd당 tmux 세션(`rc-<name>`) 하나, 이미 있으면 재기동 안 함. 자동 재시작 루프는 v1 미포함(필요 시 옵트인).

## 변경
- `remote-spawn/` 신규 플러그인 — `plugin.json`, `skills/remote-spawn/SKILL.md`, `scripts/rc-spawn.sh`, `README.md`
- `.claude-plugin/marketplace.json` 등록

## Test plan
- [x] `rc-spawn.sh spawn` — cc-plugin repo에 RC 세션 기동, 프로세스 + "Remote Control active" 확인 (검증 완료)
- [x] `rc-spawn.sh list` — rc-* 세션 목록 노출 확인 (검증 완료)
- [ ] `bash remote-spawn/scripts/rc-spawn.sh kill cc-plugin` — teardown(SIGTERM + tmux 정리) 동작 확인
- [ ] 앱(claude.ai/code + 모바일)에서 cc-plugin 세션 열어 한국어 음성 받아쓰기 품질 실측
- [ ] 플러그인 install/refresh(reload) 후 remote-spawn 스킬이 트리거로 호출되는지 확인
