### PR TITLE
Add make-deck plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,6 +78,11 @@
       "name": "excalidraw-host",
       "source": "./excalidraw-host",
       "description": "Self-host the official open-source Excalidraw whiteboard (clone + Vite dev server, no Docker)"
+    },
+    {
+      "name": "make-deck",
+      "source": "./make-deck",
+      "description": "Generate self-contained HTML slide decks from organized notes (progressive dimension elicitation, bundled layout-catalog skeleton, mascot decorators)"
     }
   ]
 }

--- a/make-deck/.claude-plugin/plugin.json
+++ b/make-deck/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "make-deck",
+  "description": "Generate self-contained HTML slide decks from organized notes. Progressively surfaces audience/difficulty/density/time/scope dimensions, fills a bundled layout-catalog skeleton (10 layouts, 4 narrative ZONEs, clawd mascot decorators), and outputs a single-file deck with inlined assets. Use whenever the user wants to turn notes or content into a presentation, slides, or a deck.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/make-deck/skills/make-deck/SKILL.md
+++ b/make-deck/skills/make-deck/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: make-deck
+description: Generate a self-contained HTML slide deck from organized notes. Use whenever the user wants to turn notes, a doc, or session content into a presentation, slides, or a deck. The skill surfaces the audience/difficulty/density/time/scope dimensions progressively (never an all-at-once panel), fills a bundled layout-catalog skeleton (10 layouts, 4 narrative ZONEs, clawd mascot decorators), derives slide count from talk length, and outputs one portable HTML file with assets inlined.
+---
+
+# Make Deck
+
+Turn an already-organized set of notes into a presentation-ready HTML slide deck.
+
+Invoke with `/make-deck` (optionally `/make-deck <path-to-notes>`) when the user wants
+slides or a deck from content they already have.
+
+This skill is **self-contained and portable**: it carries its own template, mascot assets,
+and dimension reference. It does not depend on any other plugin. The dimension-elicitation
+step below embeds the *method* of progressive reverse-elicitation inline — you run it
+directly, no external protocol call required.
+
+## When to Use
+
+- User has notes / a summary / a doc and wants a slide deck or presentation built from it.
+- User says "make a deck", "turn this into slides", "발표 자료 만들어줘", "슬라이드로".
+
+## Skip When
+
+- The source is raw and unorganized (many transcripts, scattered files). This skill
+  **assumes the notes are already digestible**. If they are not, summarize/organize first
+  (e.g. parallel-summarize into a notes doc), then invoke this skill on the result.
+- The user wants a non-slide artifact (blog post, doc) — use a writing skill instead.
+
+## Inputs
+
+- **Source notes** — a path passed as the argument, a file in context, or pasted content.
+  Treated read-only as the substrate you elicit dimensions from and fill slides with.
+
+## Workflow
+
+```
+READ notes → ELICIT dimensions (progressive) → DERIVE slide count → OUTLINE gate
+  → FILL skeleton → GENERATE self-contained HTML → REFINE (per-slide feedback)
+```
+
+### 1. Read the notes
+
+Read the source. Identify its natural sections — these become candidate slides. Do not
+ask anything yet.
+
+### 2. Elicit dimensions — progressively (inline reverse-elicitation)
+
+Read `references/dimensions.md`. It lists the five dimensions that shape a deck:
+**audience, difficulty/technical-depth, brevity/density, presentation-time, scope/angle.**
+
+Surface them **progressively, grounded in the notes** — this ordering matters and is the
+core method:
+
+1. **Density/form first** — "presentation-core only, or core + a detailed appendix?"
+2. **Then scope/angle** — "faithful to these notes, or reframed toward a goal (which may
+   add or drop content)?" — bundle the audience + difficulty questions here, since they
+   co-determine scope.
+3. **Then time** — "how long is the talk?" → you derive slide count, you don't ask it.
+
+Rules for this step:
+- **Recognition over recall.** Use `AskUserQuestion` with concrete options drawn from the
+  notes, not open prompts. Propose a substrate-cited default for each ("these notes are
+  mostly conceptual, so I'd default to analogy-centric — agree?").
+- **Don't ask all five at once.** One cluster per turn; later clusters can shift based on
+  earlier answers. Audience especially tends to get refined after a first pass — leave room.
+- **Cite the notes** when proposing a value. Every question carries evidence.
+
+### 3. Derive slide count from time
+
+~1 slide per 1.3–1.7 min. 20 min ≈ 12–16 slides. Scale **within** the four ZONEs (grow
+Part 1 / Part 2) using the skeleton's parallel-add convention — never break the ZONE
+structure to hit a number.
+
+### 4. Outline gate (confirm before generating)
+
+Propose a ZONE plan as text: which notes map to which ZONE → slide → layout, with the
+derived slide count. Get a yes before generating the full deck. This is cheap insurance
+against regenerating 14 slides on a wrong premise.
+
+### 5. Fill the skeleton
+
+Copy `assets/templates/deck-skeleton.html` to the output path, then fill it. **Read the
+skeleton's own top comment and per-slide `[LAYOUT N/10]` comments first** — they are the
+authoritative convention reference (10 layout classes, 4 ZONEs, mascot rule, talk cues,
+parallel-add anchors, color tokens). Key points:
+
+- **Keep the layout classes**; replace only the `{{...}}` placeholder content.
+- **Every `<section class="slide">` gets one mascot** `<object class="deco" ...>` right
+  after `chrome-tl` (see the skeleton's mascot convention block). Pick a pose from
+  `assets/clawd-*.svg` that fits the slide's tone.
+- Add slides by inserting before a ZONE's closing `<!-- ══ /ZONE: X ══ -->` anchor.
+- Fill `talk` presenter cues, `chrome-bl` labels, `chrome-br` counts.
+- Recolor via the three `:root` tokens (`--blue/--purple/--amber`) only if the user wants.
+
+### 6. Generate a self-contained single file
+
+Output one portable HTML file. **Inline each referenced mascot SVG as a data-URI** so the
+deck needs no sibling files: replace `<object data="../clawd-X.svg">` with
+`<object data="data:image/svg+xml;base64,...">` (base64 of that SVG), or inline the `<svg>`
+directly. User-supplied images (`{{...png}}` placeholders) stay as the user's own asset
+references unless the user wants them inlined too.
+
+Default output path: alongside the notes, named `YYYY-MM-DD-<topic>-deck.html`.
+
+### 7. Refine loop
+
+Present the deck. Take per-slide feedback ("drop slide 14", "I don't get slide 11") and
+revise in place. Decks converge through pruning — expect it.
+
+## Skeleton reference
+
+The bundled template (`assets/templates/deck-skeleton.html`) is a layout catalog: one
+example slide per layout, with narrative-function comments. Its 10 layouts —
+`lay-cover / lay-statement / lay-divider / lay-split(.rev) / lay-twocol / lay-clips /
+lay-list / lay-cue / lay-bleed / lay-checklist` — map onto 4 ZONEs:
+
+- **오프닝** — cover, one-line thesis, headline collage, audience cue
+- **Part 1 (왜)** — concept/why: split, list, two-column contrast
+- **Part 2 (실습/본문)** — divider transition, full-bleed impact, worked examples
+- **Part 3 + 마무리** — closing dialogue cue, summary checklist
+
+Treat the 4 ZONEs as the fixed methodology; swap only the topic and content.
+
+## Assets
+
+- `assets/templates/deck-skeleton.html` — the layout-catalog template (fill, don't restructure).
+- `assets/clawd-*.svg` — 19 normalized mascot poses (viewBox `-15 -25 45 45`).
+- `references/dimensions.md` — the five elicitation dimensions + pose guide.

--- a/make-deck/skills/make-deck/assets/clawd-about-hero.svg
+++ b/make-deck/skills/make-deck/assets/clawd-about-hero.svg
@@ -1,0 +1,202 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="crispEdges">
+  <!-- Clawd About hero: "Deal with it" intro → freeze at 55% (cool pose, post-second-sparkle, hands not yet returning).
+       Adapted from themes/clawd/assets/source/clawd-experiment-put-on-v4.svg:
+         - 8s infinite → 4.4s forwards (plays once, freezes at terminal keyframe)
+         - Keyframes past 55% removed; remaining remapped from 0-55% → 0-100%
+         - Wrapped in <g class="breath-wrap"> for subtle breathing after intro
+         - Wrapped in <g id="shake-slot"> outermost — JS adds .shake class on click
+  -->
+
+  <defs>
+    <style>
+      .arm-right-motion {
+        transform-origin: 13px 10px;
+        animation: arm-right 4.4s ease-in-out forwards;
+      }
+      .arm-left-motion {
+        transform-origin: 2px 10px;
+        animation: arm-left 4.4s ease-in-out forwards;
+      }
+      .glasses-fly {
+        transform-origin: 0 0;
+        animation: glasses-fly 4.4s ease-in-out forwards;
+      }
+      .mood {
+        transform-origin: 7.5px 13px;
+        animation: mood 4.4s ease-in-out forwards;
+      }
+      .shadow-fade {
+        animation: shadow-fade 4.4s ease-in-out forwards;
+      }
+      .sparkle-near {
+        transform-origin: 2.5px 6.5px;
+        animation: sparkle-near 4.4s ease-in-out forwards;
+      }
+      .sparkle-far {
+        transform-origin: 3.5px 4.5px;
+        animation: sparkle-far 4.4s ease-in-out forwards;
+      }
+
+      /* Breath: kick in after intro completes; gentle infinite up-down */
+      .breath-wrap {
+        animation: breath 4s infinite ease-in-out;
+        animation-delay: 4.4s;
+      }
+      @keyframes breath {
+        0%, 100% { transform: translateY(0); }
+        50%      { transform: translateY(-0.3px); }
+      }
+
+      /* Shake: JS toggles .shake on click; animationend removes the class */
+      .shake-slot {
+        transform-origin: 7.5px 10px;
+      }
+      .shake-slot.shake {
+        animation: shake 0.4s ease-in-out;
+      }
+      @keyframes shake {
+        0%, 100% { transform: rotate(0); }
+        20%      { transform: rotate(-3deg); }
+        60%      { transform: rotate(3deg); }
+        80%      { transform: rotate(-2deg); }
+      }
+
+      /* Right arm: idle → raise → hold → cool pose (freeze at translate(0.5,1)) */
+      @keyframes arm-right {
+        0%, 9%    { transform: none; }
+        15%, 33%  { transform: translateY(-3px) rotate(-90deg); }
+        45%, 73%  { transform: translate(-1px, -1px); }
+        82%, 100% { transform: translate(0.5px, 1px); }
+      }
+
+      /* Left arm: idle → hold → cool pose (freeze at translate(-0.5,1)) */
+      @keyframes arm-left {
+        0%, 27%   { transform: none; }
+        45%, 73%  { transform: translate(1px, -1px); }
+        82%, 100% { transform: translate(-0.5px, 1px); }
+      }
+
+      /* Glasses: invisible → summon → fly to face → display (freeze at translate(1.325,7.375) scale(0.65)) */
+      @keyframes glasses-fly {
+        0%, 15%   { transform: translate(10.15px, 3.25px) scale(0.3); opacity: 0; }
+        22%, 33%  { transform: translate(10.15px, 3.25px) scale(0.3); opacity: 1; }
+        55%, 100% { transform: translate(1.325px, 7.375px) scale(0.65); opacity: 1; }
+      }
+
+      /* Mood: single head shake mid-intro → cool pose tilt (freeze at +1deg) */
+      @keyframes mood {
+        0%, 55%   { transform: rotate(0deg); }
+        60%       { transform: rotate(1deg); }
+        65%       { transform: rotate(-1deg); }
+        73%       { transform: rotate(0deg); }
+        82%, 100% { transform: rotate(1deg); }
+      }
+
+      /* Hand shadows: visible only during hold periods */
+      @keyframes shadow-fade {
+        0%, 40%   { opacity: 0; }
+        51%, 76%  { opacity: 1; }
+        87%, 100% { opacity: 0; }
+      }
+
+      /* Sparkle near (small, glasses corner): flashes mid-pose then fades */
+      @keyframes sparkle-near {
+        0%, 73%   { opacity: 0; transform: scale(0.4); }
+        75%       { opacity: 1; transform: scale(0.7); }
+        78%       { opacity: 0.7; transform: scale(0.5); }
+        80%, 100% { opacity: 0; transform: scale(0.4); }
+      }
+
+      /* Sparkle far (big, upper-left void): peaks late, faded before freeze */
+      @keyframes sparkle-far {
+        0%, 84%   { opacity: 0; transform: scale(0.5); }
+        87%       { opacity: 1; transform: scale(1.4); }
+        91%       { opacity: 0.9; transform: scale(1.2); }
+        96%, 100% { opacity: 0; transform: scale(0.6); }
+      }
+    </style>
+
+    <clipPath id="inside-torso">
+      <rect x="2" y="6" width="11" height="7"/>
+    </clipPath>
+  </defs>
+
+  <g class="shake-slot" id="shake-slot">
+    <rect id="ground-shadow" x="3" y="15" width="9" height="1" fill="#000000" opacity="0.5"/>
+
+    <g class="breath-wrap">
+      <g class="mood">
+        <g id="master-group">
+
+          <g id="legs" fill="#DE886D">
+            <rect x="3"  y="13" width="1" height="2"/>
+            <rect x="5"  y="13" width="1" height="2"/>
+            <rect x="9"  y="13" width="1" height="2"/>
+            <rect x="11" y="13" width="1" height="2"/>
+          </g>
+
+          <rect x="2" y="6" width="11" height="7" fill="#DE886D"/>
+
+          <g clip-path="url(#inside-torso)" class="shadow-fade">
+            <g class="arm-left-motion">
+              <rect x="0" y="9" width="2.4" height="2.4" fill="#A85A3A"/>
+            </g>
+            <g class="arm-right-motion">
+              <rect x="12.6" y="9" width="2.4" height="2.4" fill="#A85A3A"/>
+            </g>
+          </g>
+
+          <g fill="#000000">
+            <rect x="4"  y="8" width="1" height="2"/>
+            <rect x="10" y="8" width="1" height="2"/>
+          </g>
+
+          <g class="glasses-fly">
+            <g fill="#000000">
+              <rect x="0"  y="0" width="19" height="1"/>
+              <rect x="0"  y="1" width="8"  height="1"/>
+              <rect x="11" y="1" width="8"  height="1"/>
+              <rect x="0"  y="2" width="8"  height="1"/>
+              <rect x="11" y="2" width="8"  height="1"/>
+              <rect x="1"  y="3" width="6"  height="1"/>
+              <rect x="12" y="3" width="6"  height="1"/>
+              <rect x="2"  y="4" width="4"  height="1"/>
+              <rect x="13" y="4" width="4"  height="1"/>
+            </g>
+            <g fill="#FFFFFF">
+              <rect x="5"  y="1" width="1" height="1"/>
+              <rect x="4"  y="2" width="1" height="1"/>
+              <rect x="16" y="1" width="1" height="1"/>
+              <rect x="15" y="2" width="1" height="1"/>
+            </g>
+          </g>
+
+          <g class="arm-left-motion">
+            <rect x="0" y="9" width="2" height="2" fill="#DE886D"/>
+          </g>
+
+          <g class="arm-right-motion">
+            <rect x="13" y="9" width="2" height="2" fill="#DE886D"/>
+          </g>
+
+          <g class="sparkle-near" fill="#FFFFFF">
+            <rect x="2" y="6" width="1" height="1"/>
+            <rect x="2" y="5" width="1" height="1"/>
+            <rect x="2" y="7" width="1" height="1"/>
+            <rect x="1" y="6" width="1" height="1"/>
+            <rect x="3" y="6" width="1" height="1"/>
+          </g>
+
+          <g class="sparkle-far" fill="#FFFFFF">
+            <rect x="3" y="4" width="1" height="1"/>
+            <rect x="3" y="3" width="1" height="1"/>
+            <rect x="3" y="5" width="1" height="1"/>
+            <rect x="2" y="4" width="1" height="1"/>
+            <rect x="4" y="4" width="1" height="1"/>
+          </g>
+
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-error.svg
+++ b/make-deck/skills/make-deck/assets/clawd-error.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <defs>
+    <style>
+      .body-exhausted {
+        transform-origin: 7.5px 15px;
+        animation: heavy-breathe 2.5s infinite ease-in-out;
+      }
+      .arm-fan {
+        transform-origin: 14px 10px;
+        animation: fan-self 0.4s infinite alternate ease-in-out;
+      }
+      .smoke {
+        opacity: 0;
+        animation: puff-smoke 3s infinite ease-out;
+      }
+      .sm1 { animation-delay: 0s; }
+      .sm2 { animation-delay: 1s; }
+      .sm3 { animation-delay: 2s; }
+
+      /* Error warning flash */
+      .error-warning {
+        animation: error-flash 0.8s infinite ease-in-out;
+      }
+
+      @keyframes heavy-breathe {
+        0%, 100% { transform: scale(1, 1) translateY(0); }
+        50% { transform: scale(1.05, 0.9) translateY(1.5px); }
+      }
+      @keyframes fan-self {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(-60deg); }
+      }
+      @keyframes puff-smoke {
+        0% { transform: translate(7.5px, 6px) scale(0.5); opacity: 0; }
+        20% { opacity: 0.6; }
+        100% { transform: translate(7.5px, -15px) scale(2); opacity: 0; }
+      }
+      @keyframes error-flash {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.15; }
+      }
+    </style>
+    <g id="smoke-puff">
+      <rect x="-1" y="-1" width="2" height="2" fill="#B0BEC5" rx="0.5"/>
+      <rect x="0" y="-2" width="2" height="2" fill="#CFD8DC" rx="0.5"/>
+    </g>
+  </defs>
+
+  <rect id="ground-shadow" x="-1" y="15" width="17" height="1" fill="#000000" opacity="0.5"/>
+
+  <!-- Smoke -->
+  <g>
+    <use href="#smoke-puff" class="smoke sm1"/>
+    <use href="#smoke-puff" class="smoke sm2" transform="translate(-2, 0)"/>
+    <use href="#smoke-puff" class="smoke sm3" transform="translate(2, 0)"/>
+  </g>
+
+  <g class="body-exhausted">
+    <!-- Sploot Legs -->
+    <g fill="#DE886D">
+      <rect x="3" y="9" width="1" height="1"/>
+      <rect x="5" y="9" width="1" height="1"/>
+      <rect x="9" y="9" width="1" height="1"/>
+      <rect x="11" y="9" width="1" height="1"/>
+    </g>
+
+    <!-- Torso Sploot -->
+    <g fill="#DE886D">
+      <rect x="1" y="10" width="13" height="5"/>
+      <rect x="-1" y="13" width="2" height="2"/>
+    </g>
+
+    <!-- Fanning Arm (closer to body) -->
+    <g class="arm-fan">
+      <rect x="13" y="11" width="2" height="2" fill="#DE886D"/>
+    </g>
+
+    <!-- XX Eyes -->
+    <g fill="#000000">
+      <!-- Left X -->
+      <rect x="3" y="12" width="0.6" height="2.2" transform="rotate(45 3.3 13.1)"/>
+      <rect x="3" y="12" width="0.6" height="2.2" transform="rotate(-45 3.3 13.1)"/>
+      <!-- Right X -->
+      <rect x="10" y="12" width="0.6" height="2.2" transform="rotate(45 10.3 13.1)"/>
+      <rect x="10" y="12" width="0.6" height="2.2" transform="rotate(-45 10.3 13.1)"/>
+    </g>
+  </g>
+
+  <!-- Error Warning (flashing) -->
+  <g class="error-warning">
+    <!-- Error text only -->
+    <text x="7.5" y="6" text-anchor="middle" font-family="'Söhne', 'Helvetica Neue', Arial, sans-serif" font-size="3.5" font-weight="700" fill="#FF3B30">ERROR</text>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-headphones-groove.svg
+++ b/make-deck/skills/make-deck/assets/clawd-headphones-groove.svg
@@ -1,0 +1,194 @@
+<!--
+  clawd-experiment-headphones-groove-v6.svg
+  v5 基础上鹿鹿两个微调:
+  1. 眼睛 V 字 y +0.5 (顶 8->8.5 底 9->9.5) — v5 位置偏高
+  2. 耳罩压缩 0.78 -> 0.85 (缩量 22%->15%), 过冲 1.04 -> 1.02 一起收 — v5 压太多
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <defs>
+    <style>
+      .shadow-sway {
+        transform-box: fill-box;
+        transform-origin: 50% 50%;
+        animation: shadow-sway 1.6s infinite ease-in-out;
+      }
+
+      .body-sway {
+        transform-origin: 7.5px 13px;
+        animation: body-sway 1.6s infinite ease-in-out;
+      }
+
+      .leg-left-inner,
+      .leg-left-outer,
+      .leg-right-inner,
+      .leg-right-outer {
+        transform-box: fill-box;
+        transform-origin: 50% 0%;
+      }
+      .leg-left-inner  { animation: leg-left-inner  1.6s infinite ease-in-out; }
+      .leg-left-outer  { animation: leg-left-outer  1.6s infinite ease-in-out; }
+      .leg-right-inner { animation: leg-right-inner 1.6s infinite ease-in-out; }
+      .leg-right-outer { animation: leg-right-outer 1.6s infinite ease-in-out; }
+
+      .arm-left-dance  {
+        transform-box: fill-box;
+        transform-origin: 100% 0%;
+        animation: arm-left-dance 1.6s infinite ease-in-out;
+      }
+      .arm-right-dance {
+        transform-box: fill-box;
+        transform-origin: 0% 0%;
+        animation: arm-right-dance 1.6s infinite ease-in-out;
+      }
+
+      /* 耳罩 squeeze: 拍点挤压, 中性回弹过冲 */
+      .earcup-left {
+        transform-box: fill-box;
+        transform-origin: 100% 50%; /* 右边缘 = 内侧, 朝身体方向收 */
+        animation: earcup-squeeze 1.6s infinite ease-in-out;
+      }
+      .earcup-right {
+        transform-box: fill-box;
+        transform-origin: 0% 50%;   /* 左边缘 = 内侧 */
+        animation: earcup-squeeze 1.6s infinite ease-in-out;
+      }
+
+      .note-left  { animation: note-left  1.6s infinite ease-out; }
+      .note-right { animation: note-right 1.6s infinite ease-out; }
+
+      @keyframes shadow-sway {
+        0%, 100% { transform: translateX(0) scaleX(1); opacity: 0.5; }
+        22%, 30% { transform: translateX(-0.5px) scaleX(0.85); opacity: 0.45; }
+        50%      { transform: translateX(0) scaleX(1); opacity: 0.5; }
+        70%, 78% { transform: translateX(0.5px) scaleX(0.85); opacity: 0.45; }
+      }
+
+      @keyframes body-sway {
+        0%, 100% { transform: rotate(0deg) translateY(0); }
+        22%, 30% { transform: rotate(-6deg) translateY(0.3px); }
+        50%      { transform: rotate(0deg) translateY(-0.2px); }
+        70%, 78% { transform: rotate(6deg) translateY(0.3px); }
+      }
+
+      @keyframes leg-right-inner {
+        0%, 100% { transform: rotate(0deg) translateY(0); }
+        22%, 30% { transform: rotate(-12deg) translateY(-0.2px); }
+        50%, 70%, 78% { transform: rotate(0deg) translateY(0); }
+      }
+      @keyframes leg-right-outer {
+        0%, 100% { transform: rotate(0deg) translateY(0); }
+        22%, 30% { transform: rotate(-22deg) translateY(-0.3px); }
+        50%, 70%, 78% { transform: rotate(0deg) translateY(0); }
+      }
+      @keyframes leg-left-inner {
+        0%, 22%, 30%, 50%, 100% { transform: rotate(0deg) translateY(0); }
+        70%, 78% { transform: rotate(12deg) translateY(-0.2px); }
+      }
+      @keyframes leg-left-outer {
+        0%, 22%, 30%, 50%, 100% { transform: rotate(0deg) translateY(0); }
+        70%, 78% { transform: rotate(22deg) translateY(-0.3px); }
+      }
+
+      @keyframes arm-left-dance {
+        0%, 100% { transform: rotate(0deg); }
+        22%, 30% { transform: rotate(-30deg); }
+        50%      { transform: rotate(0deg); }
+        70%, 78% { transform: rotate(20deg); }
+      }
+      @keyframes arm-right-dance {
+        0%, 100% { transform: rotate(0deg); }
+        22%, 30% { transform: rotate(-20deg); }
+        50%      { transform: rotate(0deg); }
+        70%, 78% { transform: rotate(30deg); }
+      }
+
+      /* 耳罩: 拍点 (左压/右压) 都 squeeze 0.78, 中性 50% 回弹过冲 1.04 */
+      @keyframes earcup-squeeze {
+        0%, 100% { transform: scaleX(1); }
+        22%, 30% { transform: scaleX(0.85); }
+        50%      { transform: scaleX(1.02); }
+        70%, 78% { transform: scaleX(0.85); }
+      }
+
+      @keyframes note-left {
+        0%, 14%, 42%, 100% { opacity: 0; transform: translate(0, 0); }
+        22%                { opacity: 1; transform: translate(-0.4px, -1.2px); }
+        38%                { opacity: 0; transform: translate(-1.6px, -3.5px); }
+      }
+      @keyframes note-right {
+        0%, 62%, 82%, 100% { opacity: 0; transform: translate(0, 0); }
+        70%                { opacity: 1; transform: translate(0.4px, -1.2px); }
+        78%                { opacity: 0; transform: translate(1.6px, -3.5px); }
+      }
+    </style>
+
+    <g id="music-note" fill="#FFE066">
+      <rect x="0" y="2" width="1" height="1"/>
+      <rect x="1" y="0" width="1" height="3"/>
+      <rect x="2" y="0" width="1" height="1"/>
+    </g>
+  </defs>
+
+  <rect class="shadow-sway" x="3" y="15" width="9" height="1" fill="#000000"/>
+
+  <g fill="#DE886D">
+    <rect class="leg-left-outer"  x="3"  y="13" width="1" height="2"/>
+    <rect class="leg-left-inner"  x="5"  y="13" width="1" height="2"/>
+    <rect class="leg-right-inner" x="9"  y="13" width="1" height="2"/>
+    <rect class="leg-right-outer" x="11" y="13" width="1" height="2"/>
+  </g>
+
+  <g class="body-sway">
+    <rect x="2" y="6" width="11" height="7" fill="#DE886D"/>
+
+    <!-- 头带 (不参与 squeeze, 只跟随 body-sway) -->
+    <g fill="#1D5C83">
+      <rect x="4.9"   y="2.85" width="5.05" height="0.75"/>
+      <rect x="4.46"  y="2.93" width="0.75" height="0.75"/>
+      <rect x="9.66"  y="2.93" width="0.75" height="0.75"/>
+      <rect x="4.03"  y="3.1"  width="0.75" height="0.75"/>
+      <rect x="10.11" y="3.09" width="0.75" height="0.75"/>
+      <rect x="3.59"  y="3.34" width="0.75" height="0.75"/>
+      <rect x="10.57" y="3.33" width="0.75" height="0.75"/>
+      <rect x="3.15"  y="3.63" width="0.75" height="0.75"/>
+      <rect x="11.02" y="3.61" width="0.75" height="0.75"/>
+      <rect x="2.71"  y="3.98" width="0.75" height="0.75"/>
+      <rect x="11.48" y="3.96" width="0.75" height="0.75"/>
+      <rect x="2.28"  y="4.37" width="0.75" height="0.75"/>
+      <rect x="11.94" y="4.34" width="0.75" height="0.75"/>
+      <rect x="1.84"  y="4.82" width="0.75" height="0.75"/>
+      <rect x="12.39" y="4.78" width="0.75" height="0.75"/>
+      <rect x="1.4"   y="5.3"  width="0.75" height="0.75"/>
+      <rect x="12.85" y="5.25" width="0.75" height="0.75"/>
+    </g>
+
+    <!-- 左耳罩 (三层) -->
+    <g class="earcup-left">
+      <rect x="0.2" y="7"   width="0.6" height="2.4"  fill="#1D5C83"/>
+      <rect x="0.8" y="6.5" width="0.6" height="3.25" fill="#256891"/>
+      <rect x="1.4" y="6"   width="0.6" height="4.05" fill="#2E7AA8"/>
+    </g>
+
+    <!-- 右耳罩 (三层) -->
+    <g class="earcup-right">
+      <rect x="14.2" y="7"   width="0.6" height="2.4"  fill="#1D5C83"/>
+      <rect x="13.6" y="6.5" width="0.6" height="3.25" fill="#256891"/>
+      <rect x="13"   y="6"   width="0.6" height="4.05" fill="#2E7AA8"/>
+    </g>
+
+    <g class="arm-left-dance">
+      <rect x="-1" y="9" width="2" height="2" fill="#DE886D"/>
+    </g>
+    <g class="arm-right-dance">
+      <rect x="14" y="9" width="2" height="2" fill="#DE886D"/>
+    </g>
+
+    <g fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="3.5,8.5 4.5,9.5 5.5,8.5"/>
+      <polyline points="9.5,8.5 10.5,9.5 11.5,8.5"/>
+    </g>
+  </g>
+
+  <g transform="translate(-5 4)"><g class="note-left"><use href="#music-note"/></g></g>
+  <g transform="translate(15 4)"><g class="note-right"><use href="#music-note"/></g></g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-idle-bubble.svg
+++ b/make-deck/skills/make-deck/assets/clawd-idle-bubble.svg
@@ -1,0 +1,180 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="crispEdges">
+  <!-- 吹泡泡 v8
+       v7 反馈: 整体 ok, 但眼睛回到正中后再眨一次眼更好
+       v8 修正: eyes-anim 加一个 96% 眨眼帧 (在 (0, 0) 正中位置) -->
+
+  <style>
+    @keyframes body-squash {
+      0%, 30%   { transform: scaleY(1); }
+      36%       { transform: scaleY(0.93); }
+      42%       { transform: scaleY(1.05); }
+      50%, 100% { transform: scaleY(1); }
+    }
+    .body-squash {
+      transform-origin: 7.5px 15px;
+      animation: body-squash 4.5s linear infinite;
+    }
+
+    /* === 眼睛: 复合 translate + scaleY, 含双眨眼 (88% pop 后 + 96% 回正后) === */
+    @keyframes eyes-anim {
+      0%, 6%    { transform: translate(0px, 0px) scaleY(1); }
+      18%, 30%  { transform: translate(1px, 0px) scaleY(1); }
+      34%       { transform: translate(1px, 0px) scaleY(0.5); }    /* 鼓气眯眼 */
+      42%, 46%  { transform: translate(1px, 0px) scaleY(1); }
+      66%, 86%  { transform: translate(1.5px, -0.5px) scaleY(1); }/* 追随主泡 + 看副泡 pop */
+      88%       { transform: translate(1.5px, -0.5px) scaleY(0.1); }/* 第一次眨眼 (响应 pop) */
+      90%       { transform: translate(1.5px, -0.5px) scaleY(1); } /* 睁开 */
+      94%       { transform: translate(0px, 0px) scaleY(1); }       /* 回到正中 */
+      96%       { transform: translate(0px, 0px) scaleY(0.1); }     /* 第二次眨眼 (回正后) */
+      98%, 100% { transform: translate(0px, 0px) scaleY(1); }       /* 睁开 + hold to loop */
+    }
+    .eyes-anim {
+      transform-origin: 7.5px 9px;
+      animation: eyes-anim 4.5s linear infinite;
+    }
+
+    @keyframes arm-right-out {
+      0%, 6%    { transform: translate(0px, 0px); }
+      18%, 86%  { transform: translate(0.45px, 0.55px); }
+      94%, 100% { transform: translate(0px, 0px); }
+    }
+    .arm-right-out { animation: arm-right-out 4.5s linear infinite; }
+
+    @keyframes arm-left-down {
+      0%, 6%    { transform: translate(0px, 0px); }
+      18%, 86%  { transform: translate(0px, 1px); }
+      94%, 100% { transform: translate(0px, 0px); }
+    }
+    .arm-left-down { animation: arm-left-down 4.5s linear infinite; }
+
+    @keyframes wand-appear {
+      0%, 16%   { opacity: 0; transform: scale(0.5); }
+      26%, 86%  { opacity: 1; transform: scale(1); }
+      92%, 100% { opacity: 0; transform: scale(0.5); }
+    }
+    .wand-appear { animation: wand-appear 4.5s linear infinite; }
+
+    @keyframes frame-puff {
+      0%, 30%   { transform: scale(1); }
+      36%       { transform: scale(1.08); }
+      42%       { transform: scale(0.95); }
+      50%, 100% { transform: scale(1); }
+    }
+    .frame-puff { animation: frame-puff 4.5s linear infinite; }
+
+    @keyframes bubble1-life {
+      0%, 42%   { opacity: 0; transform: translate(0px, 0px) scale(0); }
+      46%       { opacity: 1; transform: translate(0px, -0.3px) scale(0.3); }
+      52%       { opacity: 1; transform: translate(0.5px, -1.5px) scale(0.5); }
+      58%       { opacity: 1; transform: translate(1.5px, -3.5px) scale(0.7); }
+      64%       { opacity: 1; transform: translate(3px, -6px) scale(0.92); }
+      68%       { opacity: 1; transform: translate(4.1px, -8.45px) scale(1); }
+      70%       { opacity: 0.6; transform: translate(4.1px, -8.45px) scale(1.2); }
+      72%, 99%  { opacity: 0; transform: translate(4.1px, -8.45px) scale(1.4); }
+      100%      { opacity: 0; transform: translate(0px, 0px) scale(0); }
+    }
+    .bubble1-life { animation: bubble1-life 4.5s linear infinite; }
+
+    @keyframes bubble2-life {
+      0%, 58%   { opacity: 0; transform: translate(0px, 0px) scale(0); }
+      62%       { opacity: 1; transform: translate(0px, -0.3px) scale(0.3); }
+      68%       { opacity: 1; transform: translate(0.8px, -1.3px) scale(0.5); }
+      74%       { opacity: 1; transform: translate(2.5px, -3px) scale(0.65); }
+      80%       { opacity: 1; transform: translate(5px, -4.8px) scale(0.85); }
+      84%       { opacity: 1; transform: translate(7.1px, -6.3px) scale(1); }
+      86%       { opacity: 0.5; transform: translate(7.1px, -6.3px) scale(1.2); }
+      88%, 99%  { opacity: 0; transform: translate(7.1px, -6.3px) scale(1.4); }
+      100%      { opacity: 0; transform: translate(0px, 0px) scale(0); }
+    }
+    .bubble2-life { animation: bubble2-life 4.5s linear infinite; }
+
+    @keyframes pop-flash1 {
+      0%, 68%   { opacity: 0; transform: scale(0); }
+      70%       { opacity: 1; transform: scale(1); }
+      73%, 100% { opacity: 0; transform: scale(0); }
+    }
+    .pop-flash1 { animation: pop-flash1 4.5s linear infinite; }
+
+    @keyframes pop-flash2 {
+      0%, 84%   { opacity: 0; transform: scale(0); }
+      86%       { opacity: 1; transform: scale(1); }
+      89%, 100% { opacity: 0; transform: scale(0); }
+    }
+    .pop-flash2 { animation: pop-flash2 4.5s linear infinite; }
+  </style>
+
+  <rect id="ground-shadow" x="3" y="15" width="9" height="1" fill="#000000" opacity="0.5"/>
+
+  <g id="master-group">
+    <g class="body-squash">
+      <g fill="#DE886D">
+        <rect x="2" y="6" width="11" height="7"/>
+        <rect class="arm-left-down" x="0" y="9" width="2" height="2"/>
+        <rect x="3" y="13" width="1" height="2"/>
+        <rect x="5" y="13" width="1" height="2"/>
+        <rect x="9" y="13" width="1" height="2"/>
+        <rect x="11" y="13" width="1" height="2"/>
+      </g>
+      <g class="eyes-anim" fill="#000000">
+        <rect x="4" y="8" width="1" height="2"/>
+        <rect x="10" y="8" width="1" height="2"/>
+      </g>
+    </g>
+
+    <g class="arm-right-out">
+      <rect x="13" y="9" width="2" height="2" fill="#DE886D"/>
+    </g>
+
+    <g transform="translate(14.45 10.55)">
+      <g class="wand-appear">
+        <rect x="0.06" y="-2.075" width="0.8" height="2.6" rx="0.4" fill="#3A2926"/>
+        <g transform="translate(0.45 -3.3)" shape-rendering="auto">
+          <g class="frame-puff">
+            <rect x="-1.275" y="-1.275" width="2.55" height="2.55" rx="0.42"
+                  fill="none" stroke="#3A2926" stroke-width="0.68" stroke-linejoin="round"/>
+            <rect x="-0.235" y="-0.645" width="0.82" height="0.82" rx="0.22"
+                  fill="none" stroke="#E8D8CF" stroke-width="0.24" opacity="0.9"/>
+          </g>
+        </g>
+      </g>
+    </g>
+
+    <g transform="translate(14.9 7.25)" shape-rendering="auto">
+      <g class="bubble1-life">
+        <circle r="3.05" fill="#F7FFFF" fill-opacity="0.12" stroke="#C7E6E8" stroke-width="0.24"/>
+        <circle r="2.72" fill="none" stroke="#FFFDF6" stroke-width="0.16" opacity="0.58"/>
+        <rect x="-1.75" y="-1.75" width="0.85" height="0.85" fill="#FFFDF6" opacity="0.9" shape-rendering="crispEdges"/>
+      </g>
+    </g>
+
+    <g transform="translate(14.9 7.25)" shape-rendering="auto">
+      <g class="bubble2-life">
+        <circle r="1.55" fill="#FFF9F4" fill-opacity="0.13" stroke="#E4D2C8" stroke-width="0.2"/>
+        <circle r="1.32" fill="none" stroke="#FFFDF6" stroke-width="0.12" opacity="0.5"/>
+        <rect x="0.7" y="0.7" width="0.38" height="0.38" fill="#FFF7EF" opacity="0.7" shape-rendering="crispEdges"/>
+      </g>
+    </g>
+
+    <g transform="translate(19 -1.2)">
+      <g class="pop-flash1" fill="#FFFFFF" shape-rendering="crispEdges">
+        <rect x="-3.25" y="-0.25" width="0.5" height="0.5"/>
+        <rect x="2.75" y="-0.25" width="0.5" height="0.5"/>
+        <rect x="-0.25" y="-3.25" width="0.5" height="0.5"/>
+        <rect x="-0.25" y="2.75" width="0.5" height="0.5"/>
+        <rect x="-2.2" y="-2.2" width="0.4" height="0.4" opacity="0.7"/>
+        <rect x="1.8" y="-2.2" width="0.4" height="0.4" opacity="0.7"/>
+        <rect x="-2.2" y="1.8" width="0.4" height="0.4" opacity="0.7"/>
+        <rect x="1.8" y="1.8" width="0.4" height="0.4" opacity="0.7"/>
+      </g>
+    </g>
+
+    <g transform="translate(22 0.95)">
+      <g class="pop-flash2" fill="#FFFFFF" shape-rendering="crispEdges">
+        <rect x="-1.75" y="-0.2" width="0.4" height="0.4"/>
+        <rect x="1.35" y="-0.2" width="0.4" height="0.4"/>
+        <rect x="-0.2" y="-1.75" width="0.4" height="0.4"/>
+        <rect x="-0.2" y="1.35" width="0.4" height="0.4"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-idle-reading.svg
+++ b/make-deck/skills/make-deck/assets/clawd-idle-reading.svg
@@ -1,0 +1,252 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="crispEdges">
+  <defs>
+    <style>
+      /* ═══ 14s story: idle 挥手 → 抓书 + 戴眼镜 → 读 (眼镜下滑+推回) → 书+眼镜同步退场
+         在 clawd-idle-reading.svg 基础上加:
+         1. 圆框眼镜 (跟书同步 fade in/out + 读书慢下滑 + 推回过冲)
+         2. 双手 L 阴影 (clip 到 torso, 跟手 transform 同步, opacity 窗口对齐读书阶段)
+         3. z-order 重排: 手阴影 → 眼睛 → 眼镜 → 书 → 手
+         所有 wrapper 合并成单一 breathe 以方便理解 (原文件 3 个 breathe 效果等价) */
+
+      /* ── Independent loops ── */
+
+      .breathe {
+        transform-origin: 7.5px 13px;
+        animation: breathe 3.2s infinite ease-in-out;
+      }
+      @keyframes breathe {
+        0%, 100% { transform: scale(1, 1) translate(0, 0); }
+        50% { transform: scale(1.02, 0.98) translate(0, 0.5px); }
+      }
+
+      .blink {
+        transform-origin: 7.5px 9px;
+        animation: blink 5s infinite;
+      }
+      @keyframes blink {
+        0%, 6%, 100% { transform: scaleY(1); }
+        3% { transform: scaleY(0.1); }
+      }
+
+      .shadow {
+        transform-origin: 7.5px 15.5px;
+        animation: shadow-breathe 3.2s infinite ease-in-out;
+      }
+      @keyframes shadow-breathe {
+        0%, 100% { transform: scaleX(1); opacity: 0.5; }
+        50% { transform: scaleX(1.03); opacity: 0.47; }
+      }
+
+      /* ── Main 14s story ── */
+
+      .body-nod {
+        animation: body-nod 14s infinite ease-in-out;
+      }
+      @keyframes body-nod {
+        0%, 36%, 44%, 54%, 62%, 100% { transform: translateY(0); }
+        40% { transform: translateY(0.4px); }
+        58% { transform: translateY(0.4px); }
+      }
+
+      .arm-l {
+        transform-origin: 2px 10px;
+        animation: arm-l-anim 14s infinite ease-in-out;
+      }
+      @keyframes arm-l-anim {
+        0%        { transform: translate(0, 0) rotate(0deg); }
+        2.5%      { transform: translate(-0.5px, 0) rotate(25deg); }
+        5%        { transform: translate(0.3px, 0) rotate(-20deg); }
+        7.5%      { transform: translate(-0.5px, 0) rotate(22deg); }
+        10%       { transform: translate(0, 0) rotate(0deg); }
+        18%       { transform: translate(-1px, -1px) rotate(15deg); }
+        26%       { transform: translate(2px, 0) rotate(-5deg); }
+        76%       { transform: translate(2px, 0) rotate(-5deg); }
+        84%       { transform: translate(1px, 2px) rotate(0deg); }
+        92%       { transform: translate(0, 0) rotate(0deg); }
+        100%      { transform: translate(0, 0) rotate(0deg); }
+      }
+
+      .arm-r {
+        animation: arm-r-anim 14s infinite ease-in-out;
+      }
+      @keyframes arm-r-anim {
+        0%, 22%   { transform: translate(0, 0); }
+        28%, 76%  { transform: translate(-1px, 0); }
+        84%, 100% { transform: translate(0, 0); }
+      }
+
+      .book {
+        opacity: 0;
+        transform-origin: 7px 11.5px;
+        animation: book-anim 14s infinite ease-in-out;
+      }
+      @keyframes book-anim {
+        0%, 12%   { opacity: 0; transform: translate(-5px, -2px) scaleX(0.5); }
+        18%       { opacity: 1; transform: translate(-5px, -2px) scaleX(0.5); }
+        26%       { opacity: 1; transform: translate(0, 0) scaleX(1); }
+        76%       { opacity: 1; transform: translate(0, 0) scaleX(1); }
+        84%       { opacity: 0; transform: translate(0, 4px) scaleX(0.8); }
+        100%      { opacity: 0; transform: translate(0, 4px) scaleX(0.8); }
+      }
+
+      .eyes-read {
+        animation: eyes-read 14s infinite ease-in-out;
+      }
+      @keyframes eyes-read {
+        0%, 22%   { transform: translate(0, 0); }
+        30%       { transform: translate(0, 0.5px); }
+        46%       { transform: translate(-0.3px, 0.5px); }
+        60%       { transform: translate(0.3px, 0.5px); }
+        70%       { transform: translate(0, 0.5px); }
+        80%, 100% { transform: translate(0, 0); }
+      }
+
+      /* ── NEW: 圆框眼镜
+         - 0-12% 不可见 (idle 阶段, 还没戴)
+         - 12-18% fade in + 从额头位置 0.5px 上方滑到鼻梁 (跟书出场同步)
+         - 18-72% 戴好读书, 慢慢下滑 0.3px (读累了往鼻头下溜)
+         - 72-78% 推回 -0.1px 过冲 (顺手把眼镜推上去, 配合书要滑下的节点)
+         - 78-84% 稳住到 0
+         - 84-92% fade out + 滑回额头位置 (跟书退场同步) */
+      .glasses {
+        animation: glasses-anim 14s infinite ease-in-out;
+      }
+      @keyframes glasses-anim {
+        0%, 12%   { opacity: 0; transform: translateY(-0.5px); }
+        18%       { opacity: 1; transform: translateY(0); }
+        30%       { opacity: 1; transform: translateY(0); }
+        72%       { opacity: 1; transform: translateY(0.3px); }
+        78%       { opacity: 1; transform: translateY(-0.1px); }
+        84%       { opacity: 1; transform: translateY(0); }
+        92%       { opacity: 0; transform: translateY(-0.5px); }
+        100%      { opacity: 0; transform: translateY(-0.5px); }
+      }
+
+      /* ── NEW: 手阴影 opacity 窗口 (避免 idle 大挥时阴影闪烁)
+         - 左手 22% fade in (手快抓到书时), 84% fade out (随书下滑时)
+         - 右手 26% fade in (右手 nudge 进 torso 前), 84% fade out */
+      .shadow-l-fade {
+        animation: shadow-l-fade 14s infinite ease-in-out;
+      }
+      @keyframes shadow-l-fade {
+        0%, 20%   { opacity: 0; }
+        26%, 78%  { opacity: 1; }
+        84%, 100% { opacity: 0; }
+      }
+      .shadow-r-fade {
+        animation: shadow-r-fade 14s infinite ease-in-out;
+      }
+      @keyframes shadow-r-fade {
+        0%, 24%   { opacity: 0; }
+        30%, 78%  { opacity: 1; }
+        84%, 100% { opacity: 0; }
+      }
+
+      /* ── Thought particles ── */
+      .reading-fx {
+        animation: reading-fx-vis 14s infinite;
+      }
+      @keyframes reading-fx-vis {
+        0%, 27%   { opacity: 0; }
+        32%, 75%  { opacity: 1; }
+        78%, 100% { opacity: 0; }
+      }
+
+      .thought-bit {
+        opacity: 0;
+        animation: float-thought 2.5s infinite linear;
+      }
+      .t1 { animation-delay: 0s; }
+      .t2 { animation-delay: -0.7s; }
+      .t3 { animation-delay: -1.4s; }
+      .t4 { animation-delay: -2.1s; }
+
+      @keyframes float-thought {
+        0%   { transform: translateY(0); opacity: 0; }
+        10%  { opacity: 0.6; }
+        100% { transform: translateY(-12px); opacity: 0; }
+      }
+    </style>
+
+    <clipPath id="inside-torso">
+      <rect x="2" y="6" width="11" height="7"/>
+    </clipPath>
+  </defs>
+
+  <!-- Ground shadow -->
+  <rect class="shadow" x="3" y="15" width="9" height="1" fill="#000"/>
+
+  <!-- Thought particles -->
+  <g class="reading-fx">
+    <rect class="thought-bit t1" x="2"  y="4" width="2" height="2" fill="#40C4FF"/>
+    <rect class="thought-bit t2" x="8"  y="3" width="1.5" height="1.5" fill="#B388FF"/>
+    <rect class="thought-bit t3" x="12" y="5" width="2" height="2" fill="#40C4FF"/>
+    <rect class="thought-bit t4" x="5"  y="3" width="1.5" height="1.5" fill="#69F0AE"/>
+  </g>
+
+  <g class="body-nod">
+    <g class="breathe">
+
+      <!-- 腿 + torso -->
+      <g fill="#DE886D">
+        <rect x="3" y="11" width="1" height="4"/>
+        <rect x="5" y="11" width="1" height="4"/>
+        <rect x="9" y="11" width="1" height="4"/>
+        <rect x="11" y="11" width="1" height="4"/>
+      </g>
+      <rect x="2" y="6" width="11" height="7" fill="#DE886D"/>
+
+      <!-- 手阴影 (clip 到 torso, opacity 窗口 + 跟手 transform 同步) -->
+      <g clip-path="url(#inside-torso)" fill="#A85A3A">
+        <g class="shadow-l-fade">
+          <g class="arm-l">
+            <rect x="0" y="9" width="2.4" height="2.4"/>
+          </g>
+        </g>
+        <g class="shadow-r-fade">
+          <g class="arm-r">
+            <rect x="12.6" y="9" width="2.4" height="2.4"/>
+          </g>
+        </g>
+      </g>
+
+      <!-- 眼睛 (跟 eyes-read 漂移 + blink 眨眼) -->
+      <g class="eyes-read">
+        <g class="blink" fill="#000">
+          <rect x="4" y="8" width="1" height="2"/>
+          <rect x="10" y="8" width="1" height="2"/>
+        </g>
+      </g>
+
+      <!-- 圆框眼镜 (不嵌 eyes-read/blink, 镜片固定眼球转) -->
+      <g class="glasses" shape-rendering="auto">
+        <g fill="none" stroke="#6B2522" stroke-width="0.56" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="4.415" cy="9" r="2.03"/>
+          <circle cx="10.585" cy="9" r="2.03"/>
+          <path d="M6.445 8.85 C7.036 8.35 7.964 8.35 8.555 8.85"/>
+          <path d="M2.426 8.45 C2.127 8.37 1.893 8.35 1.716 8.35"/>
+          <path d="M12.574 8.45 C12.873 8.37 13.107 8.35 13.284 8.35"/>
+        </g>
+      </g>
+
+      <!-- 书 (在脸之上, 手之下) -->
+      <g class="book">
+        <rect x="3" y="10" width="8" height="4" fill="#4A90D9"/>
+        <rect x="7" y="10" width="1" height="4" fill="#2E6AB0"/>
+        <rect x="3.9" y="9.7" width="6.5" height="0.3" fill="#FFFDE7"/>
+        <rect x="10.5" y="10.5" width="0.5" height="3" fill="#FFFDE7"/>
+        <rect x="4.5" y="10.5" width="5" height="1.5" fill="#E3F2FD" opacity="0.5"/>
+        <rect x="5" y="10.8" width="3" height="0.5" fill="#2E6AB0"/>
+        <rect x="5.5" y="11.5" width="2" height="0.3" fill="#2E6AB0" opacity="0.6"/>
+        <rect x="6" y="12.5" width="2" height="0.5" fill="#E3F2FD" opacity="0.4"/>
+      </g>
+
+      <!-- 双手 (最上层) -->
+      <g fill="#DE886D">
+        <g class="arm-l"><rect x="0" y="9" width="2" height="2"/></g>
+        <g class="arm-r"><rect x="13" y="9" width="2" height="2"/></g>
+      </g>
+
+    </g>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-mini-alert.svg
+++ b/make-deck/skills/make-deck/assets/clawd-mini-alert.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <defs>
+    <style>
+      .breathe-anim {
+        transform-origin: 7.5px 13px;
+        animation: breathe 3.2s infinite ease-in-out;
+      }
+
+      .arm-alert {
+        transform-origin: 2px 9px;
+        animation: alert-arm 4s infinite ease-in-out;
+      }
+
+      /* Normal rect eyes: visible first, hidden after blink */
+      .eyes-rect {
+        transform-origin: 7.5px 9px; /* eye vertical center for blink */
+        animation: rect-vis 4s infinite step-end, rect-move 4s infinite ease-in-out;
+      }
+
+      /* xmark squint eyes: hidden first, visible after switch */
+      .eyes-xmark {
+        visibility: hidden;
+        animation: xmark-vis 4s infinite step-end;
+      }
+
+      .alert-pop {
+        animation: alert-flash 4s infinite ease-in-out;
+        opacity: 0;
+      }
+
+      @keyframes breathe {
+        0%, 100% { transform: scale(1, 1) translate(0, 0); }
+        50% { transform: scale(1.02, 0.98) translate(0, 0.5px); }
+      }
+
+      @keyframes alert-arm {
+        0%, 49% { transform: rotate(0deg); }
+        51% { transform: rotate(20deg); }
+        60% { transform: rotate(-8deg); }
+        64% { transform: rotate(20deg); }
+        68% { transform: rotate(-8deg); }
+        72% { transform: rotate(20deg); }
+        76% { transform: rotate(-8deg); }
+        80% { transform: rotate(20deg); }
+        84% { transform: rotate(-8deg); }
+        88% { transform: rotate(20deg); }
+        92%, 100% { transform: rotate(0deg); }
+      }
+
+      /* Rect eyes: center, wait for exclamation, slowly look left, back, pause, blink, switch */
+      @keyframes rect-move {
+        0%, 16% { transform: translate(0, 0) scaleY(1); }
+        22%, 28% { transform: translate(-2px, 0) scaleY(1); }
+        34% { transform: translate(0, 0) scaleY(1); }
+        36% { transform: translate(0, 0) scaleY(0.1); }
+        37%, 39% { transform: translate(0, 0) scaleY(1); }
+        41% { transform: translate(0, 0) scaleY(0.1); }
+        42%, 100% { transform: translate(0, 0) scaleY(1); }
+      }
+
+      /* Rect eyes visibility: visible → hidden at 22%, back at 91% */
+      @keyframes rect-vis {
+        0% { visibility: visible; }
+        42% { visibility: hidden; }
+        91% { visibility: visible; }
+      }
+
+      /* xmark eyes visibility: hidden at start, visible at 42%, hidden at 89% */
+      @keyframes xmark-vis {
+        0% { visibility: hidden; }
+        42% { visibility: visible; }
+        89% { visibility: hidden; }
+      }
+
+      @keyframes alert-flash {
+        0%, 8% { opacity: 0; transform: scale(0.5); }
+        12% { opacity: 1; transform: translate(0, -4px) scale(1.2); }
+        20%, 70% { opacity: 1; transform: translate(0, -4px) scale(1); }
+        85%, 100% { opacity: 0; transform: translate(0, -6px) scale(0.8); }
+      }
+    </style>
+  </defs>
+
+  <!-- Entire character leaning -->
+  <g transform="rotate(-12, 7.5, 15)">
+
+    <!-- Legs -->
+    <g fill="#DE886D">
+      <rect x="3" y="11" width="1" height="4"/>
+      <rect x="5" y="11" width="1" height="4"/>
+      <rect x="9" y="11" width="1" height="4"/>
+      <rect x="11" y="11" width="1" height="4"/>
+    </g>
+
+    <g id="body-js">
+      <g class="breathe-anim">
+        <!-- Torso -->
+        <rect x="2" y="6" width="11" height="7" fill="#DE886D"/>
+
+        <!-- Left Arm — still then shake -->
+        <g class="arm-alert">
+          <rect x="-1.5" y="9" width="4.5" height="2" fill="#DE886D"/>
+        </g>
+
+        <!-- Right Arm -->
+        <rect x="13" y="9" width="2" height="2" fill="#DE886D"/>
+
+        <!-- Phase 1: Normal rect eyes (look left at exclamation, then blink away) -->
+        <g class="eyes-rect" fill="#000000">
+          <rect x="4" y="8" width="1" height="2"/>
+          <rect x="10" y="8" width="1" height="2"/>
+        </g>
+
+        <!-- Phase 2: >< squint eyes (appear after blink) -->
+        <g class="eyes-xmark" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="4,8 5.5,9 4,10"/>
+          <polyline points="11,8 9.5,9 11,10"/>
+        </g>
+      </g>
+    </g>
+
+  </g>
+
+  <!-- Exclamation mark (outside rotation = stays vertical) -->
+  <g class="alert-pop" fill="#FF3D00">
+    <rect x="-8" y="5" width="2" height="4"/>
+    <rect x="-8" y="10" width="2" height="2"/>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-mini-enter.svg
+++ b/make-deck/skills/make-deck/assets/clawd-mini-enter.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="-15 -25 45 45"
+  shape-rendering="crispEdges">
+    <style>
+      #body-js {
+        animation: bodyEnter 3.2s cubic-bezier(0.22, 1, 0.36, 1) 1 forwards;
+      }
+
+      #left-arm {
+        transform-origin: 2px 9px;
+        animation: armEnterWave 3.2s ease-in-out 1 forwards;
+      }
+
+      #eyes-js {
+        transform-origin: 7.5px 9px;
+        animation: eyesEnter 3.2s ease-in-out 1 forwards;
+      }
+
+      @keyframes bodyEnter {
+        0% {
+          transform: translate(25px, 0px);
+        }
+        18% {
+          transform: translate(-3px, -0.8px);
+        }
+        24% {
+          transform: translate(1.4px, 0.4px);
+        }
+        30% {
+          transform: translate(0px, 0px);
+        }
+        65% {
+          transform: translate(0px, 0px);
+        }
+        76% {
+          transform: translate(0.5px, 0.2px);
+        }
+        88%,
+        100% {
+          transform: translate(0px, 0px);
+        }
+      }
+
+      @keyframes armEnterWave {
+        0%,
+        30% {
+          transform: scaleX(0.05) rotate(0deg);
+        }
+        38% {
+          transform: scaleX(1.18) rotate(-8deg);
+        }
+        43% {
+          transform: scaleX(0.96) rotate(6deg);
+        }
+        48% {
+          transform: scaleX(1) rotate(-14deg);
+        }
+        53% {
+          transform: scaleX(1) rotate(16deg);
+        }
+        58% {
+          transform: scaleX(1) rotate(-12deg);
+        }
+        63% {
+          transform: scaleX(1) rotate(9deg);
+        }
+        70%,
+        100% {
+          transform: scaleX(1) rotate(0deg);
+        }
+      }
+
+      @keyframes eyesEnter {
+        0%,
+        65% {
+          transform: translateX(-1px) scaleY(1);
+        }
+        74% {
+          transform: translateX(-0.6px) scaleY(1);
+        }
+        80% {
+          transform: translateX(-0.1px) scaleY(1);
+        }
+        84% {
+          transform: translateX(0px) scaleY(0.1);
+        }
+        88% {
+          transform: translateX(0px) scaleY(1.08);
+        }
+        92%,
+        100% {
+          transform: translateX(0px) scaleY(1);
+        }
+      }
+    </style>
+    <g id="body-js">
+      <g transform="rotate(-12, 7.5, 15)">
+        <rect id="left-arm" x="-1.5" y="9" width="4.5" height="2" fill="#DE886D"/>
+
+        <rect x="2" y="6" width="11" height="7" fill="#DE886D"/>
+        <rect x="13" y="9" width="2" height="2" fill="#DE886D"/>
+
+        <g id="eyes-js" fill="#000000">
+          <rect x="4" y="8" width="1" height="2"/>
+          <rect x="10" y="8" width="1" height="2"/>
+        </g>
+
+        <g fill="#DE886D">
+          <rect x="3" y="11" width="1" height="4"/>
+          <rect x="5" y="11" width="1" height="4"/>
+          <rect x="9" y="11" width="1" height="4"/>
+          <rect x="11" y="11" width="1" height="4"/>
+        </g>
+      </g>
+    </g>
+  </svg>

--- a/make-deck/skills/make-deck/assets/clawd-mini-happy.svg
+++ b/make-deck/skills/make-deck/assets/clawd-mini-happy.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <defs>
+    <style>
+      .breathe-anim {
+        transform-origin: 7.5px 13px;
+        animation: breathe 3.2s infinite ease-in-out;
+      }
+
+      /* Happy arm wave — continuous, fast, fixed pivot at shoulder */
+      .arm-happy {
+        transform-origin: 2px 9px; /* Shoulder joint in SVG coords, no fill-box */
+        animation: arm-happy-wave 0.4s infinite alternate ease-in-out;
+      }
+
+      /* Eyes ^^ blink — mostly ^^ with occasional full blink */
+      .eyes-happy-blink {
+        transform-origin: 7.5px 9px;
+        animation: happy-blink 3s infinite ease-in-out;
+      }
+
+      /* Pixel-Art Sparkle Animations */
+      .spark-center {
+        opacity: 0;
+        animation: flash-center 1.5s infinite step-end;
+        animation-delay: var(--delay, 0s);
+      }
+      .spark-outer {
+        opacity: 0;
+        animation: flash-outer 1.5s infinite step-end;
+        animation-delay: var(--delay, 0s);
+      }
+
+      @keyframes breathe {
+        0%, 100% { transform: scale(1, 1) translate(0, 0); }
+        50% { transform: scale(1.02, 0.98) translate(0, 0.5px); }
+      }
+
+      /* Continuous happy waving */
+      @keyframes arm-happy-wave {
+        0% { transform: rotate(22deg); }
+        100% { transform: rotate(-8deg); }
+      }
+
+      /* Happy blink: frequent blinks to look excited */
+      @keyframes happy-blink {
+        0%, 12%, 30%, 42%, 100% { transform: scaleY(1); }
+        6% { transform: scaleY(0.1); }
+        36% { transform: scaleY(0.1); }
+      }
+
+      @keyframes flash-center {
+        0%  { opacity: 0; }
+        10% { opacity: 1; }
+        30% { opacity: 0; }
+        100%{ opacity: 0; }
+      }
+      @keyframes flash-outer {
+        0%  { opacity: 0; }
+        20% { opacity: 1; }
+        40% { opacity: 0; }
+        100%{ opacity: 0; }
+      }
+    </style>
+
+    <!-- Reusable Pixel Art Sparkle (from clawd-happy.svg) -->
+    <g id="px-sparkle">
+      <rect class="spark-center" x="-0.5" y="-0.5" width="1" height="1" />
+      <path class="spark-outer" d="M -0.5,-1.5 h1 v1 h-1 z
+                                   M -0.5,0.5 h1 v1 h-1 z
+                                   M -1.5,-0.5 h1 v1 h-1 z
+                                   M 0.5,-0.5 h1 v1 h-1 z" />
+    </g>
+  </defs>
+
+  <!-- Entire character leaning -->
+  <g transform="rotate(-12, 7.5, 15)">
+
+    <!-- Legs -->
+    <g fill="#DE886D">
+      <rect x="3" y="11" width="1" height="4"/>
+      <rect x="5" y="11" width="1" height="4"/>
+      <rect x="9" y="11" width="1" height="4"/>
+      <rect x="11" y="11" width="1" height="4"/>
+    </g>
+
+    <g id="body-js">
+      <g class="breathe-anim">
+        <!-- Torso -->
+        <rect x="2" y="6" width="11" height="7" fill="#DE886D"/>
+
+        <!-- Left Arm — happy continuous wave + flower on top -->
+        <g class="arm-happy">
+          <rect x="-1.5" y="9" width="4.5" height="2" fill="#DE886D"/>
+          <!-- Flower held at hand tip -->
+          <!-- Stem (black, from hand top to flower) -->
+          <rect x="-1.5" y="6" width="0.5" height="3" fill="#000000"/>
+          <!-- Petals (yellow pixel cross) -->
+          <rect x="-2.5" y="5" width="0.8" height="0.8" fill="#FFD700"/>
+          <rect x="-0.5" y="5" width="0.8" height="0.8" fill="#FFD700"/>
+          <rect x="-1.5" y="4.2" width="0.8" height="0.8" fill="#FFD700"/>
+          <rect x="-1.5" y="5.8" width="0.8" height="0.8" fill="#FFD700"/>
+          <!-- Center -->
+          <rect x="-1.5" y="5" width="0.8" height="0.8" fill="#FFA000"/>
+        </g>
+
+        <!-- Right Arm -->
+        <rect x="13" y="9" width="2" height="2" fill="#DE886D"/>
+
+        <!-- Eyes: ^^ happy squint with blink -->
+        <g class="eyes-happy-blink">
+          <g fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3.5,9 4.5,8 5.5,9"/>
+            <polyline points="9.5,9 10.5,8 11.5,9"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+
+  <!-- Sparkles (outside rotation = stay upright, within window bounds) -->
+  <use href="#px-sparkle" x="-3" y="0"  fill="#FFD700" style="--delay: 0s"/>
+  <use href="#px-sparkle" x="-6" y="6"  fill="#FFA000" style="--delay: 0.4s"/>
+  <use href="#px-sparkle" x="0"  y="-5" fill="#FFF59D" style="--delay: 0.8s"/>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-mini-peek.svg
+++ b/make-deck/skills/make-deck/assets/clawd-mini-peek.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <defs>
+    <style>
+      .breathe-anim {
+        transform-origin: 7.5px 13px;
+        animation: breathe 3.2s infinite ease-in-out;
+      }
+
+      .eyes-blink {
+        transform-origin: 7.5px 9px;
+        animation: eye-blink 4s infinite ease-in-out;
+      }
+
+      #eyes-js {
+        transition: transform 0.2s ease-out;
+      }
+
+      /* Arm waving — fast 3 waves then pause, loop */
+      .arm-wave {
+        transform-origin: 2px 9px;
+        animation: peek-wave 3s infinite ease-in-out;
+      }
+
+      @keyframes breathe {
+        0%, 100% { transform: scale(1, 1) translate(0, 0); }
+        50% { transform: scale(1.02, 0.98) translate(0, 0.5px); }
+      }
+
+      @keyframes eye-blink {
+        0%, 10%, 100% { transform: scaleY(1); }
+        5% { transform: scaleY(0.1); }
+      }
+
+      /* Fast 3 waves (~0.9s) then still (~2.1s), loop */
+      @keyframes peek-wave {
+        0% { transform: rotate(0deg); }
+        5% { transform: rotate(35deg); }
+        10% { transform: rotate(-15deg); }
+        15% { transform: rotate(35deg); }
+        20% { transform: rotate(-15deg); }
+        25% { transform: rotate(35deg); }
+        30%, 100% { transform: rotate(0deg); }
+      }
+    </style>
+  </defs>
+
+  <!-- Entire character leaning -->
+  <g transform="rotate(-12, 7.5, 15)">
+
+    <!-- Legs -->
+    <g fill="#DE886D">
+      <rect x="3" y="11" width="1" height="4"/>
+      <rect x="5" y="11" width="1" height="4"/>
+      <rect x="9" y="11" width="1" height="4"/>
+      <rect x="11" y="11" width="1" height="4"/>
+    </g>
+
+    <!-- Upper Body -->
+    <g id="body-js">
+      <g class="breathe-anim">
+        <!-- Torso -->
+        <rect x="2" y="6" width="11" height="7" fill="#DE886D"/>
+
+        <!-- Left Arm — continuous big wave -->
+        <g class="arm-wave">
+          <rect x="-1.5" y="9" width="5.5" height="2" fill="#DE886D"/>
+        </g>
+
+        <!-- Right Arm -->
+        <rect x="13" y="9" width="2" height="2" fill="#DE886D"/>
+
+        <!-- Eyes: JS translate wrapper + CSS blink -->
+        <g id="eyes-js" fill="#000000">
+          <g class="eyes-blink">
+            <rect x="4" y="8" width="1" height="2"/>
+            <rect x="10" y="8" width="1" height="2"/>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-react-annoyed.svg
+++ b/make-deck/skills/make-deck/assets/clawd-react-annoyed.svg
@@ -1,0 +1,167 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <defs>
+    <style>
+      /* ===== 6s one-shot: annoyed, pause, resigned sigh, slow return =====
+         Phase 1 (0-6%,    ~0.36s): Flinch
+         Phase 2 (6-18%,   ~0.72s): Lean away + hand block + question mark
+         Phase 3 (18-35%,  ~1.02s): Hold — stay annoyed, question mark fades
+         Phase 4 (35-55%,  ~1.20s): Sigh — hand drops, body slumps, puff cloud
+         Phase 5 (55-70%,  ~0.90s): Linger slumped — still tired
+         Phase 6 (70-90%,  ~1.20s): Slow return
+         Phase 7 (90-100%, ~0.60s): Still
+      */
+
+      .body-react {
+        transform-origin: 7.5px 12px;
+        animation: body-react 6s 1 ease-in-out forwards;
+      }
+      .arm-l-react {
+        transform-origin: 2px 10px;
+        animation: arm-l-react 6s 1 ease-in-out forwards;
+      }
+      .eyes-react {
+        transform-origin: 7.5px 9px;
+        animation: eyes-react 6s 1 ease-in-out forwards;
+      }
+      .shadow-react {
+        transform-origin: 7.5px 15.5px;
+        animation: shadow-react 6s 1 ease-in-out forwards;
+      }
+      .qmark {
+        opacity: 0;
+        transform-origin: 8px -2px;
+        animation: qmark-pop 6s 1 ease-out forwards;
+      }
+      .sigh-cloud {
+        opacity: 0;
+        transform-origin: 16px 9px;
+        animation: sigh-puff 6s 1 ease-out forwards;
+      }
+
+      /* Body: flinch, lean, HOLD, sigh slump, LINGER, slow return */
+      @keyframes body-react {
+        0%        { transform: translate(0, 0) scale(1, 1); }
+        4%        { transform: translate(0, 1.5px) scale(1, 1); }
+        6%        { transform: translate(0, 1px) scale(1, 1); }
+        14%       { transform: translate(2px, 0) scale(1, 1); }
+        /* hold annoyed pose */
+        35%       { transform: translate(2px, 0) scale(1, 1); }
+        /* sigh: rise then slump */
+        40%       { transform: translate(1.5px, -0.5px) scale(1, 1.01); }
+        46%       { transform: translate(1px, 1px) scale(1.03, 0.97); }
+        52%       { transform: translate(0.5px, 0.5px) scale(1.01, 0.99); }
+        /* linger slumped */
+        68%       { transform: translate(0.3px, 0.3px) scale(1, 1); }
+        /* slow return */
+        85%       { transform: translate(0, 0) scale(1, 1); }
+        100%      { transform: translate(0, 0) scale(1, 1); }
+      }
+
+      /* Left arm: block, hold, resigned drop */
+      @keyframes arm-l-react {
+        0%        { transform: rotate(0deg); }
+        6%        { transform: rotate(0deg); }
+        14%       { transform: rotate(-50deg); }
+        /* hold block through pause */
+        35%       { transform: rotate(-45deg); }
+        /* resigned drop */
+        43%       { transform: rotate(-15deg); }
+        48%       { transform: rotate(0deg); }
+        100%      { transform: rotate(0deg); }
+      }
+
+      /* Eyes: squint, half-lid, HOLD, sigh-close, tired linger, recover */
+      @keyframes eyes-react {
+        0%        { transform: scaleY(1); }
+        3%        { transform: scaleY(0.2); }
+        6%        { transform: scaleY(0.6); }
+        14%       { transform: scaleY(0.5); }
+        /* hold half-lid through pause */
+        35%       { transform: scaleY(0.5); }
+        /* sigh: close then reopen tired */
+        40%       { transform: scaleY(0.1); }
+        46%       { transform: scaleY(0.6); }
+        /* linger tired */
+        68%       { transform: scaleY(0.6); }
+        /* blink, back to normal */
+        74%       { transform: scaleY(0.1); }
+        78%       { transform: scaleY(1); }
+        100%      { transform: scaleY(1); }
+      }
+
+      /* Question mark: pop during lean, fade during hold */
+      @keyframes qmark-pop {
+        0%, 4%    { opacity: 0; transform: translate(0, 4px) scale(0.5); }
+        10%       { opacity: 1; transform: translate(0, 0) scale(1.1); }
+        14%, 26%  { opacity: 1; transform: translate(0, 0) scale(1); }
+        34%       { opacity: 0; transform: translate(0, -3px) scale(1.1); }
+        100%      { opacity: 0; }
+      }
+
+      /* Sigh puff: breath cloud after hold */
+      @keyframes sigh-puff {
+        0%, 37%   { opacity: 0; transform: translate(0, 1px) scale(0.3); }
+        43%       { opacity: 0.6; transform: translate(0, 0) scale(0.8); }
+        48%       { opacity: 0.7; transform: translate(1px, 0) scale(1); }
+        60%       { opacity: 0; transform: translate(4px, -4px) scale(1.3); }
+        100%      { opacity: 0; }
+      }
+
+      /* Shadow */
+      @keyframes shadow-react {
+        0%        { transform: translate(0, 0) scaleX(1); opacity: 0.5; }
+        4%        { transform: translate(0, 0) scaleX(0.93); opacity: 0.45; }
+        14%       { transform: translate(1px, 0) scaleX(1); opacity: 0.5; }
+        35%       { transform: translate(1px, 0) scaleX(1); opacity: 0.5; }
+        46%       { transform: translate(0.5px, 0) scaleX(1.05); opacity: 0.55; }
+        68%       { transform: translate(0.3px, 0) scaleX(1.02); opacity: 0.52; }
+        85%       { transform: translate(0, 0) scaleX(1); opacity: 0.5; }
+        100%      { transform: translate(0, 0) scaleX(1); opacity: 0.5; }
+      }
+    </style>
+  </defs>
+
+  <!-- Ground Shadow -->
+  <rect class="shadow-react" x="3" y="15" width="9" height="1" fill="#000" opacity="0.5"/>
+
+  <!-- Static Legs -->
+  <g fill="#DE886D">
+    <rect x="3" y="11" width="1" height="4"/>
+    <rect x="5" y="11" width="1" height="4"/>
+    <rect x="9" y="11" width="1" height="4"/>
+    <rect x="11" y="11" width="1" height="4"/>
+  </g>
+
+  <!-- Animated Upper Body -->
+  <g class="body-react">
+    <!-- Torso -->
+    <g fill="#DE886D">
+      <rect x="2" y="6" width="11" height="7"/>
+    </g>
+    <!-- Arms -->
+    <g fill="#DE886D">
+      <g class="arm-l-react"><rect x="0" y="9" width="2" height="2"/></g>
+      <rect x="13" y="9" width="2" height="2"/>
+    </g>
+    <!-- Eyes -->
+    <g class="eyes-react" fill="#000">
+      <rect x="4" y="8" width="1" height="2"/>
+      <rect x="10" y="8" width="1" height="2"/>
+    </g>
+    <!-- Question mark -->
+    <g class="qmark" fill="#5C9CE6">
+      <rect x="7" y="-5" width="2" height="1"/>
+      <rect x="6" y="-4" width="1" height="1"/>
+      <rect x="9" y="-4" width="1" height="2"/>
+      <rect x="8" y="-2" width="1" height="1"/>
+      <rect x="7" y="-1" width="1" height="1"/>
+      <rect x="7" y="1" width="1" height="1"/>
+    </g>
+    <!-- Sigh puff cloud (right side of face) -->
+    <g class="sigh-cloud" fill="#FFF">
+      <rect x="14" y="9" width="2" height="1"/>
+      <rect x="15" y="8" width="2" height="1"/>
+      <rect x="16" y="7" width="2" height="1"/>
+    </g>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-react-double.svg
+++ b/make-deck/skills/make-deck/assets/clawd-react-double.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <defs>
+    <style>
+      .body-react {
+        animation: body-panic 3.5s 1 ease-in-out forwards;
+      }
+      .eyes-react {
+        animation: eyes-panic 3.5s 1 ease-in-out forwards;
+      }
+      .eyes-blink {
+        transform-origin: 7.5px 9px;
+        animation: blink 3s infinite linear;
+      }
+      .question-pop {
+        transform-origin: center;
+        animation: question-fade 3.5s 1 ease-in-out forwards;
+        opacity: 0;
+      }
+      .exclamation-pop {
+        transform-origin: center;
+        animation: excl-fade 3.5s 1 ease-in-out forwards;
+        opacity: 0;
+      }
+
+      /* Frantic left-right looking */
+      @keyframes body-panic {
+        0%, 4%   { transform: translate(0px, 0px); }
+        10%, 18% { transform: translate(-1px, 0px); }
+        24%, 32% { transform: translate(1px, 0px); }
+        36%      { transform: translate(-1px, 0px); }
+        40%      { transform: translate(1px, 0px); }
+        46%, 72% { transform: translate(1px, -1px); }
+        82%, 100%{ transform: translate(0px, 0px); }
+      }
+
+      @keyframes eyes-panic {
+        0%, 4%   { transform: translate(0px, 0px); }
+        10%, 18% { transform: translate(-2px, 0px); }
+        24%, 32% { transform: translate(2px, 0px); }
+        36%      { transform: translate(-2px, 0px); }
+        40%      { transform: translate(2px, 0px); }
+        46%, 72% { transform: translate(3px, -2px); }
+        82%, 100%{ transform: translate(0px, 0px); }
+      }
+
+      @keyframes blink {
+        0%, 20%, 24%, 60%, 64%, 80%, 84%, 100% { transform: scaleY(1); }
+        22%, 62%, 82% { transform: scaleY(0.1); }
+      }
+
+      /* Question mark appears early (while looking left) */
+      @keyframes question-fade {
+        0%, 6%   { opacity: 0; transform: translate(-4px, 4px) scale(0.5); }
+        12%, 38% { opacity: 1; transform: translate(-4px, 0px) scale(1); }
+        44%, 100%{ opacity: 0; transform: translate(-4px, -4px) scale(1.2); }
+      }
+
+      /* Exclamation appears later (while staring up-right) */
+      @keyframes excl-fade {
+        0%, 42%  { opacity: 0; transform: translate(6px, 0px) scale(0.5); }
+        48%, 72% { opacity: 1; transform: translate(6px, -4px) scale(1); }
+        80%, 100%{ opacity: 0; transform: translate(6px, -8px) scale(1.2); }
+      }
+    </style>
+  </defs>
+
+  <!-- Ground Shadow -->
+  <rect x="3" y="15" width="9" height="1" fill="#000000" opacity="0.5"/>
+
+  <!-- Static Legs (extended upward to prevent gap when body shifts up) -->
+  <g fill="#DE886D">
+    <rect x="3" y="11" width="1" height="4"/>
+    <rect x="5" y="11" width="1" height="4"/>
+    <rect x="9" y="11" width="1" height="4"/>
+    <rect x="11" y="11" width="1" height="4"/>
+  </g>
+
+  <!-- Animated Upper Body -->
+  <g class="body-react">
+    <g fill="#DE886D">
+      <rect x="2" y="6" width="11" height="7"/>
+      <rect x="0" y="9" width="2" height="2"/>
+      <rect x="13" y="9" width="2" height="2"/>
+    </g>
+    <g class="eyes-react">
+      <g class="eyes-blink" fill="#000000">
+        <rect x="4" y="8" width="1" height="2"/>
+        <rect x="10" y="8" width="1" height="2"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- Question Mark (left side) -->
+  <g class="question-pop" fill="#FFFFFF">
+    <rect x="1" y="0" width="2" height="1"/>
+    <rect x="0" y="1" width="1" height="1"/>
+    <rect x="3" y="1" width="1" height="2"/>
+    <rect x="2" y="3" width="1" height="1"/>
+    <rect x="1" y="4" width="1" height="1"/>
+    <rect x="1" y="6" width="1" height="1"/>
+  </g>
+
+  <!-- Exclamation Mark (right side) -->
+  <g class="exclamation-pop" fill="#0082FC">
+    <rect x="1" y="0" width="1" height="4"/>
+    <rect x="1" y="5" width="1" height="1"/>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-wake.svg
+++ b/make-deck/skills/make-deck/assets/clawd-wake.svg
@@ -1,0 +1,277 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="crispEdges">
+  <defs>
+    <style>
+      .once {
+        animation-duration: 1.5s;
+        animation-fill-mode: forwards;
+        animation-iteration-count: 1;
+      }
+
+      .scale-top-left {
+        transform-box: fill-box;
+        transform-origin: top left;
+      }
+
+      .shadow {
+        transform-origin: 7.5px 15.5px;
+        animation-name: shadow-wake;
+        animation-timing-function: linear;
+      }
+
+      .body-motion {
+        transform-origin: 7.5px 15px;
+        animation-name: body-motion;
+        animation-timing-function: cubic-bezier(0.24, 0.8, 0.24, 1);
+      }
+
+      .torso-shift {
+        animation: torso-shift 1.5s linear forwards;
+      }
+
+      .torso-shape {
+        animation: torso-shape 1.5s linear forwards;
+      }
+
+      .arm-left {
+        animation: arm-left 1.5s linear forwards;
+      }
+
+      .arm-right {
+        animation: arm-right 1.5s linear forwards;
+      }
+
+      .leg-shift {
+        animation: leg-shift 1.5s linear forwards;
+      }
+
+      .leg-grow {
+        animation: leg-grow 1.5s linear forwards;
+      }
+
+      .eye-shift {
+        animation: eye-shift 1.5s linear forwards;
+      }
+
+      .eye-shape {
+        animation: eye-shape 1.5s linear forwards;
+      }
+
+      @keyframes shadow-wake {
+        0% {
+          opacity: 0.4;
+          transform: scaleX(1);
+        }
+        20% {
+          opacity: 0.47;
+          transform: scaleX(0.56);
+        }
+        33.333% {
+          opacity: 0.54;
+          transform: scaleX(0.42);
+        }
+        46.667% {
+          opacity: 0.48;
+          transform: scaleX(0.48);
+        }
+        56% {
+          opacity: 0.52;
+          transform: scaleX(0.56);
+        }
+        66.667%, 100% {
+          opacity: 0.5;
+          transform: scaleX(0.5294);
+        }
+      }
+
+      @keyframes body-motion {
+        0% {
+          transform: translate(0, 0) scale(1, 1) rotate(0deg);
+        }
+        6.667% {
+          transform: translate(0, 0.35px) scale(1.03, 0.96) rotate(0deg);
+        }
+        20% {
+          transform: translate(0, -2.6px) scale(0.98, 1.04) rotate(-6deg);
+        }
+        33.333% {
+          transform: translate(0, -4.1px) scale(0.9, 1.22) rotate(2deg);
+        }
+        46.667% {
+          transform: translate(0, -2px) scale(0.95, 1.11) rotate(0deg);
+        }
+        54% {
+          transform: translate(0, -0.55px) scale(1.02, 0.98) rotate(-4deg);
+        }
+        60% {
+          transform: translate(0, -0.2px) scale(0.99, 1.02) rotate(2.5deg);
+        }
+        66.667%, 100% {
+          transform: translate(0, 0) scale(1, 1) rotate(0deg);
+        }
+      }
+
+      @keyframes torso-shift {
+        0% {
+          transform: translate(-1px, 4px);
+        }
+        8% {
+          transform: translate(-0.82px, 3.4px);
+        }
+        20%, 100% {
+          transform: translate(0, 0);
+        }
+      }
+
+      @keyframes torso-shape {
+        0% {
+          transform: scale(1.1818, 0.7143);
+        }
+        8% {
+          transform: scale(1.14, 0.76);
+        }
+        20%, 100% {
+          transform: scale(1, 1);
+        }
+      }
+
+      @keyframes arm-left {
+        0% {
+          transform: translate(-1px, 4px);
+        }
+        8% {
+          transform: translate(-0.8px, 3.4px);
+        }
+        20%, 100% {
+          transform: translate(0, 0);
+        }
+      }
+
+      @keyframes arm-right {
+        0% {
+          transform: translate(1px, 4px);
+        }
+        8% {
+          transform: translate(0.8px, 3.4px);
+        }
+        20%, 100% {
+          transform: translate(0, 0);
+        }
+      }
+
+      @keyframes leg-shift {
+        0% {
+          transform: translate(0, -2px);
+        }
+        8% {
+          transform: translate(0, -1.5px);
+        }
+        20%, 100% {
+          transform: translate(0, 0);
+        }
+      }
+
+      @keyframes leg-grow {
+        0% {
+          transform: scale(1, 0.25);
+        }
+        8% {
+          transform: scale(1, 0.45);
+        }
+        20%, 100% {
+          transform: scale(1, 1);
+        }
+      }
+
+      @keyframes eye-shift {
+        0% {
+          transform: translate(-0.5px, 4.5px);
+        }
+        6.667% {
+          transform: translate(-0.5px, 4.15px);
+        }
+        10% {
+          transform: translate(-0.2px, 1px);
+        }
+        14% {
+          transform: translate(-0.06px, 0.2px);
+        }
+        20%, 54% {
+          transform: translate(0, 0);
+        }
+        58% {
+          transform: translate(0, 0.5px);
+        }
+        62%, 100% {
+          transform: translate(0, 0);
+        }
+      }
+
+      @keyframes eye-shape {
+        0% {
+          transform: scale(2, 0.2);
+        }
+        6.667% {
+          transform: scale(2.12, 0.12);
+        }
+        10% {
+          transform: scale(1.45, 1.8);
+        }
+        14% {
+          transform: scale(0.92, 1.08);
+        }
+        20%, 54% {
+          transform: scale(1, 1);
+        }
+        58% {
+          transform: scale(1, 0.08);
+        }
+        62% {
+          transform: scale(1, 1.08);
+        }
+        66.667%, 100% {
+          transform: scale(1, 1);
+        }
+      }
+    </style>
+  </defs>
+
+  <rect class="once shadow" x="-1" y="15" width="17" height="1" fill="#000000" opacity="0.4"/>
+
+  <g class="once body-motion">
+    <g fill="#DE886D">
+      <g class="once leg-shift">
+        <rect class="once scale-top-left leg-grow" x="3" y="11" width="1" height="4"/>
+      </g>
+      <g class="once leg-shift">
+        <rect class="once scale-top-left leg-grow" x="5" y="11" width="1" height="4"/>
+      </g>
+      <g class="once leg-shift">
+        <rect class="once scale-top-left leg-grow" x="9" y="11" width="1" height="4"/>
+      </g>
+      <g class="once leg-shift">
+        <rect class="once scale-top-left leg-grow" x="11" y="11" width="1" height="4"/>
+      </g>
+    </g>
+
+    <g class="once torso-shift">
+      <rect class="once scale-top-left torso-shape" x="2" y="6" width="11" height="7" fill="#DE886D"/>
+    </g>
+
+    <g class="once arm-left">
+      <rect x="0" y="9" width="2" height="2" fill="#DE886D"/>
+    </g>
+
+    <g class="once arm-right">
+      <rect x="13" y="9" width="2" height="2" fill="#DE886D"/>
+    </g>
+
+    <g fill="#000000">
+      <g class="once eye-shift">
+        <rect class="once scale-top-left eye-shape" x="4" y="8" width="1" height="2"/>
+      </g>
+      <g class="once eye-shift">
+        <rect class="once scale-top-left eye-shape" x="10" y="8" width="1" height="2"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-working-building.svg
+++ b/make-deck/skills/make-deck/assets/clawd-working-building.svg
@@ -1,0 +1,329 @@
+<!--
+  clawd-experiment-working-building-helmet-v1.svg (2026-04-24)
+  基础 = D:\animation\assets\svg\clawd-working-building.svg
+  改动 = 把原黄色安全帽 (#FBC02D/#F9A825) 换成 helmet-tryon-v1 的三色橙帽 (#EFA74A/#B7782E/#FAB253)
+  帽子仍放在 body-squash 组内, 跟随锤击 squash; z-order: torso → helmet → eyes (helmet 不遮眼, 无视觉冲突)
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="crispEdges">
+  <defs>
+    <style>
+      /* ===== Independent sub-animations ===== */
+
+      /* Breathe 3.2s */
+      .breathe {
+        transform-origin: 7.5px 13px;
+        animation: breathe 3.2s infinite ease-in-out;
+      }
+
+      /* Blink 4s */
+      .blink {
+        transform-origin: 7.5px 9px;
+        animation: blink 4s infinite;
+      }
+
+      /* ===== Hammer cycle 1.2s ===== */
+
+      /* Body bounce: up-down motion (shared by body + arms) */
+      .body-bounce {
+        transform-origin: 7.5px 15px;
+        animation: body-bounce 1.2s infinite;
+      }
+
+      /* Body squash: scale only (torso + hat + eyes, arms excluded) */
+      .body-squash {
+        transform-origin: 7.5px 15px;
+        animation: body-squash 1.2s infinite;
+      }
+
+      /* Right arm hammer swing */
+      .arm-hammer {
+        transform-origin: 14px 10px;
+        animation: hammer-swing 1.2s infinite;
+      }
+
+      /* Left arm counter-motion */
+      .arm-l-rest {
+        transform-origin: 2px 10px;
+        animation: arm-l-rest 1.2s infinite;
+      }
+
+      /* Shadow synced with bounce */
+      .shadow-anim {
+        transform-origin: 7.5px 15.5px;
+        animation: shadow-bounce 1.2s infinite;
+      }
+
+      /* Hot metal flash */
+      .hot-metal {
+        animation: metal-glow 1.2s infinite;
+      }
+
+      /* Sparks */
+      .spark { opacity: 0; }
+      .s1 { animation: spark-1 1.2s infinite; }
+      .s2 { animation: spark-2 1.2s infinite; }
+      .s3 { animation: spark-3 1.2s infinite; }
+
+      /* ===== Eyes 5s ===== */
+      .eyes-look {
+        animation: eyes-look 5s infinite ease-in-out;
+      }
+
+      /* ===== Sweat 6s ===== */
+      .sweat {
+        opacity: 0;
+        animation: sweat-fly 6s infinite;
+      }
+
+      /* ==================== Keyframes ==================== */
+
+      @keyframes breathe {
+        0%, 100% { transform: scale(1, 1) translate(0, 0); }
+        50% { transform: scale(1.02, 0.98) translate(0, 0.5px); }
+      }
+
+      @keyframes blink {
+        0%, 10%, 100% { transform: scaleY(1); }
+        5% { transform: scaleY(0.1); }
+      }
+
+      /* Body bounce: translateY only (arms share this, stay clean) */
+      @keyframes body-bounce {
+        0%, 100% { transform: translateY(0); }
+        30%      { transform: translateY(-2px); }
+        45%      { transform: translateY(0); }
+        50%      { transform: translateY(2px); }
+        70%      { transform: translateY(0); }
+      }
+
+      /* Body squash: scale only (torso+hat+eyes, not arms) */
+      @keyframes body-squash {
+        0%, 100% { transform: scale(1, 1); }
+        30%      { transform: scale(0.95, 1.05); }
+        45%      { transform: scale(1, 1); }
+        50%      { transform: scale(1.15, 0.85); }
+        70%      { transform: scale(1, 1); }
+      }
+
+      /* Shadow: lighter on rise, heavier on impact */
+      @keyframes shadow-bounce {
+        0%, 45%, 70%, 100% { transform: scaleX(1); opacity: 0.5; }
+        30%      { transform: scaleX(0.92); opacity: 0.42; }
+        50%      { transform: scaleX(1.08); opacity: 0.58; }
+      }
+
+      /* Hammer swing: original angles preserved */
+      @keyframes hammer-swing {
+        0%, 100% { transform: rotate(15deg); }
+        30%      { transform: rotate(-45deg); }
+        45%      { transform: rotate(40deg); }
+        50%      { transform: rotate(125deg); }
+        70%      { transform: rotate(15deg); }
+      }
+
+      /* Left arm: reacts to hammer rhythm */
+      @keyframes arm-l-rest {
+        0%, 100% { transform: rotate(0deg); }
+        30%      { transform: rotate(15deg); }
+        50%      { transform: rotate(-5deg); }
+      }
+
+      /* Hot metal glow on impact */
+      @keyframes metal-glow {
+        0%, 49%  { fill: #FF5252; }
+        50%, 60% { fill: #FFF59D; }
+        100%     { fill: #FF5252; }
+      }
+
+      /* Eyes: mostly watch anvil, occasional glance at hammer */
+      @keyframes eyes-look {
+        0%, 100% { transform: translate(1.5px, 0.5px); }
+        20%      { transform: translate(1.5px, 0.5px); }
+        25%      { transform: translate(1px, -0.5px); }
+        35%      { transform: translate(1px, -0.5px); }
+        40%      { transform: translate(1.5px, 0.5px); }
+        70%      { transform: translate(0.3px, 0); }
+        80%      { transform: translate(1.5px, 0.5px); }
+      }
+
+      /* Sparks: appear at impact, scatter outward */
+      @keyframes spark-1 {
+        0%, 49%   { opacity: 0; transform: translate(0, 0) scale(0); }
+        50%       { opacity: 1; transform: translate(0, 0) scale(1); }
+        70%       { opacity: 0; transform: translate(4px, -6px) scale(0); }
+        71%, 100% { opacity: 0; transform: translate(0, 0) scale(0); }
+      }
+      @keyframes spark-2 {
+        0%, 49%   { opacity: 0; transform: translate(0, 0) scale(0); }
+        50%       { opacity: 1; transform: translate(0, 0) scale(1); }
+        70%       { opacity: 0; transform: translate(7px, -1px) scale(0); }
+        71%, 100% { opacity: 0; transform: translate(0, 0) scale(0); }
+      }
+      @keyframes spark-3 {
+        0%, 49%   { opacity: 0; transform: translate(0, 0) scale(0); }
+        50%       { opacity: 1; transform: translate(0, 0) scale(1); }
+        70%       { opacity: 0; transform: translate(3px, 3px) scale(0); }
+        71%, 100% { opacity: 0; transform: translate(0, 0) scale(0); }
+      }
+
+      /* Sweat: one drop every 6s */
+      @keyframes sweat-fly {
+        0%, 55%  { opacity: 0; transform: translate(0, 0) scale(0); }
+        60%      { opacity: 1; transform: translate(0, 0) scale(1); }
+        80%      { opacity: 0; transform: translate(-6px, -6px) scale(0.5); }
+        100%     { opacity: 0; }
+      }
+    </style>
+
+    <!-- Pixel Spark -->
+    <g id="pixel-spark">
+      <rect x="0" y="0" width="1" height="1"/>
+    </g>
+  </defs>
+
+  <!-- Ground Shadows -->
+  <rect class="shadow-anim" x="3" y="15" width="9" height="1" fill="#000000"/>
+  <rect x="16" y="15" width="7" height="1" fill="#000000" opacity="0.4"/>
+
+  <!-- Metal Block / Anvil -->
+  <g transform="translate(17, 13)">
+    <rect x="0" y="2" width="5" height="1" fill="#546E7A"/>
+    <rect x="1" y="0" width="3" height="2" fill="#78909C"/>
+    <rect x="1.5" y="-0.5" width="2" height="1" class="hot-metal"/>
+  </g>
+
+  <!-- Impact Sparks -->
+  <g fill="#FFC107" transform="translate(19, 12.5)">
+    <use href="#pixel-spark" class="spark s1"/>
+    <use href="#pixel-spark" class="spark s2"/>
+    <use href="#pixel-spark" class="spark s3"/>
+  </g>
+
+  <!-- Legs (bounce with body, no squash) -->
+  <g class="body-bounce" fill="#DE886D">
+    <rect x="3" y="13" width="1" height="2"/>
+    <rect x="5" y="13" width="1" height="2"/>
+    <rect x="9" y="13" width="1" height="2"/>
+    <rect x="11" y="13" width="1" height="2"/>
+  </g>
+
+  <!-- Body group [bounce > breathe] -->
+  <g class="body-bounce">
+    <g class="breathe">
+
+      <!-- Sweat (bounces + breathes, outside squash) -->
+      <g transform="translate(1, 8)">
+        <g class="sweat" fill="#40C4FF">
+          <rect x="0" y="1" width="1.5" height="1.5"/>
+          <rect x="0.25" y="0" width="1" height="1"/>
+        </g>
+      </g>
+
+      <!-- Body core [squash] — only torso + hat + eyes get squashed -->
+      <g class="body-squash">
+
+        <!-- Torso -->
+        <rect x="2" y="6" width="11" height="7" fill="#DE886D"/>
+
+        <!-- Eyes [look 5s > blink 4s] — 放在 helmet 之前, 让帽子压过眼睛 -->
+        <g class="eyes-look">
+          <g class="blink" fill="#000">
+            <rect x="4" y="8" width="1" height="2"/>
+            <rect x="10" y="8" width="1" height="2"/>
+          </g>
+        </g>
+
+        <!-- Helmet (from helmet-tryon-v1: 三色橙, translate(0.5 1) scale(0.7) — v1 下移 1 格戴更低) -->
+        <g id="helmet" transform="translate(0.5 1) scale(0.7)">
+          <g fill="#EFA74A">
+            <rect x="7" y="0" width="6" height="1"/>
+            <rect x="7" y="1" width="6" height="1"/>
+            <rect x="14" y="1" width="2" height="1"/>
+            <rect x="2" y="2" width="3" height="1"/>
+            <rect x="7" y="2" width="2" height="1"/>
+            <rect x="11" y="2" width="2" height="1"/>
+            <rect x="14" y="2" width="4" height="1"/>
+            <rect x="2" y="3" width="3" height="1"/>
+            <rect x="7" y="3" width="1" height="1"/>
+            <rect x="14" y="3" width="4" height="1"/>
+            <rect x="1" y="4" width="4" height="1"/>
+            <rect x="7" y="4" width="1" height="1"/>
+            <rect x="14" y="4" width="5" height="1"/>
+            <rect x="1" y="5" width="4" height="1"/>
+            <rect x="7" y="5" width="1" height="1"/>
+            <rect x="12" y="5" width="1" height="1"/>
+            <rect x="14" y="5" width="5" height="1"/>
+            <rect x="1" y="6" width="4" height="1"/>
+            <rect x="8" y="6" width="1" height="1"/>
+            <rect x="11" y="6" width="1" height="1"/>
+            <rect x="14" y="6" width="5" height="1"/>
+            <rect x="1" y="7" width="1" height="1"/>
+            <rect x="0" y="9" width="20" height="1"/>
+          </g>
+          <g fill="#B7782E">
+            <rect x="6" y="1" width="1" height="1"/>
+            <rect x="13" y="1" width="1" height="1"/>
+            <rect x="6" y="2" width="1" height="1"/>
+            <rect x="9" y="2" width="2" height="1"/>
+            <rect x="13" y="2" width="1" height="1"/>
+            <rect x="6" y="3" width="1" height="1"/>
+            <rect x="8" y="3" width="4" height="1"/>
+            <rect x="13" y="3" width="1" height="1"/>
+            <rect x="6" y="4" width="1" height="1"/>
+            <rect x="8" y="4" width="4" height="1"/>
+            <rect x="13" y="4" width="1" height="1"/>
+            <rect x="6" y="5" width="1" height="1"/>
+            <rect x="9" y="5" width="2" height="1"/>
+            <rect x="13" y="5" width="1" height="1"/>
+            <rect x="6" y="6" width="1" height="1"/>
+            <rect x="9" y="6" width="2" height="1"/>
+            <rect x="13" y="6" width="1" height="1"/>
+            <rect x="7" y="7" width="1" height="1"/>
+            <rect x="12" y="7" width="1" height="1"/>
+            <rect x="1" y="8" width="18" height="1"/>
+          </g>
+          <g fill="#FAB253">
+            <rect x="5" y="1" width="1" height="1"/>
+            <rect x="5" y="2" width="1" height="1"/>
+            <rect x="5" y="3" width="1" height="1"/>
+            <rect x="12" y="3" width="1" height="1"/>
+            <rect x="5" y="4" width="1" height="1"/>
+            <rect x="12" y="4" width="1" height="1"/>
+            <rect x="5" y="5" width="1" height="1"/>
+            <rect x="8" y="5" width="1" height="1"/>
+            <rect x="11" y="5" width="1" height="1"/>
+            <rect x="5" y="6" width="1" height="1"/>
+            <rect x="7" y="6" width="1" height="1"/>
+            <rect x="12" y="6" width="1" height="1"/>
+            <rect x="2" y="7" width="5" height="1"/>
+            <rect x="8" y="7" width="4" height="1"/>
+            <rect x="13" y="7" width="6" height="1"/>
+          </g>
+        </g>
+
+      </g>
+
+      <!-- Left arm (bounces + breathes, NO squash) -->
+      <g class="arm-l-rest">
+        <rect x="0" y="9" width="2" height="2" fill="#DE886D"/>
+      </g>
+
+    </g>
+  </g>
+
+  <!-- Right arm + hammer [bounce > breathe] (separate group, same classes = auto sync) -->
+  <g class="body-bounce">
+    <g class="breathe">
+      <g class="arm-hammer">
+        <rect x="13" y="9" width="2" height="2" fill="#DE886D"/>
+        <!-- Hammer -->
+        <g>
+          <!-- Handle -->
+          <rect x="13.5" y="4" width="1" height="6" fill="#795548"/>
+          <!-- Head -->
+          <rect x="12.5" y="3" width="3" height="2" fill="#9E9E9E"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-working-debugger.svg
+++ b/make-deck/skills/make-deck/assets/clawd-working-debugger.svg
@@ -1,0 +1,245 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <defs>
+    <style>
+      /* ═══ Independent animations (always running) ═══ */
+
+      .breathe {
+        transform-origin: 7.5px 13px;
+        animation: breathe 3.2s infinite ease-in-out;
+      }
+
+      .blink {
+        transform-origin: 7.5px 9px;
+        animation: blink 4s infinite linear;
+      }
+
+      .leg-a {
+        animation: sneak-a 0.5s infinite linear;
+        transform-origin: top center;
+        transform-box: fill-box;
+      }
+      .leg-b {
+        animation: sneak-b 0.5s infinite linear;
+        transform-origin: top center;
+        transform-box: fill-box;
+      }
+
+      .glass-wobble {
+        transform-origin: 14px 10px;
+        animation: glass-wobble 3s infinite ease-in-out;
+      }
+
+      /* ═══ Main 14s timeline ═══ */
+
+      .body-main {
+        transform-origin: 7.5px 15px;
+        animation: body-main 14s infinite ease-in-out;
+      }
+
+      .shadow-main {
+        transform-origin: 7.5px 15.5px;
+        animation: shadow-main 14s infinite ease-in-out;
+      }
+
+      .arm-l {
+        transform-origin: 1px 10px;
+        animation: arm-l 14s infinite ease-in-out;
+      }
+
+      .arm-r {
+        transform-origin: 14px 10px;
+        animation: arm-r 14s infinite ease-in-out;
+      }
+
+      .glass-vis {
+        animation: glass-vis 14s infinite linear;
+      }
+
+      .eye-squint {
+        transform-origin: 4.5px 9px;
+        animation: eye-squint 14s infinite ease-in-out;
+      }
+
+      .legs-idle {
+        animation: legs-idle 14s infinite linear;
+      }
+
+      .legs-sneak {
+        animation: legs-sneak 14s infinite linear;
+      }
+
+      /* ═══ Independent keyframes ═══ */
+
+      @keyframes breathe {
+        0%, 100% { transform: scale(1, 1) translate(0, 0); }
+        50% { transform: scale(1.02, 0.98) translate(0, 0.5px); }
+      }
+
+      @keyframes blink {
+        0%, 10%, 100% { transform: scaleY(1); }
+        5% { transform: scaleY(0.1); }
+      }
+
+      @keyframes sneak-a {
+        0%, 100% { transform: rotate(0deg) scaleY(1); }
+        50% { transform: rotate(-25deg) scaleY(0.7); }
+      }
+      @keyframes sneak-b {
+        0%, 100% { transform: rotate(-25deg) scaleY(0.7); }
+        50% { transform: rotate(0deg) scaleY(1); }
+      }
+
+      @keyframes glass-wobble {
+        0%, 100% { transform: rotate(0deg) scale(1); }
+        50% { transform: rotate(-3deg) scale(1.05); }
+      }
+
+      /* ═══ Main timeline keyframes (14s) ═══ */
+
+      /* Body: idle → hunch + patrol → idle (both idle phases trimmed) */
+      @keyframes body-main {
+        0%, 3%    { transform: translate(0, 0) rotate(0deg); }
+        15%       { transform: translate(0, 1px) rotate(2deg); }
+        22%       { transform: translate(-2px, 1px) rotate(2deg); }
+        35%       { transform: translate(3px, 1px) rotate(2deg); }
+        48%       { transform: translate(-2px, 1px) rotate(2deg); }
+        61%       { transform: translate(2px, 1px) rotate(2deg); }
+        78%       { transform: translate(0, 1px) rotate(2deg); }
+        90%       { transform: translate(0, 0) rotate(0deg); }
+        96%, 100% { transform: translate(0, 0) rotate(0deg); }
+      }
+
+      /* Shadow: follows body X, shrinks during detective */
+      @keyframes shadow-main {
+        0%, 3%    { transform: scaleX(1) translate(0, 0); opacity: 0.5; }
+        15%       { transform: scale(0.9) translate(0, 0); opacity: 0.4; }
+        22%       { transform: scale(0.9) translate(-2px, 0); opacity: 0.4; }
+        35%       { transform: scale(0.9) translate(3px, 0); opacity: 0.4; }
+        48%       { transform: scale(0.9) translate(-2px, 0); opacity: 0.4; }
+        61%       { transform: scale(0.9) translate(2px, 0); opacity: 0.4; }
+        78%       { transform: scale(0.9) translate(0, 0); opacity: 0.4; }
+        90%       { transform: scaleX(1) translate(0, 0); opacity: 0.5; }
+        96%, 100% { transform: scaleX(1) translate(0, 0); opacity: 0.5; }
+      }
+
+      /* Left arm: normal → tucked behind → normal */
+      @keyframes arm-l {
+        0%, 5%    { transform: translate(0, 0) rotate(0deg); }
+        15%, 78%  { transform: translate(1px, -1px) rotate(15deg); }
+        90%, 100% { transform: translate(0, 0) rotate(0deg); }
+      }
+
+      /* Right arm: lifts briefly when glass appears/disappears */
+      @keyframes arm-r {
+        0%, 4%    { transform: translate(0, 0); }
+        7%, 10%   { transform: translate(0, -2px); }
+        13%, 80%  { transform: translate(0, 0); }
+        83%, 86%  { transform: translate(0, -2px); }
+        90%, 100% { transform: translate(0, 0); }
+      }
+
+      /* Magnifying glass: appears while arm is up, vanishes while arm is up */
+      @keyframes glass-vis {
+        0%, 8.9%  { opacity: 0; }
+        9%        { opacity: 1; }
+        83.9%     { opacity: 1; }
+        84%       { opacity: 0; }
+        100%      { opacity: 0; }
+      }
+
+      /* Left eye: normal → squint → normal */
+      @keyframes eye-squint {
+        0%, 10%   { transform: scaleY(1); }
+        15%, 78%  { transform: scaleY(0.5); }
+        86%, 100% { transform: scaleY(1); }
+      }
+
+      /* Idle legs: visible in idle, hidden in detective */
+      @keyframes legs-idle {
+        0%, 13.9% { opacity: 1; }
+        14%       { opacity: 0; }
+        85.9%     { opacity: 0; }
+        86%       { opacity: 1; }
+        100%      { opacity: 1; }
+      }
+
+      /* Sneak legs: hidden in idle, visible in detective */
+      @keyframes legs-sneak {
+        0%, 13.9% { opacity: 0; }
+        14%       { opacity: 1; }
+        85.9%     { opacity: 1; }
+        86%       { opacity: 0; }
+        100%      { opacity: 0; }
+      }
+    </style>
+  </defs>
+
+  <!-- Ground Shadow -->
+  <g class="shadow-main">
+    <rect x="3" y="15" width="9" height="1" fill="#000000"/>
+  </g>
+
+  <!-- Static Legs (idle phases) -->
+  <g class="legs-idle" fill="#DE886D">
+    <rect x="3" y="12" width="1" height="3"/>
+    <rect x="5" y="12" width="1" height="3"/>
+    <rect x="9" y="12" width="1" height="3"/>
+    <rect x="11" y="12" width="1" height="3"/>
+  </g>
+
+  <!-- Body Group (main timeline: hunch + walk) -->
+  <g class="body-main">
+
+    <!-- Sneaking Legs (detective phase, inside body so they walk with it) -->
+    <g class="legs-sneak" fill="#DE886D" opacity="0">
+      <rect class="leg-a" x="3" y="13" width="1" height="2"/>
+      <rect class="leg-b" x="5" y="13" width="1" height="2"/>
+      <rect class="leg-a" x="9" y="13" width="1" height="2"/>
+      <rect class="leg-b" x="11" y="13" width="1" height="2"/>
+    </g>
+
+    <!-- Upper Body (breathing) -->
+    <g class="breathe">
+      <!-- Torso -->
+      <rect x="2" y="6" width="11" height="7" fill="#DE886D"/>
+
+      <!-- Left Arm -->
+      <g class="arm-l">
+        <rect x="0" y="9" width="2" height="2" fill="#DE886D"/>
+      </g>
+
+      <!-- Eyes -->
+      <g class="blink" fill="#000000">
+        <!-- Left Eye (squints during detective phase) -->
+        <g class="eye-squint">
+          <rect x="4" y="8" width="1" height="2"/>
+        </g>
+        <!-- Right Eye -->
+        <rect x="10" y="8" width="1" height="2"/>
+      </g>
+
+      <!-- Right Arm + Magnifying Glass (on top of eyes in z-order) -->
+      <g class="arm-r">
+        <rect x="13" y="9" width="2" height="2" fill="#DE886D"/>
+
+        <!-- Magnifying Glass -->
+        <g class="glass-vis" opacity="0">
+          <g class="glass-wobble">
+            <g transform="translate(13.5, 9.5)">
+              <!-- Handle -->
+              <polygon points="0.5,1.5 1.5,0.5 -1,-2 -2,-1" fill="#795548"/>
+              <!-- Rim -->
+              <rect x="-6" y="-5" width="6" height="6" fill="#546E7A" rx="2"/>
+              <!-- Magnified Eye -->
+              <rect x="-4" y="-3.5" width="2" height="3" fill="#000000"/>
+              <!-- Lens -->
+              <rect x="-5.5" y="-4.5" width="5" height="5" fill="#E0F7FA" rx="1.5" opacity="0.6"/>
+              <!-- Glare -->
+              <rect x="-4.5" y="-3.5" width="1.5" height="1.5" fill="#FFFFFF" opacity="0.8"/>
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-working-juggling.svg
+++ b/make-deck/skills/make-deck/assets/clawd-working-juggling.svg
@@ -1,0 +1,183 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <defs>
+    <style>
+      /* ===== Independent sub-animations ===== */
+      .breathe {
+        transform-origin: 7.5px 13px;
+        animation: breathe 3.2s infinite ease-in-out;
+      }
+      .blink {
+        transform-origin: 7.5px 9px;
+        animation: blink 4s infinite;
+      }
+
+      /* ===== Body rock: left-right sway + micro-dip ===== */
+      .body-rock {
+        transform-origin: 7.5px 15px;
+        animation: rock 1.2s infinite ease-in-out;
+      }
+
+      /* ===== Shadow ===== */
+      .shadow-anim {
+        transform-origin: 7.5px 15.5px;
+        animation: shadow-rock 1.2s infinite ease-in-out;
+      }
+
+      /* ===== Arms: alternate catch/throw, synced with rock ===== */
+      .arm-juggle-l {
+        transform-origin: 1px 10px;
+        animation: arm-jl 1.2s infinite ease-in-out;
+      }
+      .arm-juggle-r {
+        transform-origin: 14px 10px;
+        animation: arm-jr 1.2s infinite ease-in-out;
+      }
+
+      /* ===== Eyes: track balls ===== */
+      .eye-track {
+        animation: eye-track 2.4s infinite ease-in-out;
+      }
+
+      /* ===== Juggling packets: parabolic arc ===== */
+      .packet {
+        animation: juggle 1.2s infinite;
+      }
+      .p1 { animation-delay: 0s; fill: #FF5252; }
+      .p2 { animation-delay: -0.4s; fill: #FFC107; }
+      .p3 { animation-delay: -0.8s; fill: #4CAF50; }
+
+      /* (no sweat — juggling is a steady state, not emergency) */
+
+      /* ===== Keyframes ===== */
+
+      @keyframes breathe {
+        0%, 100% { transform: scale(1, 1) translate(0, 0); }
+        50% { transform: scale(1.02, 0.98) translate(0, 0.5px); }
+      }
+
+      @keyframes blink {
+        0%, 10%, 100% { transform: scaleY(1); }
+        5% { transform: scaleY(0.1); }
+      }
+
+      /* Body: center → left-dip → center → right-dip → center */
+      @keyframes rock {
+        0%, 50%, 100% { transform: rotate(0deg) translateY(0); }
+        25% { transform: rotate(-3deg) translateY(0.3px); }
+        75% { transform: rotate(3deg) translateY(0.3px); }
+      }
+
+      /* Shadow: sway with body */
+      @keyframes shadow-rock {
+        0%, 50%, 100% { transform: scaleX(1); opacity: 0.5; }
+        25% { transform: scaleX(1.03) translateX(-0.3px); opacity: 0.52; }
+        75% { transform: scaleX(1.03) translateX(0.3px); opacity: 0.52; }
+      }
+
+      /* Left arm: up at 25% (catch left), down at 75% */
+      @keyframes arm-jl {
+        0%, 50%, 100% { transform: rotate(20deg); }
+        25% { transform: rotate(35deg); }
+        75% { transform: rotate(5deg); }
+      }
+
+      /* Right arm: down at 25%, up at 75% (catch right) */
+      @keyframes arm-jr {
+        0%, 50%, 100% { transform: rotate(-20deg); }
+        25% { transform: rotate(-5deg); }
+        75% { transform: rotate(-35deg); }
+      }
+
+      /* Eyes: track ball arc left-right */
+      @keyframes eye-track {
+        0%, 100% { transform: translate(-1px, -1px); }
+        15% { transform: translate(0, -1.5px); }
+        30% { transform: translate(1px, -1px); }
+        45% { transform: translate(1px, 0.5px); }
+        50% { transform: translate(1px, -1px); }
+        65% { transform: translate(0, -1.5px); }
+        80% { transform: translate(-1px, -1px); }
+        90% { transform: translate(-1px, 0.5px); }
+      }
+
+      /* Juggle: parabolic arc between hands, hang at top
+         Packet origin is x=-1 y=-1 (2x2 rect center ~0,0)
+         Left hand: x~1, y~10  → translate(2, 10)
+         Right hand: x~14, y~10 → translate(14, 10)
+         Arc peak: y ~ -1 (well above head) */
+      @keyframes juggle {
+        0%   { transform: translate(2px, 10px); }
+        8%   { transform: translate(4px, 4px); }
+        18%  { transform: translate(6px, 0px); }
+        30%  { transform: translate(8px, -1px); }
+        42%  { transform: translate(10px, 0px); }
+        50%  { transform: translate(14px, 10px); }
+        58%  { transform: translate(12px, 4px); }
+        68%  { transform: translate(10px, 0px); }
+        80%  { transform: translate(8px, -1px); }
+        92%  { transform: translate(4px, 4px); }
+        100% { transform: translate(2px, 10px); }
+      }
+    </style>
+  </defs>
+
+  <!-- Ground Shadow -->
+  <rect class="shadow-anim" x="3" y="15" width="9" height="1" fill="#000" opacity="0.5"/>
+
+  <!-- Juggling Packets -->
+  <g>
+    <!-- Red ball -->
+    <g class="packet p1">
+      <circle cx="0" cy="0" r="1.2" fill="#FF5252"/>
+      <circle cx="-0.35" cy="-0.35" r="0.45" fill="#FF8A80" opacity="0.7"/>
+      <circle cx="0.3" cy="0.4" r="0.6" fill="#D32F2F" opacity="0.3"/>
+    </g>
+    <!-- Yellow ball -->
+    <g class="packet p2">
+      <circle cx="0" cy="0" r="1.2" fill="#FFC107"/>
+      <circle cx="-0.35" cy="-0.35" r="0.45" fill="#FFE082" opacity="0.7"/>
+      <circle cx="0.3" cy="0.4" r="0.6" fill="#FFA000" opacity="0.3"/>
+    </g>
+    <!-- Green ball -->
+    <g class="packet p3">
+      <circle cx="0" cy="0" r="1.2" fill="#4CAF50"/>
+      <circle cx="-0.35" cy="-0.35" r="0.45" fill="#81C784" opacity="0.7"/>
+      <circle cx="0.3" cy="0.4" r="0.6" fill="#388E3C" opacity="0.3"/>
+    </g>
+  </g>
+
+  <!-- Static Legs -->
+  <g fill="#DE886D">
+    <rect x="3" y="13" width="1" height="2"/>
+    <rect x="5" y="13" width="1" height="2"/>
+    <rect x="9" y="13" width="1" height="2"/>
+    <rect x="11" y="13" width="1" height="2"/>
+  </g>
+
+  <!-- Upper Body -->
+  <g class="body-rock">
+    <g class="breathe">
+      <!-- Torso -->
+      <rect x="2" y="6" width="11" height="7" fill="#DE886D"/>
+
+      <!-- Left Arm -->
+      <g class="arm-juggle-l">
+        <rect x="0" y="9" width="2" height="2" fill="#DE886D"/>
+      </g>
+
+      <!-- Right Arm -->
+      <g class="arm-juggle-r">
+        <rect x="13" y="9" width="2" height="2" fill="#DE886D"/>
+      </g>
+
+      <!-- Eyes -->
+      <g class="eye-track" fill="#000">
+        <g class="blink">
+          <rect x="4" y="8" width="1" height="2"/>
+          <rect x="10" y="8" width="1" height="2"/>
+        </g>
+      </g>
+
+    </g>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-working-thinking.svg
+++ b/make-deck/skills/make-deck/assets/clawd-working-thinking.svg
@@ -1,0 +1,501 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <!-- clawd thinking bubble v25 (2026-05-15)
+
+       v25 = v24 + dreamy edge-flow rewrite.
+       Lu's call: v24 flow pixels read as broken — codex used
+       step-end (hard on/off) + translate jumps + scattered
+       positions across different sides, so the eye reads
+       "buggy detached pixel" not "edge flow".
+
+       Fix: 4 pale-blue 1x1 pixels per bubble, each sitting
+       exactly 1px outside one flat edge (top / right / bottom
+       / left of rim). They fade in and out softly via
+       ease-in-out opacity only (no transform), staggered 6%
+       apart so adjacent pixels overlap during their fades.
+       The eye reads this as a single highlight marching
+       clockwise around the rim — the dreamy / imagining /
+       thought-cloud signature Lu asked for.
+
+       v24 = v23 + "脚站定不动".
+       Lu's call: legs jiggling per body-lean reads as restless.
+       Fix: lift the 4 leg <rect>s out of #clawd-body so they do
+       NOT inherit body-attend rotate/translate or body-breathe
+       scale. Torso / arm / eyes still inherit body motion as
+       before. The leg-*-think keyframes are no longer
+       referenced (kept defined for diff clarity, no perf cost).
+
+       Side note: torso底部边缘旋转时会与脚顶部出现 0.1-0.2px
+       的极小错位 (max body-attend rotate ≈ 2.6deg around y=13
+       即脚顶部基线), 桌宠尺寸下肉眼不可见。
+
+       v23 from v22 critique: "not cute / not精致".
+       Five fixes layered on top of v22 timing:
+         1. Bubble tail: chat-style stair removed.
+            Now a real "thought bubble chain" — main bubble +
+            two recurring small puffs (1px and 0.5px) trailing
+            down to clawd's head. This is the manga thought-cloud
+            signature; clawd looks like he is thinking, not being
+            messaged.
+         2. Eyes react: rect eyes during the thinking hold
+            switch to ^^ smile eyes for a "got it!" beat
+            during the third dot reveal, then blink back to rect
+            before the bubble exits. Uses technique 14
+            (blink-cover swap from rect to smile).
+         3. Inspiration sparkle: a small + pops above the
+            bubble exactly when the smile happens, technique 8
+            "double-flash" reused as a single emphatic blink.
+         4. Chin-rest arm now visible: same-side arm rotates
+            ~50deg with a translate so the hand actually reaches
+            the cheek/chin area, not the previous +22deg micro-tilt.
+         5. Bubble tone switched to white (#FFFFFF), with dots
+            in a slightly deeper Clawd blue (#256891) so they read
+            clearly inside the bubble.
+         6. White bubble gets subtle pale-blue pixels outside the
+            rim, stepping around the outer contour for a small
+            pixel-flow feel while keeping the interior clean.
+
+       Timing, 12s loop (three slow dot reveals per side):
+         0-3%    idle
+         3-7%    notice left + left bubble arrives
+         7-43%   left thinking, three slow dot reveals
+         43-44%  blink (cover swap rect -> smile)
+         44-48%  "got it" smile + + flash
+         48-49%  blink (cover swap smile -> rect)
+         49-52%  left bubble leaves
+         52-54%  very short neutral reset
+         54-58%  notice right + right bubble arrives
+         58-92%  right thinking, three slow dot reveals
+         92-93%  blink (cover swap rect -> smile)
+         93-96%  "got it" smile + + flash
+         96-97%  blink (cover swap smile -> rect)
+         97-99%  right bubble leaves
+         99-100% short loop-end idle
+  -->
+
+  <defs>
+    <style>
+      #ground-shadow {
+        transform-box: view-box;
+        transform-origin: 7.5px 15.5px;
+        animation: shadow-think 12s infinite ease-in-out;
+      }
+
+      .body-breathe {
+        transform-box: view-box;
+        transform-origin: 7.5px 13px;
+        animation: body-breathe 12s infinite ease-in-out;
+      }
+
+      .body-attend {
+        transform-box: view-box;
+        transform-origin: 7.5px 13px;
+        animation: body-attend 12s infinite ease-in-out;
+      }
+
+      .arm-left,
+      .arm-right,
+      .leg-left-inner,
+      .leg-left-outer,
+      .leg-right-inner,
+      .leg-right-outer {
+        transform-box: fill-box;
+        transform-origin: 50% 0%;
+      }
+
+      .arm-left {
+        transform-origin: 100% 0%;
+        animation: arm-left-think 12s infinite ease-in-out;
+      }
+      .arm-right {
+        transform-origin: 0% 0%;
+        animation: arm-right-think 12s infinite ease-in-out;
+      }
+      .leg-right-inner { animation: leg-right-inner-think 12s infinite ease-in-out; }
+      .leg-right-outer { animation: leg-right-outer-think 12s infinite ease-in-out; }
+      .leg-left-inner  { animation: leg-left-inner-think  12s infinite ease-in-out; }
+      .leg-left-outer  { animation: leg-left-outer-think  12s infinite ease-in-out; }
+
+      .eyes {
+        transform-box: view-box;
+        transform-origin: 7.5px 9px;
+        animation: eyes-think 12s infinite ease-in-out;
+      }
+
+      .eyes-rect  { animation: eyes-rect-vis  12s infinite step-end; }
+      .eyes-smile { opacity: 0; animation: eyes-smile-vis 12s infinite step-end; }
+
+      .left-bubble,
+      .right-bubble {
+        transform-box: fill-box;
+        transform-origin: 50% 100%;
+        opacity: 0;
+      }
+      .left-bubble  { animation: left-bubble-life 12s infinite ease-in-out; }
+      .right-bubble { animation: right-bubble-life 12s infinite ease-in-out; }
+
+      .dot { opacity: 0; }
+      .left-bubble  .dot1 { animation: left-dot-1  12s infinite step-end; }
+      .left-bubble  .dot2 { animation: left-dot-2  12s infinite step-end; }
+      .left-bubble  .dot3 { animation: left-dot-3  12s infinite step-end; }
+      .right-bubble .dot1 { animation: right-dot-1 12s infinite step-end; }
+      .right-bubble .dot2 { animation: right-dot-2 12s infinite step-end; }
+      .right-bubble .dot3 { animation: right-dot-3 12s infinite step-end; }
+
+      .bubble-flow {
+        opacity: 0;
+      }
+      .left-bubble  .flow1 { animation: left-flow-1  12s infinite ease-in-out; }
+      .left-bubble  .flow2 { animation: left-flow-2  12s infinite ease-in-out; }
+      .left-bubble  .flow3 { animation: left-flow-3  12s infinite ease-in-out; }
+      .left-bubble  .flow4 { animation: left-flow-4  12s infinite ease-in-out; }
+      .right-bubble .flow1 { animation: right-flow-1 12s infinite ease-in-out; }
+      .right-bubble .flow2 { animation: right-flow-2 12s infinite ease-in-out; }
+      .right-bubble .flow3 { animation: right-flow-3 12s infinite ease-in-out; }
+      .right-bubble .flow4 { animation: right-flow-4 12s infinite ease-in-out; }
+
+      .left-spark,
+      .right-spark {
+        transform-box: fill-box;
+        transform-origin: 50% 50%;
+        opacity: 0;
+      }
+      .left-spark  { animation: left-spark-bling  12s infinite ease-out; }
+      .right-spark { animation: right-spark-bling 12s infinite ease-out; }
+
+      @keyframes shadow-think {
+        0%, 3%, 52%, 99%, 100%      { opacity: 0.5; transform: translateX(0) scaleX(1); }
+        15%, 43%                    { opacity: 0.4; transform: translateX(-0.28px) scaleX(0.9); }
+        70%, 96%                    { opacity: 0.4; transform: translateX(0.28px) scaleX(0.9); }
+      }
+
+      @keyframes body-breathe {
+        0%, 3%, 52%, 99%, 100%      { transform: scale(1, 1) translateY(0); }
+        15%, 29%, 43%, 70%, 84%, 96% { transform: scale(1.006, 0.994) translateY(0.08px); }
+        22%, 36%, 64%, 78%, 90%     { transform: scale(1.014, 0.986) translateY(0.18px); }
+        54%                         { transform: scale(0.996, 1.004) translateY(-0.08px); }
+      }
+
+      @keyframes body-attend {
+        0%, 3%, 52%, 99%, 100%      { transform: translate(0, 0) rotate(0deg); }
+        7%                          { transform: translate(-0.3px, 0.08px) rotate(-1.6deg); }
+        15%                         { transform: translate(-0.48px, 0.14px) rotate(-2.6deg); }
+        30%                         { transform: translate(-0.45px, 0.1px) rotate(-2.3deg); }
+        42%                         { transform: translate(-0.4px, 0.08px) rotate(-2.0deg); }
+        49%                         { transform: translate(-0.2px, 0.04px) rotate(-0.8deg); }
+        51%                         { transform: translate(-0.05px, 0) rotate(-0.2deg); }
+        54%                         { transform: translate(0, 0.08px) rotate(0deg); }
+        58%                         { transform: translate(0.3px, 0.08px) rotate(1.6deg); }
+        70%                         { transform: translate(0.48px, 0.14px) rotate(2.6deg); }
+        84%                         { transform: translate(0.45px, 0.1px) rotate(2.3deg); }
+        96%                         { transform: translate(0.32px, 0.06px) rotate(1.4deg); }
+        98%                         { transform: translate(0.05px, 0) rotate(0.2deg); }
+      }
+
+      /*
+        v23 chin-rest arm: noticeable lift instead of v22's
+        invisible +22deg / -1px microtilt. Same-side arm
+        rotates ~52deg + translate so the hand physically
+        reaches the cheek line.
+      */
+      /*
+        v23 arm: per Lu's call, restored verbatim from v22.
+        v22's micro-tilt feels "still" but does not stutter.
+        The other v23 changes (bubble chain / smile eyes /
+        sparkle / timing) are kept on top.
+      */
+      @keyframes arm-left-think {
+        0%, 3%, 52%, 99%, 100%      { transform: translate(0, 0) rotate(0deg); }
+        7%                          { transform: translate(0.18px, -0.7px) rotate(14deg); }
+        15%, 49%                    { transform: translate(0.35px, -1.05px) rotate(22deg); }
+        30%                         { transform: translate(0.28px, -0.92px) rotate(26deg); }
+        58%, 96%                    { transform: translate(-0.08px, 0.45px) rotate(0deg); }
+        84%                         { transform: translate(-0.12px, 0.55px) rotate(0deg); }
+      }
+      @keyframes arm-right-think {
+        0%, 3%, 52%, 99%, 100%      { transform: translate(0, 0) rotate(0deg); }
+        7%, 49%                     { transform: translate(0.08px, 0.45px) rotate(0deg); }
+        30%                         { transform: translate(0.12px, 0.55px) rotate(0deg); }
+        58%                         { transform: translate(-0.18px, -0.7px) rotate(-14deg); }
+        70%, 96%                    { transform: translate(-0.35px, -1.05px) rotate(-22deg); }
+        84%                         { transform: translate(-0.28px, -0.92px) rotate(-26deg); }
+      }
+
+      @keyframes leg-right-inner-think {
+        0%, 3%, 39%, 98%, 100%      { transform: rotate(0deg) translateY(0); }
+        8%, 34%                     { transform: rotate(7deg) translateY(-0.12px); }
+        20%                         { transform: rotate(9deg) translateY(-0.2px); }
+        42%, 94%                    { transform: rotate(-4deg) translateY(-0.08px); }
+        70%                         { transform: rotate(-5deg) translateY(-0.14px); }
+      }
+      @keyframes leg-right-outer-think {
+        0%, 3%, 39%, 98%, 100%      { transform: rotate(0deg) translateY(0); }
+        8%, 34%                     { transform: rotate(10deg) translateY(-0.18px); }
+        20%                         { transform: rotate(12deg) translateY(-0.26px); }
+        42%, 94%                    { transform: rotate(-5deg) translateY(-0.1px); }
+        70%                         { transform: rotate(-6deg) translateY(-0.16px); }
+      }
+      @keyframes leg-left-inner-think {
+        0%, 3%, 39%, 98%, 100%      { transform: rotate(0deg) translateY(0); }
+        8%, 34%                     { transform: rotate(4deg) translateY(-0.08px); }
+        20%                         { transform: rotate(5deg) translateY(-0.14px); }
+        42%, 94%                    { transform: rotate(-7deg) translateY(-0.12px); }
+        70%                         { transform: rotate(-9deg) translateY(-0.2px); }
+      }
+      @keyframes leg-left-outer-think {
+        0%, 3%, 39%, 98%, 100%      { transform: rotate(0deg) translateY(0); }
+        8%, 34%                     { transform: rotate(5deg) translateY(-0.1px); }
+        20%                         { transform: rotate(6deg) translateY(-0.16px); }
+        42%, 94%                    { transform: rotate(-10deg) translateY(-0.18px); }
+        70%                         { transform: rotate(-12deg) translateY(-0.26px); }
+      }
+
+      /*
+        v23 eyes: thinking squint + blink-cover swap to ^^ smile
+        at 43%/48% (left) and 92%/97% (right).
+        scaleY(0.85) during thinking = subtle squint.
+        scaleY(0.12) at swap = full blink that hides the
+        rect->smile / smile->rect transition.
+      */
+      @keyframes eyes-think {
+        0%, 3%, 52%, 99%, 100%      { transform: translate(0, 0) scaleY(1); }
+        5%                          { transform: translate(-0.3px, -0.5px) scaleY(0.95); }
+        9%, 42%                     { transform: translate(-0.45px, -0.78px) scaleY(0.85); }
+        43%                         { transform: translate(-0.45px, -0.78px) scaleY(0.12); }
+        44%, 47%                    { transform: translate(-0.45px, -0.78px) scaleY(1); }
+        48%                         { transform: translate(-0.45px, -0.78px) scaleY(0.12); }
+        50%                         { transform: translate(-0.15px, -0.25px) scaleY(0.95); }
+        54%                         { transform: translate(0, 0) scaleY(0.18); }
+        55%                         { transform: translate(0.3px, -0.5px) scaleY(0.95); }
+        59%, 88%                    { transform: translate(0.45px, -0.78px) scaleY(0.85); }
+        92%                         { transform: translate(0.45px, -0.78px) scaleY(0.12); }
+        93%, 96%                    { transform: translate(0.45px, -0.78px) scaleY(1); }
+        97%                         { transform: translate(0.45px, -0.78px) scaleY(0.12); }
+        98%                         { transform: translate(0.2px, -0.4px) scaleY(0.95); }
+        100%                        { transform: translate(0, 0) scaleY(1); }
+      }
+
+      @keyframes eyes-rect-vis {
+        0%   { opacity: 1; }
+        43%  { opacity: 0; }
+        48%  { opacity: 1; }
+        92%  { opacity: 0; }
+        97%  { opacity: 1; }
+      }
+      @keyframes eyes-smile-vis {
+        0%   { opacity: 0; }
+        43%  { opacity: 1; }
+        48%  { opacity: 0; }
+        92%  { opacity: 1; }
+        97%  { opacity: 0; }
+      }
+
+      @keyframes left-bubble-life {
+        0%, 3%    { opacity: 0; transform: translate(-0.2px, 0.7px) scale(0.82); }
+        5%        { opacity: 0.75; transform: translate(-0.1px, 0.25px) scale(0.94); }
+        7%        { opacity: 1; transform: translate(0, 0) scale(1.04); }
+        10%, 43%  { opacity: 1; transform: translate(0, 0) scale(1); }
+        46%       { opacity: 1; transform: translate(0, -0.2px) scale(1.02); }
+        48%       { opacity: 1; transform: translate(0, -0.18px) scale(1.01); }
+        49%       { opacity: 1; transform: translate(0, 0) scale(1); }
+        52%       { opacity: 0; transform: translate(0, 0.65px) scale(0.9); }
+        53%, 100% { opacity: 0; transform: translate(0, 0.65px) scale(0.9); }
+      }
+
+      @keyframes right-bubble-life {
+        0%, 53%        { opacity: 0; transform: translate(0.2px, 0.7px) scale(0.82); }
+        54%            { opacity: 0.75; transform: translate(0.1px, 0.25px) scale(0.94); }
+        58%            { opacity: 1; transform: translate(0, 0) scale(1.04); }
+        61%, 92%       { opacity: 1; transform: translate(0, 0) scale(1); }
+        94%            { opacity: 1; transform: translate(0, -0.2px) scale(1.02); }
+        96%            { opacity: 1; transform: translate(0, -0.18px) scale(1.01); }
+        97%            { opacity: 1; transform: translate(0, 0) scale(1); }
+        99%            { opacity: 0; transform: translate(0, 0.65px) scale(0.9); }
+        100%           { opacity: 0; transform: translate(0, 0.65px) scale(0.9); }
+      }
+
+      @keyframes left-dot-1 {
+        0%, 7.99%, 17.99%, 19.99%, 29.99%, 31.99%, 48.99%, 100% { opacity: 0; }
+        8%, 17.98%, 20%, 29.98%, 32%, 48.98%                    { opacity: 1; }
+      }
+      @keyframes left-dot-2 {
+        0%, 11.99%, 17.99%, 23.99%, 29.99%, 35.99%, 48.99%, 100% { opacity: 0; }
+        12%, 17.98%, 24%, 29.98%, 36%, 48.98%                    { opacity: 1; }
+      }
+      @keyframes left-dot-3 {
+        0%, 15.99%, 17.99%, 27.99%, 29.99%, 39.99%, 48.99%, 100% { opacity: 0; }
+        16%, 17.98%, 28%, 29.98%, 40%, 48.98%                    { opacity: 1; }
+      }
+      @keyframes right-dot-1 {
+        0%, 58.99%, 68.99%, 70.99%, 80.99%, 82.99%, 98.49%, 100% { opacity: 0; }
+        59%, 68.98%, 71%, 80.98%, 83%, 98.48%                    { opacity: 1; }
+      }
+      @keyframes right-dot-2 {
+        0%, 62.99%, 68.99%, 74.99%, 80.99%, 86.99%, 98.49%, 100% { opacity: 0; }
+        63%, 68.98%, 75%, 80.98%, 87%, 98.48%                    { opacity: 1; }
+      }
+      @keyframes right-dot-3 {
+        0%, 66.99%, 68.99%, 78.99%, 80.99%, 90.99%, 98.49%, 100% { opacity: 0; }
+        67%, 68.98%, 79%, 80.98%, 91%, 98.48%                    { opacity: 1; }
+      }
+
+      /*
+        v25 edge-flow keyframes.
+        Each pixel: opacity 0 -> 0.7 -> 0 over a 12% window,
+        with 6% stagger between adjacent pixels so two are
+        always overlapping mid-fade. Pure opacity, no transform
+        (v24's translate jumps were the broken-pixel feel).
+        Window math:
+          left thinking phase  = 10-43%
+          right thinking phase = 60-92%
+        flow1 = top rim, flow2 = right rim,
+        flow3 = bottom rim, flow4 = left rim (clockwise).
+      */
+      @keyframes left-flow-1 {
+        0%, 10%, 22%, 100% { opacity: 0; }
+        14%, 18%           { opacity: 0.7; }
+      }
+      @keyframes left-flow-2 {
+        0%, 16%, 28%, 100% { opacity: 0; }
+        20%, 24%           { opacity: 0.7; }
+      }
+      @keyframes left-flow-3 {
+        0%, 22%, 34%, 100% { opacity: 0; }
+        26%, 30%           { opacity: 0.7; }
+      }
+      @keyframes left-flow-4 {
+        0%, 28%, 40%, 100% { opacity: 0; }
+        32%, 36%           { opacity: 0.7; }
+      }
+      @keyframes right-flow-1 {
+        0%, 62%, 74%, 100% { opacity: 0; }
+        66%, 70%           { opacity: 0.7; }
+      }
+      @keyframes right-flow-2 {
+        0%, 68%, 80%, 100% { opacity: 0; }
+        72%, 76%           { opacity: 0.7; }
+      }
+      @keyframes right-flow-3 {
+        0%, 74%, 86%, 100% { opacity: 0; }
+        78%, 82%           { opacity: 0.7; }
+      }
+      @keyframes right-flow-4 {
+        0%, 80%, 92%, 100% { opacity: 0; }
+        84%, 88%           { opacity: 0.7; }
+      }
+
+      /*
+        v23 sparkle bling: single emphatic flash at "got it"
+        moment (left 28-32% / right 71-82%).
+        scale + opacity pulse from technique 8.
+      */
+      @keyframes left-spark-bling {
+        0%, 43%, 49%, 100% { opacity: 0; transform: scale(0.4); }
+        44%                { opacity: 0; transform: scale(0.5); }
+        45%                { opacity: 1; transform: scale(1.35); }
+        46.5%              { opacity: 1; transform: scale(1); }
+        48%                { opacity: 0.4; transform: scale(0.7); }
+      }
+      @keyframes right-spark-bling {
+        0%, 91%, 97%, 100% { opacity: 0; transform: scale(0.4); }
+        92%                { opacity: 0; transform: scale(0.5); }
+        93%                { opacity: 1; transform: scale(1.35); }
+        94.5%              { opacity: 1; transform: scale(1); }
+        96%                { opacity: 0.4; transform: scale(0.7); }
+      }
+    </style>
+  </defs>
+
+  <rect id="ground-shadow" x="3" y="15" width="9" height="1" fill="#000000" opacity="0.5"/>
+
+  <!--
+    v24: legs are lifted out of #clawd-body so they do not inherit
+    body-attend (rotate/translate toward bubble) or body-breathe
+    (scale). Rendered before #master-group so the torso (which is
+    inside master-group) draws on top of the leg tops as before.
+  -->
+  <g id="legs-static" fill="#DE886D">
+    <rect id="outer-left-leg"  x="3"  y="13" width="1" height="2"/>
+    <rect id="inner-left-leg"  x="5"  y="13" width="1" height="2"/>
+    <rect id="inner-right-leg" x="9"  y="13" width="1" height="2"/>
+    <rect id="outer-right-leg" x="11" y="13" width="1" height="2"/>
+  </g>
+
+  <g id="master-group">
+    <g class="body-breathe">
+      <g id="clawd-body" class="body-attend">
+        <g id="body-color-group" fill="#DE886D">
+          <rect id="torso" x="2" y="6" width="11" height="7"/>
+          <rect class="arm-left"  id="left-arm"  x="0"  y="9" width="2" height="2"/>
+          <rect class="arm-right" id="right-arm" x="13" y="9" width="2" height="2"/>
+        </g>
+
+        <g class="eyes" id="eyes-color-group">
+          <g class="eyes-rect" fill="#000000">
+            <rect id="left-eye"  x="4"  y="8" width="1" height="2"/>
+            <rect id="right-eye" x="10" y="8" width="1" height="2"/>
+          </g>
+          <g class="eyes-smile" fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3.5,9 4.5,8 5.5,9"/>
+            <polyline points="9.5,9 10.5,8 11.5,9"/>
+          </g>
+        </g>
+      </g>
+    </g>
+
+    <!--
+      Left thought bubble.
+      v23: bubble path lifted by 1px (path y -3..4 -> -4..3) so
+      there is a 3px gap to clawd's head. Old chat-tail
+      (0,4)(1,4)(1,5) deleted. New chain: 1x1 puff at (1,4) +
+      0.5x0.5 puff at (2,5.5) trailing toward clawd's head top
+      (y=6).
+    -->
+    <g class="left-bubble">
+      <path d="M-1 -4 H6 V-3 H7 V2 H6 V3 H-1 V2 H-2 V-3 H-1 Z" fill="#FFFFFF"/>
+      <!-- v25 rim-flow pixels: clockwise top -> right -> bottom -> left -->
+      <rect class="bubble-flow flow1" x="3"  y="-5" width="1" height="1" fill="#BFEAFF"/>
+      <rect class="bubble-flow flow2" x="8"  y="0"  width="1" height="1" fill="#BFEAFF"/>
+      <rect class="bubble-flow flow3" x="4"  y="4"  width="1" height="1" fill="#BFEAFF"/>
+      <rect class="bubble-flow flow4" x="-3" y="0"  width="1" height="1" fill="#BFEAFF"/>
+      <rect x="1"   y="4"   width="1"   height="1"   fill="#FFFFFF"/>
+      <rect x="2"   y="5.5" width="0.5" height="0.5" fill="#FFFFFF"/>
+      <rect class="dot dot1" x="0" y="-1" width="1" height="1" fill="#256891"/>
+      <rect class="dot dot2" x="2" y="-1" width="1" height="1" fill="#256891"/>
+      <rect class="dot dot3" x="4" y="-1" width="1" height="1" fill="#256891"/>
+    </g>
+
+    <g class="right-bubble">
+      <path d="M9 -4 H16 V-3 H17 V2 H16 V3 H9 V2 H8 V-3 H9 Z" fill="#FFFFFF"/>
+      <!-- v25 rim-flow pixels: clockwise top -> right -> bottom -> left -->
+      <rect class="bubble-flow flow1" x="12" y="-5" width="1" height="1" fill="#BFEAFF"/>
+      <rect class="bubble-flow flow2" x="18" y="0"  width="1" height="1" fill="#BFEAFF"/>
+      <rect class="bubble-flow flow3" x="15" y="4"  width="1" height="1" fill="#BFEAFF"/>
+      <rect class="bubble-flow flow4" x="7"  y="0"  width="1" height="1" fill="#BFEAFF"/>
+      <rect x="13"   y="4"   width="1"   height="1"   fill="#FFFFFF"/>
+      <rect x="12.5" y="5.5" width="0.5" height="0.5" fill="#FFFFFF"/>
+      <rect class="dot dot1" x="10" y="-1" width="1" height="1" fill="#256891"/>
+      <rect class="dot dot2" x="12" y="-1" width="1" height="1" fill="#256891"/>
+      <rect class="dot dot3" x="14" y="-1" width="1" height="1" fill="#256891"/>
+    </g>
+
+    <!--
+      v23 inspiration sparkles. Pixel + (5 small rects) above
+      each bubble, bling at the "got it" moment.
+      Color #FFE066 (per technique 12 anti-boss-gold rule).
+    -->
+    <g class="left-spark">
+      <rect x="6"   y="-7"   width="1"   height="0.6" fill="#FFE066"/>
+      <rect x="6"   y="-6.4" width="1"   height="1"   fill="#FFE066"/>
+      <rect x="6"   y="-5.4" width="1"   height="0.6" fill="#FFE066"/>
+      <rect x="5"   y="-6.4" width="1"   height="1"   fill="#FFE066"/>
+      <rect x="7"   y="-6.4" width="1"   height="1"   fill="#FFE066"/>
+    </g>
+    <g class="right-spark">
+      <rect x="8"   y="-7"   width="1"   height="0.6" fill="#FFE066"/>
+      <rect x="8"   y="-6.4" width="1"   height="1"   fill="#FFE066"/>
+      <rect x="8"   y="-5.4" width="1"   height="0.6" fill="#FFE066"/>
+      <rect x="7"   y="-6.4" width="1"   height="1"   fill="#FFE066"/>
+      <rect x="9"   y="-6.4" width="1"   height="1"   fill="#FFE066"/>
+    </g>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-working-typing.svg
+++ b/make-deck/skills/make-deck/assets/clawd-working-typing.svg
@@ -1,0 +1,273 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <defs>
+    <style>
+      /* ===== Body (KEEP) ===== */
+      .body-bounce {
+        transform-origin: 7.5px 15px;
+        animation: body-bounce 0.35s infinite ease-in-out;
+      }
+      .breathe {
+        transform-origin: 7.5px 13px;
+        animation: breathe 3.2s infinite ease-in-out;
+      }
+
+      /* ===== Arms (KEEP) ===== */
+      .arm-l-type {
+        transform-origin: 2px 10px;
+        animation: type-l 0.15s infinite ease-in-out;
+      }
+      .arm-r-type {
+        transform-origin: 13px 10px;
+        animation: type-r 0.12s infinite ease-in-out;
+      }
+
+      /* ===== Eyes ===== */
+      .eyes-code {
+        transform-origin: 7.5px 9px;
+        animation: eye-code 10s infinite ease-in-out;
+      }
+
+      /* ===== Code lines: each line grows, holds, then slides up + fades ===== */
+      .code-line {
+        transform-box: fill-box;
+        transform-origin: left center;
+      }
+      .cl1 { animation: cl1 6s infinite; }
+      .cl2 { animation: cl2 6s infinite; }
+      .cl3 { animation: cl3 6s infinite; }
+      .cl4 { animation: cl4 6s infinite; }
+
+      /* Key press flashes — different periods so they look random */
+      .key-flash { opacity: 0; }
+      .kf1 { animation: kflash 0.6s infinite; }
+      .kf2 { animation: kflash 0.8s infinite; animation-delay: -0.25s; }
+      .kf3 { animation: kflash 0.5s infinite; animation-delay: -0.1s; }
+      .kf4 { animation: kflash 0.7s infinite; animation-delay: -0.45s; }
+      .kf5 { animation: kflash 0.55s infinite; animation-delay: -0.3s; }
+      .kf6 { animation: kflash 0.9s infinite; animation-delay: -0.5s; }
+
+      /* Data particles (float up behind screen) */
+      .data-bit { opacity: 0; animation: float-data 1.5s infinite linear; }
+      .d1 { animation-delay: 0s; }
+      .d2 { animation-delay: -0.4s; }
+      .d3 { animation-delay: -0.8s; }
+      .d4 { animation-delay: -1.2s; }
+
+      /* Shadow */
+      .shadow-anim {
+        transform-origin: 7.5px 15.5px;
+        animation: shadow-bob 0.4s infinite ease-in-out;
+      }
+
+      /* ==================== Keyframes ==================== */
+
+      @keyframes body-bounce {
+        0%, 100% { transform: translateY(0); }
+        50% { transform: translateY(0.8px); }
+      }
+      @keyframes breathe {
+        0%, 100% { transform: scale(1, 1) translate(0, 0); }
+        50% { transform: scale(1.02, 0.98) translate(0, 0.5px); }
+      }
+      @keyframes shadow-bob {
+        0%, 100% { transform: scaleX(1.02); opacity: 0.5; }
+        50% { transform: scaleX(1.05); opacity: 0.55; }
+      }
+
+      @keyframes type-l {
+        0%   { transform: rotate(-5deg); }
+        25%  { transform: rotate(-38deg); }
+        50%  { transform: rotate(-10deg); }
+        75%  { transform: rotate(-30deg); }
+        100% { transform: rotate(-5deg); }
+      }
+      @keyframes type-r {
+        0%   { transform: rotate(5deg); }
+        25%  { transform: rotate(38deg); }
+        50%  { transform: rotate(10deg); }
+        75%  { transform: rotate(30deg); }
+        100% { transform: rotate(5deg); }
+      }
+
+      /* Eyes: long keyboard squint → 2 consecutive scans → keyboard */
+      @keyframes eye-code {
+        0%   { transform: translate(0, 1px) scaleY(0.6); }
+        14%  { transform: translate(0, 1px) scaleY(0.6); }
+        15%  { transform: translate(0, 1px) scaleY(0.1); }
+        16%  { transform: translate(0, 1px) scaleY(0.6); }
+        36%  { transform: translate(0, 1px) scaleY(0.6); }
+        37%  { transform: translate(0, 1px) scaleY(0.1); }
+        38%  { transform: translate(0, 1px) scaleY(0.6); }
+        54%  { transform: translate(0, 1px) scaleY(0.6); }
+        55%  { transform: translate(0, 1px) scaleY(0.1); }
+        57%  { transform: translate(-1px, -0.5px) scaleY(1); }
+        62%  { transform: translate(1.5px, -0.5px) scaleY(1); }
+        64%  { transform: translate(-0.5px, -0.3px) scaleY(1); }
+        69%  { transform: translate(1.5px, -0.5px) scaleY(1); }
+        71%  { transform: translate(1px, -0.3px) scaleY(0.1); }
+        73%  { transform: translate(0, 1px) scaleY(0.6); }
+        89%  { transform: translate(0, 1px) scaleY(0.6); }
+        90%  { transform: translate(0, 1px) scaleY(0.1); }
+        91%  { transform: translate(0, 1px) scaleY(0.6); }
+        100% { transform: translate(0, 1px) scaleY(0.6); }
+      }
+
+      /* Code lines: grow from left → hold → slide up + fade out
+         Each line staggers by ~15%. Slide-up gives "scroll" feel.
+         At 95-100% all invisible → brief blank → cycle restarts */
+      @keyframes cl1 {
+        0%        { transform: scaleX(0); opacity: 0; }
+        3%        { transform: scaleX(0); opacity: 1; }
+        13%       { transform: scaleX(1); opacity: 1; }
+        13%, 78%  { transform: scaleX(1) translateY(0); opacity: 1; }
+        88%       { transform: scaleX(1) translateY(-3px); opacity: 0; }
+        89%, 100% { transform: scaleX(0) translateY(0); opacity: 0; }
+      }
+      @keyframes cl2 {
+        0%, 14%   { transform: scaleX(0); opacity: 0; }
+        15%       { transform: scaleX(0); opacity: 1; }
+        27%       { transform: scaleX(1); opacity: 1; }
+        27%, 82%  { transform: scaleX(1) translateY(0); opacity: 1; }
+        91%       { transform: scaleX(1) translateY(-3px); opacity: 0; }
+        92%, 100% { transform: scaleX(0) translateY(0); opacity: 0; }
+      }
+      @keyframes cl3 {
+        0%, 29%   { transform: scaleX(0); opacity: 0; }
+        30%       { transform: scaleX(0); opacity: 1; }
+        42%       { transform: scaleX(1); opacity: 1; }
+        42%, 85%  { transform: scaleX(1) translateY(0); opacity: 1; }
+        93%       { transform: scaleX(1) translateY(-3px); opacity: 0; }
+        94%, 100% { transform: scaleX(0) translateY(0); opacity: 0; }
+      }
+      @keyframes cl4 {
+        0%, 44%   { transform: scaleX(0); opacity: 0; }
+        45%       { transform: scaleX(0); opacity: 1; }
+        57%       { transform: scaleX(1); opacity: 1; }
+        57%, 88%  { transform: scaleX(1) translateY(0); opacity: 1; }
+        95%       { transform: scaleX(1) translateY(-3px); opacity: 0; }
+        96%, 100% { transform: scaleX(0) translateY(0); opacity: 0; }
+      }
+
+      /* Key flash: brief bright pulse, mostly off */
+      @keyframes kflash {
+        0%, 70%, 100% { opacity: 0; }
+        35% { opacity: 0.8; }
+      }
+
+      @keyframes float-data {
+        0%   { transform: translateY(0) scale(0.5); opacity: 0; }
+        10%  { opacity: 0.8; }
+        100% { transform: translateY(-17px) scale(1); opacity: 0; }
+      }
+    </style>
+    <g id="pixel-packet">
+      <rect x="0" y="0" width="1.5" height="1.5"/>
+    </g>
+  </defs>
+
+  <!-- Ground Shadow -->
+  <rect class="shadow-anim" x="3" y="15" width="9" height="1" fill="#000" opacity="0.5"/>
+
+  <!-- Data particles (behind screen, float up and disappear behind it) -->
+  <g fill="#40C4FF">
+    <use href="#pixel-packet" class="data-bit d1" x="3" y="7"/>
+    <use href="#pixel-packet" class="data-bit d2" x="7" y="8"/>
+    <use href="#pixel-packet" class="data-bit d3" x="11" y="7"/>
+    <use href="#pixel-packet" class="data-bit d4" x="5" y="8"/>
+  </g>
+
+  <!-- Mini Screen -->
+  <g id="screen" transform="translate(1.25, 0)">
+    <rect x="-0.5" y="-6" width="13.5" height="10.5" fill="#1E1E2E" rx="0.3"/>
+    <rect x="-0.5" y="-6" width="13.5" height="1.2" fill="#2D2D3D" rx="0.3"/>
+    <rect x="0.3" y="-5.6" width="0.5" height="0.4" fill="#FF5F56"/>
+    <rect x="1.2" y="-5.6" width="0.5" height="0.4" fill="#FFBD2E"/>
+    <rect x="2.1" y="-5.6" width="0.5" height="0.4" fill="#27C93F"/>
+
+    <!-- Code lines (indented, varying lengths = code structure) -->
+    <rect class="code-line cl1" x="0.5" y="-3.5" width="5"   height="0.7" fill="#4CAF50" opacity="0.8"/>
+    <rect class="code-line cl2" x="2"   y="-1.8" width="8"   height="0.7" fill="#4CAF50" opacity="0.8"/>
+    <rect class="code-line cl3" x="2"   y="-0.1" width="4.5" height="0.7" fill="#40C4FF" opacity="0.7"/>
+    <rect class="code-line cl4" x="0.5" y="1.6"  width="2"   height="0.7" fill="#FFC107" opacity="0.7"/>
+
+  </g>
+
+  <!-- Layer 1: Body -->
+  <g class="body-bounce">
+    <g class="breathe">
+      <g fill="#DE886D">
+        <rect x="3" y="13" width="1" height="2"/>
+        <rect x="5" y="13" width="1" height="2"/>
+        <rect x="9" y="13" width="1" height="2"/>
+        <rect x="11" y="13" width="1" height="2"/>
+        <rect x="2" y="6" width="11" height="7"/>
+      </g>
+      <g class="eyes-code" fill="#000">
+        <rect x="4" y="8" width="1" height="2"/>
+        <rect x="10" y="8" width="1" height="2"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- Layer 2: Keyboard -->
+  <g id="keyboard" transform="translate(-0.5, 11.8)">
+    <rect x="0" y="0" width="16" height="3.2" fill="#455A64" rx="0.3"/>
+    <g fill="#78909C">
+      <rect x="0.5" y="0.4" width="1" height="0.7"/>
+      <rect x="1.8" y="0.4" width="1" height="0.7"/>
+      <rect x="3.5" y="0.4" width="6" height="0.7" rx="0.2"/>
+      <rect x="10.2" y="0.4" width="1" height="0.7"/>
+      <rect x="11.5" y="0.4" width="1" height="0.7"/>
+      <rect x="12.8" y="0.4" width="1" height="0.7"/>
+      <rect x="14.1" y="0.4" width="1.3" height="0.7"/>
+    </g>
+    <g fill="#78909C">
+      <rect x="0.8" y="1.3" width="0.9" height="0.7"/>
+      <rect x="2.0" y="1.3" width="0.9" height="0.7"/>
+      <rect x="3.2" y="1.3" width="0.9" height="0.7"/>
+      <rect x="4.4" y="1.3" width="0.9" height="0.7"/>
+      <rect x="5.6" y="1.3" width="0.9" height="0.7"/>
+      <rect x="6.8" y="1.3" width="0.9" height="0.7"/>
+      <rect x="8.0" y="1.3" width="0.9" height="0.7"/>
+      <rect x="9.2" y="1.3" width="0.9" height="0.7"/>
+      <rect x="10.4" y="1.3" width="0.9" height="0.7"/>
+      <rect x="11.6" y="1.3" width="0.9" height="0.7"/>
+      <rect x="12.8" y="1.3" width="0.9" height="0.7"/>
+      <rect x="14.0" y="1.3" width="0.9" height="0.7"/>
+    </g>
+    <g fill="#78909C">
+      <rect x="0.5" y="2.2" width="0.9" height="0.7"/>
+      <rect x="1.7" y="2.2" width="0.9" height="0.7"/>
+      <rect x="2.9" y="2.2" width="0.9" height="0.7"/>
+      <rect x="4.1" y="2.2" width="0.9" height="0.7"/>
+      <rect x="5.3" y="2.2" width="0.9" height="0.7"/>
+      <rect x="6.5" y="2.2" width="0.9" height="0.7"/>
+      <rect x="7.7" y="2.2" width="0.9" height="0.7"/>
+      <rect x="8.9" y="2.2" width="0.9" height="0.7"/>
+      <rect x="10.1" y="2.2" width="0.9" height="0.7"/>
+      <rect x="11.3" y="2.2" width="0.9" height="0.7"/>
+      <rect x="12.5" y="2.2" width="0.9" height="0.7"/>
+      <rect x="13.7" y="2.2" width="0.9" height="0.7"/>
+      <rect x="14.9" y="2.2" width="0.6" height="0.7"/>
+    </g>
+    <!-- Key press highlights (overlay on top of keys) -->
+    <g fill="#B0BEC5">
+      <rect class="key-flash kf1" x="4.4" y="1.3" width="0.9" height="0.7"/>
+      <rect class="key-flash kf2" x="9.2" y="1.3" width="0.9" height="0.7"/>
+      <rect class="key-flash kf3" x="2.9" y="2.2" width="0.9" height="0.7"/>
+      <rect class="key-flash kf4" x="7.7" y="2.2" width="0.9" height="0.7"/>
+      <rect class="key-flash kf5" x="11.6" y="1.3" width="0.9" height="0.7"/>
+      <rect class="key-flash kf6" x="3.5" y="0.4" width="6" height="0.7" rx="0.2"/>
+    </g>
+  </g>
+
+  <!-- Layer 3: Arms -->
+  <g class="body-bounce">
+    <g class="breathe">
+      <g fill="#DE886D">
+        <g class="arm-l-type"><rect x="0" y="9" width="2" height="2"/></g>
+        <g class="arm-r-type"><rect x="13" y="9" width="2" height="2"/></g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-working-ultrathink.svg
+++ b/make-deck/skills/make-deck/assets/clawd-working-ultrathink.svg
@@ -1,0 +1,166 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <defs>
+    <style>
+      /* Intense body trembling */
+      .body-shake {
+        transform-origin: 7.5px 15px;
+        animation: shake 0.15s infinite alternate ease-in-out;
+      }
+
+      /* Shadow vibration */
+      .shadow-shake {
+        transform-origin: 7.5px 15.5px;
+        animation: shadow-vib 0.15s infinite alternate ease-in-out;
+      }
+
+      /* Right arm tapping chin fast */
+      .arm-tap-fast {
+        transform-origin: 14px 10px;
+        animation: tap-fast 0.8s infinite ease-in-out;
+      }
+
+      /* Concentrated squint blink */
+      .eyes-focus {
+        transform-origin: 7.5px 9px;
+        animation: focus-blink 2s infinite;
+      }
+
+      /* Brain sparks rising from head */
+      .spark {
+        opacity: 0;
+        animation: spark-rise 1.2s infinite ease-out;
+      }
+      .sp1 { animation-delay: 0s; }
+      .sp2 { animation-delay: 0.3s; }
+      .sp3 { animation-delay: 0.6s; }
+      .sp4 { animation-delay: 0.9s; }
+
+      /* Loading dots spinning */
+      .load-dot {
+        opacity: 0;
+        animation: dot-pulse 1.6s infinite;
+      }
+      .d1 { animation-delay: 0s; }
+      .d2 { animation-delay: 0.4s; }
+      .d3 { animation-delay: 0.8s; }
+
+      /* Steam puffs */
+      .steam {
+        opacity: 0;
+        animation: steam-rise 2s infinite ease-out;
+      }
+      .st1 { animation-delay: 0s; }
+      .st2 { animation-delay: 0.7s; }
+      .st3 { animation-delay: 1.4s; }
+
+      /* Ultrathink letters individual pulse */
+      .ul { animation: text-pulse 1s infinite ease-in-out; }
+      .ul0 { animation-delay: 0s; }
+      .ul1 { animation-delay: 0.1s; }
+      .ul2 { animation-delay: 0.2s; }
+      .ul3 { animation-delay: 0.3s; }
+      .ul4 { animation-delay: 0.4s; }
+      .ul5 { animation-delay: 0.5s; }
+      .ul6 { animation-delay: 0.6s; }
+      .ul7 { animation-delay: 0.7s; }
+      .ul8 { animation-delay: 0.8s; }
+      .ul9 { animation-delay: 0.9s; }
+
+      @keyframes text-pulse {
+        0%, 100% { opacity: 0.15; }
+        50% { opacity: 1; }
+      }
+
+      @keyframes shake {
+        0% { transform: translate(-0.3px, 0) rotate(-0.5deg); }
+        100% { transform: translate(0.3px, 0) rotate(0.5deg); }
+      }
+
+      @keyframes shadow-vib {
+        0% { transform: scaleX(0.98); }
+        100% { transform: scaleX(1.02); }
+      }
+
+      @keyframes tap-fast {
+        0%, 100% { transform: rotate(-125deg); }
+        50% { transform: rotate(-145deg); }
+      }
+
+      @keyframes focus-blink {
+        0%, 70%, 78%, 100% { transform: scaleY(1); }
+        74% { transform: scaleY(0.1); }
+      }
+
+      @keyframes spark-rise {
+        0% { transform: translate(0, 0) scale(1); opacity: 0; }
+        15% { opacity: 1; }
+        100% { transform: translate(2px, -12px) scale(0.3); opacity: 0; }
+      }
+
+      @keyframes dot-pulse {
+        0%, 100% { opacity: 0.2; }
+        25%, 75% { opacity: 1; }
+      }
+
+      @keyframes steam-rise {
+        0% { transform: translate(0, 0) scale(0.8); opacity: 0; }
+        20% { opacity: 0.6; }
+        100% { transform: translate(-2px, -10px) scale(1.5); opacity: 0; }
+      }
+    </style>
+  </defs>
+
+  <!-- Ground Shadow -->
+  <rect class="shadow-shake" x="3" y="15" width="9" height="1" fill="#000000" opacity="0.5"/>
+
+  <!-- Brain Sparks (mirrored x positions around center 7.5) -->
+  <g fill="#FFD700">
+    <rect class="spark sp1" x="10" y="2" width="1" height="1"/>
+    <rect class="spark sp2" x="6" y="0" width="1" height="1"/>
+    <rect class="spark sp3" x="3" y="1" width="1" height="1"/>
+    <rect class="spark sp4" x="8" y="-1" width="1" height="1"/>
+  </g>
+
+  <!-- Steam Puffs -->
+  <g fill="#AAAAAA" opacity="0.5">
+    <g class="steam st1"><rect x="5" y="3" width="2" height="1" rx="0.5"/><rect x="4" y="2" width="1" height="1" rx="0.5"/></g>
+    <g class="steam st2"><rect x="9" y="2" width="2" height="1" rx="0.5"/><rect x="10" y="1" width="1" height="1" rx="0.5"/></g>
+    <g class="steam st3"><rect x="7" y="3" width="1" height="1" rx="0.5"/><rect x="6" y="2" width="2" height="1" rx="0.5"/></g>
+  </g>
+
+  <!-- Loading Dots above head -->
+  <g fill="#FF6B35">
+    <rect class="load-dot d1" x="4" y="4" width="1" height="1"/>
+    <rect class="load-dot d2" x="7" y="4" width="1" height="1"/>
+    <rect class="load-dot d3" x="10" y="4" width="1" height="1"/>
+  </g>
+
+  <!-- Mirrored: body + legs only -->
+  <g transform="translate(15, 0) scale(-1, 1)">
+    <g id="legs" fill="#DE886D">
+      <rect x="3" y="13" width="1" height="2"/>
+      <rect x="5" y="13" width="1" height="2"/>
+      <rect x="9" y="13" width="1" height="2"/>
+      <rect x="11" y="13" width="1" height="2"/>
+    </g>
+
+    <g class="body-shake">
+      <g fill="#DE886D">
+        <rect x="2" y="6" width="11" height="7"/>
+        <rect x="0" y="9" width="3" height="2" transform="rotate(25 1 10)"/>
+        <g class="arm-tap-fast">
+          <rect x="13" y="9" width="2" height="2"/>
+        </g>
+      </g>
+      <g class="eyes-focus" fill="#000000">
+        <rect x="5" y="7" width="1" height="2"/>
+        <rect x="11" y="7" width="1" height="2"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- Ultrathink rainbow text (top layer, each letter pulses independently) -->
+  <text x="7.5" y="0" text-anchor="middle" font-family="'Söhne', 'Helvetica Neue', Arial, sans-serif" font-size="3.2" font-weight="600" letter-spacing="0.2">
+    <tspan class="ul ul0" fill="#FF5252">u</tspan><tspan class="ul ul1" fill="#FF9800">l</tspan><tspan class="ul ul2" fill="#FFC107">t</tspan><tspan class="ul ul3" fill="#4CAF50">r</tspan><tspan class="ul ul4" fill="#2196F3">a</tspan><tspan class="ul ul5" fill="#9C27B0">t</tspan><tspan class="ul ul6" fill="#FF5252">h</tspan><tspan class="ul ul7" fill="#FF9800">i</tspan><tspan class="ul ul8" fill="#4CAF50">n</tspan><tspan class="ul ul9" fill="#2196F3">k</tspan>
+  </text>
+</svg>

--- a/make-deck/skills/make-deck/assets/clawd-working-wizard.svg
+++ b/make-deck/skills/make-deck/assets/clawd-working-wizard.svg
@@ -1,0 +1,356 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+  <!-- clawd 戴巫师帽螃蟹走 v7 dark-hat variant - 2026-05-11
+       基于调参页参数回填:
+       dropY=2 dropX=0.7 recoverY=0.8 fallScale=1.11 pushScale=1
+       tilt=7.5 counterTilt=-3 brimX=-0.2 brimY=-0.5 brimTilt=7 brimCounterTilt=-1.5
+
+       魔法增强:
+         - hat-drop 负责掉落位移, hat-scale 负责 42/55 帧轻微放大。
+         - 帽身和帽檐分别调角度, 帽檐额外整体上移贴回帽身。
+         - 扶帽时帽子轻微上浮, 帽尖软弹, 帽星闪烁。
+         - 手碰帽后弹出 5 颗像素星尘, 增加巫师帽魔法感。
+         - 成功后眼睛看向用户并眨眼; 眼睛高光常驻显示。
+         - dark variant: 帽子改成更接近拼豆图纸的深蓝紫/靛紫配色。
+  -->
+
+  <defs>
+    <style>
+      .body-hunch {
+        transform-origin: 7.5px 15px;
+        animation: hunch-walk 7s infinite ease-in-out;
+      }
+      .leg-step { transform-origin: top center; transform-box: fill-box; }
+      .leg-1 { animation: leg-step 7s infinite linear; }
+      .leg-2 { animation: leg-step 7s infinite linear; animation-delay: -0.245s; }
+      .shadow-walk {
+        transform-origin: 7.5px 15.5px;
+        animation: shadow-walk 7s infinite ease-in-out;
+      }
+      .hat-drop {
+        transform-origin: 7.5px 6px;
+        animation: hat-drop 7s infinite ease-in-out;
+      }
+      .hat-scale {
+        transform-origin: 7.5px 6px;
+        animation: hat-scale 7s infinite ease-in-out;
+      }
+      .hat-tilt {
+        transform-origin: 7.5px 5px;
+        animation: hat-tilt 7s infinite ease-in-out;
+      }
+      .hat-crown-magic {
+        transform-origin: 7.5px 1px;
+        animation: hat-crown-magic 7s infinite ease-in-out;
+      }
+      .hat-stars-magic {
+        animation: hat-stars-magic 7s infinite ease-in-out;
+      }
+      .brim-tilt {
+        transform-origin: 7.5px 5.5px;
+        animation: brim-tilt 7s infinite ease-in-out;
+      }
+      .brim-center {
+        transform-origin: 7.5px 5.5px;
+        animation: brim-center-sag 7s infinite ease-in-out;
+      }
+      .brim-side {
+        animation: brim-side-fall 7s infinite ease-in-out;
+      }
+      .arm-fix {
+        transform-origin: 13px 10px;
+        animation: arm-fix 7s infinite ease-in-out;
+      }
+      .eyes-wizard {
+        transform-origin: 7.5px 9px;
+        animation: eyes-wizard 7s infinite ease-in-out;
+      }
+      svg:hover .eyes-wizard {
+        animation: eyes-user-hover 0.9s infinite ease-in-out;
+      }
+      .magic-sparkle-a { animation: magic-sparkle-a 7s infinite ease-in-out; opacity: 0; }
+      .magic-sparkle-b { animation: magic-sparkle-b 7s infinite ease-in-out; opacity: 0; }
+      .magic-sparkle-c { animation: magic-sparkle-c 7s infinite ease-in-out; opacity: 0; }
+      .magic-sparkle-d { animation: magic-sparkle-d 7s infinite ease-in-out; opacity: 0; }
+      .magic-sparkle-e { animation: magic-sparkle-e 7s infinite ease-in-out; opacity: 0; }
+
+      @keyframes hunch-walk {
+        0%   { transform: translate(-2px, 1px) rotate(2deg); }
+        14%  { transform: translate(3px, 1px) rotate(2deg); }
+        28%  { transform: translate(0, 1px) rotate(2deg); }
+        72%  { transform: translate(0, 1px) rotate(2deg); }
+        87%  { transform: translate(-3px, 1px) rotate(2deg); }
+        100% { transform: translate(-2px, 1px) rotate(2deg); }
+      }
+
+      @keyframes leg-step {
+        0%   { transform: rotate(0deg) scaleY(1); }
+        7%   { transform: rotate(-25deg) scaleY(0.7); }
+        14%  { transform: rotate(0deg) scaleY(1); }
+        21%  { transform: rotate(-25deg) scaleY(0.7); }
+        28%  { transform: rotate(0deg) scaleY(1); }
+        72%  { transform: rotate(0deg) scaleY(1); }
+        79%  { transform: rotate(-25deg) scaleY(0.7); }
+        86%  { transform: rotate(0deg) scaleY(1); }
+        93%  { transform: rotate(-25deg) scaleY(0.7); }
+        100% { transform: rotate(0deg) scaleY(1); }
+      }
+
+      @keyframes shadow-walk {
+        0%   { transform: translateX(-2px) scale(0.9); opacity: 0.4; }
+        14%  { transform: translateX(3px) scale(0.9); opacity: 0.4; }
+        28%  { transform: translateX(0) scale(0.9); opacity: 0.4; }
+        72%  { transform: translateX(0) scale(0.9); opacity: 0.4; }
+        87%  { transform: translateX(-3px) scale(0.9); opacity: 0.4; }
+        100% { transform: translateX(-2px) scale(0.9); opacity: 0.4; }
+      }
+
+      @keyframes hat-drop {
+        0%, 28% { transform: translate(0, 0); }
+        35%     { transform: translate(0.42px, 1px); }
+        42%, 55%{ transform: translate(0.7px, 2px); }
+        58%     { transform: translate(0.315px, 1.2px); }
+        63%     { transform: translate(0.105px, 0.35px); }
+        67%     { transform: translate(0, -0.35px); }
+        70%     { transform: translate(0, 0.15px); }
+        72%, 100%{ transform: translate(0, 0); }
+      }
+
+      @keyframes hat-scale {
+        0%, 28% { transform: scale(1); }
+        35%     { transform: scale(1.0495); }
+        42%, 55%{ transform: scale(1.11); }
+        58%, 67%{ transform: scale(1); }
+        72%, 100%{ transform: scale(1); }
+      }
+
+      @keyframes hat-tilt {
+        0%, 28% { transform: rotate(0deg); }
+        35%     { transform: rotate(3.15deg); }
+        42%, 55%{ transform: rotate(7.5deg); }
+        58%     { transform: rotate(-3deg); }
+        63%     { transform: rotate(2.1deg); }
+        67%     { transform: rotate(-1deg); }
+        70%     { transform: rotate(0.5deg); }
+        72%, 100%{ transform: rotate(0deg); }
+      }
+
+      @keyframes hat-crown-magic {
+        0%, 55%  { transform: rotate(0deg) translateY(0); }
+        58%      { transform: rotate(-2deg) translateY(-0.15px); }
+        62%      { transform: rotate(3deg) translateY(-0.35px); }
+        66%      { transform: rotate(-1.5deg) translateY(-0.15px); }
+        70%      { transform: rotate(0.8deg) translateY(0); }
+        72%, 100%{ transform: rotate(0deg) translateY(0); }
+      }
+
+      @keyframes hat-stars-magic {
+        0%, 52%  { opacity: 1; }
+        55%      { opacity: 0.35; }
+        58%      { opacity: 1; }
+        61%      { opacity: 0.45; }
+        64%      { opacity: 1; }
+        72%, 100%{ opacity: 1; }
+      }
+
+      @keyframes brim-tilt {
+        0%, 28% { transform: rotate(0deg); }
+        35%     { transform: rotate(3.15deg); }
+        42%, 55%{ transform: rotate(7deg); }
+        58%     { transform: rotate(-1.5deg); }
+        63%     { transform: rotate(1.4deg); }
+        67%     { transform: rotate(-0.6deg); }
+        70%     { transform: rotate(0.3deg); }
+        72%, 100%{ transform: rotate(0deg); }
+      }
+
+      @keyframes brim-center-sag {
+        0%, 28% { transform: translateY(0); }
+        35%     { transform: translateY(0.2px); }
+        42%, 55%{ transform: translateY(0.4px); }
+        58%     { transform: translateY(0.24px); }
+        63%     { transform: translateY(0.25px); }
+        67%     { transform: translateY(0.1px); }
+        72%, 100%{ transform: translateY(0); }
+      }
+
+      @keyframes brim-side-fall {
+        0%, 28% { transform: translateY(0); }
+        35%     { transform: translateY(0); }
+        42%, 55%{ transform: translateY(0); }
+        58%     { transform: translateY(0); }
+        63%     { transform: translateY(0); }
+        67%     { transform: translateY(0); }
+        72%, 100%{ transform: translateY(0); }
+      }
+
+      @keyframes arm-fix {
+        0%, 38%   { transform: rotate(0deg); }
+        45%       { transform: translate(-2px, -3px) rotate(-90deg); }
+        50%       { transform: translate(-2px, -3px) rotate(-90deg); }
+        55%       { transform: translate(-2px, -3px) rotate(-100deg); }
+        58%       { transform: translate(-2px, -3px) rotate(-80deg); }
+        62%       { transform: translate(-2px, -3px) rotate(-90deg); }
+        67%       { transform: rotate(0deg); }
+        100%      { transform: rotate(0deg); }
+      }
+
+      @keyframes eyes-wizard {
+        0%, 28%  { transform: translateX(2px) scaleY(1); }
+        32%      { transform: translateX(0) scaleY(1); }
+        38%, 58% { transform: translateX(0) scaleY(1); }
+        62%      { transform: translate(0, -0.25px) scaleY(1); }
+        66%      { transform: translate(0, -0.15px) scaleY(1.12); }
+        70%      { transform: translateX(0) scaleY(0.1); }
+        73%      { transform: translateX(0) scaleY(1.08); }
+        78%      { transform: translateX(-0.7px) scaleY(1); }
+        82%      { transform: translateX(0.4px) scaleY(1); }
+        88%      { transform: translateX(2px) scaleY(1); }
+        100%     { transform: translateX(2px) scaleY(1); }
+      }
+
+      @keyframes eyes-user-hover {
+        0%   { transform: translateX(0) scaleY(1); }
+        45%  { transform: translateX(0) scaleY(1); }
+        55%  { transform: translateX(0) scaleY(0.18); }
+        70%  { transform: translateX(0) scaleY(1.08); }
+        100% { transform: translateX(0) scaleY(1); }
+      }
+
+      @keyframes magic-sparkle-a {
+        0%, 47%  { opacity: 0; transform: translate(0, 0); }
+        50%      { opacity: 1; transform: translate(0, 0); }
+        58%      { opacity: 1; transform: translate(-1.6px, -2.2px); }
+        66%      { opacity: 0; transform: translate(-2.6px, -3.6px); }
+        100%     { opacity: 0; transform: translate(-2.6px, -3.6px); }
+      }
+
+      @keyframes magic-sparkle-b {
+        0%, 50%  { opacity: 0; transform: translate(0, 0); }
+        54%      { opacity: 1; transform: translate(0, 0); }
+        62%      { opacity: 1; transform: translate(1.7px, -1.8px); }
+        70%      { opacity: 0; transform: translate(2.8px, -3px); }
+        100%     { opacity: 0; transform: translate(2.8px, -3px); }
+      }
+
+      @keyframes magic-sparkle-c {
+        0%, 52%  { opacity: 0; transform: translate(0, 0); }
+        56%      { opacity: 1; transform: translate(0, 0); }
+        64%      { opacity: 0.8; transform: translate(-0.8px, -2.8px); }
+        72%      { opacity: 0; transform: translate(-1.2px, -3.8px); }
+        100%     { opacity: 0; transform: translate(-1.2px, -3.8px); }
+      }
+
+      @keyframes magic-sparkle-d {
+        0%, 53%  { opacity: 0; transform: translate(0, 0); }
+        58%      { opacity: 1; transform: translate(0, 0); }
+        66%      { opacity: 0.7; transform: translate(2.2px, -1px); }
+        72%      { opacity: 0; transform: translate(3.4px, -1.8px); }
+        100%     { opacity: 0; transform: translate(3.4px, -1.8px); }
+      }
+
+      @keyframes magic-sparkle-e {
+        0%, 56%  { opacity: 0; transform: translate(0, 0); }
+        60%      { opacity: 1; transform: translate(0, 0); }
+        68%      { opacity: 0.8; transform: translate(-1.8px, 0.8px); }
+        74%      { opacity: 0; transform: translate(-2.8px, 1.2px); }
+        100%     { opacity: 0; transform: translate(-2.8px, 1.2px); }
+      }
+    </style>
+  </defs>
+
+  <rect id="ground-shadow" class="shadow-walk" x="3" y="15" width="9" height="1" fill="#000000" opacity="0.5"/>
+
+  <g class="body-hunch">
+
+    <g id="legs" fill="#DE886D">
+      <rect class="leg-step leg-1" x="3" y="13" width="1" height="2"/>
+      <rect class="leg-step leg-2" x="5" y="13" width="1" height="2"/>
+      <rect class="leg-step leg-1" x="9" y="13" width="1" height="2"/>
+      <rect class="leg-step leg-2" x="11" y="13" width="1" height="2"/>
+    </g>
+
+    <g id="body-color-group" fill="#DE886D">
+      <rect id="torso" x="2" y="6" width="11" height="7"/>
+      <rect id="left-arm" x="0" y="9" width="2" height="2"/>
+    </g>
+
+    <g class="eyes-wizard" fill="#000000">
+      <rect x="4" y="8" width="1" height="2"/>
+      <rect x="10" y="8" width="1" height="2"/>
+      <rect x="4" y="8" width="0.35" height="0.35" fill="#FFFFFF"/>
+      <rect x="10" y="8" width="0.35" height="0.35" fill="#FFFFFF"/>
+    </g>
+
+    <!-- 巫师帽: 帽身倾斜, 帽檐软碰撞 -->
+    <g class="hat-drop">
+      <g class="hat-scale">
+      <g id="wizard-hat-fit" transform="translate(0, 1.5) translate(7.5, 6) scale(0.95) translate(-7.5, -6)">
+        <g class="hat-tilt">
+          <g class="hat-crown-magic">
+          <g id="hat-cone" fill="#5865C8">
+            <rect x="3" y="-5" width="4" height="1"/>
+            <rect x="2" y="-4" width="6" height="1"/>
+            <rect x="2" y="-3" width="7" height="1"/>
+            <rect x="4" y="-2" width="6" height="1"/>
+            <rect x="3" y="-1" width="8" height="1"/>
+            <rect x="3" y="0"  width="9" height="1"/>
+            <rect x="2" y="1"  width="11" height="1"/>
+            <rect x="2" y="2"  width="11" height="1"/>
+          </g>
+          <g id="hat-fold" fill="#404CB0">
+            <rect x="4" y="-3" width="1" height="1"/>
+            <rect x="4" y="-2" width="1" height="1"/>
+          </g>
+          <g id="hat-stars" class="hat-stars-magic" fill="#FFFFFF">
+            <rect x="6" y="-4" width="1" height="1"/>
+            <rect x="3" y="-3" width="1" height="1"/>
+            <rect x="7" y="-2" width="1" height="1"/>
+            <rect x="8" y="0"  width="1" height="1"/>
+            <rect x="4" y="1"  width="1" height="1"/>
+            <rect x="10" y="2" width="1" height="1"/>
+          </g>
+          </g>
+          <g id="hat-band" fill="#2C2557">
+            <rect x="1" y="3" width="13" height="2"/>
+          </g>
+        </g>
+
+        <g transform="translate(-0.2, -0.5)">
+        <g class="brim-tilt">
+        <g id="hat-brim" fill="#6A70D8">
+          <rect class="brim-side" x="-1" y="5" width="3" height="1"/>
+          <rect class="brim-center" x="2" y="5" width="11" height="1"/>
+          <rect class="brim-side" x="13" y="5" width="3" height="1"/>
+        </g>
+        </g>
+        </g>
+      </g>
+      </g>
+    </g>
+
+    <g class="arm-fix" fill="#DE886D">
+      <rect id="right-arm" x="13" y="9" width="2" height="2"/>
+    </g>
+
+    <g id="magic-sparkles">
+      <g class="magic-sparkle-a" fill="#FFF3A8">
+        <rect x="13" y="2.8" width="1.1" height="1.1"/>
+      </g>
+      <g class="magic-sparkle-b" fill="#FFFFFF">
+        <rect x="15" y="4" width="1" height="1"/>
+        <rect x="15.35" y="3.65" width="0.3" height="1.7"/>
+        <rect x="14.65" y="4.35" width="1.7" height="0.3"/>
+      </g>
+      <g class="magic-sparkle-c" fill="#DCC5FF">
+        <rect x="9.2" y="3.4" width="1.1" height="1.1"/>
+      </g>
+      <g class="magic-sparkle-d" fill="#FFF3A8">
+        <rect x="15.4" y="6.2" width="1" height="1"/>
+      </g>
+      <g class="magic-sparkle-e" fill="#FFFFFF">
+        <rect x="9" y="6.5" width="0.9" height="0.9"/>
+      </g>
+    </g>
+
+  </g>
+</svg>

--- a/make-deck/skills/make-deck/assets/templates/deck-skeleton.html
+++ b/make-deck/skills/make-deck/assets/templates/deck-skeleton.html
@@ -1,0 +1,478 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Deck Skeleton — 레이아웃 카탈로그 (소스: 2026-04-20 context-efficiency deck)</title>
+
+<!-- ┌─ 템플릿 사용법 (이 주석은 새 덱 복사 후 삭제 가능) ─────────────────
+     1. 이 파일을 `../{YYYY-MM-DD-주제-deck.html}` 로 복사한 뒤 편집한다.
+        예: `cp ~/.claude/.write/templates/deck-skeleton.html ~/.claude/.write/2026-06-15-새주제-deck.html`
+     2. <title>, ZONE 안 슬라이드, talk 큐, chrome-bl 라벨을 새 주제로 채운다.
+     3. 마스코트 SVG는 `../clawd-*.svg` (flat) 에 41종 비치. 새 포즈가 필요하면
+        `~/Downloads/github/oss/clawd-on-desk/assets/svg/` 에서 flat 복사 + viewBox 정규화.
+        ※ 템플릿 위치(templates/)에서는 마스코트가 보이지 않음 — 정상. 복사 후엔 렌더됨.
+     4. 레이아웃 클래스(.lay-cover/.lay-statement/.lay-divider/.lay-split[.rev]
+        /.lay-twocol/.lay-clips/.lay-list/.lay-cue/.lay-bleed/.lay-checklist)는 그대로 두고
+        콘텐츠만 교체. 각 슬라이드 상단 주석에 "서사 기능"과 "권장 사용처" 명시.
+     5. 슬라이드 추가는 자기 ZONE의 닫는 앵커(`/ZONE: X`) 바로 앞에 insert (병렬 추가 규약).
+     6. 색상 토큰(--blue/--purple/--amber)은 :root 에서 한 번에 교체하면 전 슬라이드 톤 변경.
+     7. 4개 ZONE(오프닝 / Part1 / Part2 / Part3+마무리)은 동일 방법론의 골격 — 주제만 갈아끼움.
+        오프닝=비유 도입+외부 환기+오리엔테이션 / Part1=왜(개념·근거) / Part2=실습(직접 해보기)
+        / Part3+마무리=대화(정해지지 않은 슬라이드)+요약 체크리스트.
+     └─────────────────────────────────────────────────────────────────── -->
+
+<style>
+  /* ===== 공유 토큰 (slide-layout-archetypes.bundle.md §3) ===== */
+  :root{
+    --blue:#2563EB; --purple:#7C3AED; --amber:#F59E0B;
+    --ink:#1f2430; --muted:#8b93a3; --line:#e6e9f0; --bg:#fff; --soft:#f7f8fb;
+  }
+  *{box-sizing:border-box;}
+  html,body{margin:0;height:100%;background:#11131a;
+    font-family:-apple-system,BlinkMacSystemFont,"Apple SD Gothic Neo","Pretendard","Segoe UI",sans-serif;color:var(--ink);}
+  .deck{width:100vw;height:100vh;}
+
+  /* ===== 베이스 프레임 (뷰포트 꽉 채우기 · 패딩은 레이아웃이 소유 → divider/bleed 풀블리드) ===== */
+  .slide{display:none;width:100vw;height:100vh;background:var(--bg);
+    position:relative;overflow:hidden;}
+  .slide.active{display:block;}
+  .msg{font:700 clamp(26px,3.4vw,46px)/1.22 sans-serif;letter-spacing:-.01em;color:var(--ink);}
+  .msg .em{color:var(--blue);}
+  .sub{margin-top:14px;font:500 17px/1.5 sans-serif;color:var(--muted);}
+  .chip{display:inline-flex;align-items:center;gap:8px;margin-top:22px;
+    font:700 16px/1 sans-serif;color:#9a6200;background:#fff7e6;
+    border:1.5px solid var(--amber);padding:10px 14px;border-radius:999px;}
+  .chip .n{background:var(--amber);color:#fff;border-radius:6px;padding:3px 7px;font:700 12px/1 ui-monospace,monospace;}
+  /* 발표자 큐 (presenter cue) — 본문 흐름에서 빼서 슬라이드 최하단에 작은 글씨로 오버레이.
+     position:absolute라 DOM 어디 있든 .slide 기준 하단 중앙에 모임(청중엔 작게, 발표자 글랜스용).
+     반투명 배경으로 본문 위에서도 가독 확보 · chrome(bottom:20px)·hint(14px) 위(38px)에 안착. */
+  .talk{position:absolute;left:50%;bottom:38px;transform:translateX(-50%);z-index:4;
+    width:min(82vw,1140px);margin:0;padding:5px 16px;border:0;border-radius:8px;
+    background:rgba(255,255,255,.82);text-align:center;font:500 11px/1.35 sans-serif;color:#9aa1b1;}
+  .talk b{color:var(--muted);font-weight:700;}
+  .slide.dark .talk{background:rgba(20,24,40,.42);color:rgba(255,255,255,.8);}
+  .slide.dark .talk b{color:#fff;}
+
+  /* ===== 코너 크롬 (레이아웃 독립 · §4 공통 골격) ===== */
+  .chrome-tl{position:absolute;top:22px;left:30px;z-index:3;display:flex;align-items:center;gap:10px;}
+  .badge{font:700 13px/1 ui-monospace,monospace;color:#fff;background:var(--blue);padding:6px 10px;border-radius:7px;letter-spacing:.5px;}
+  .badge.p2{background:var(--purple);}
+  .part{font:600 13px/1 sans-serif;color:var(--muted);letter-spacing:.3px;}
+  .chrome-bl{position:absolute;bottom:20px;left:30px;z-index:3;font:600 12px/1 sans-serif;color:var(--muted);}
+  .chrome-br{position:absolute;bottom:20px;right:30px;z-index:3;font:600 12px/1 ui-monospace,monospace;color:var(--muted);}
+  .slide.dark .part,.slide.dark .chrome-bl,.slide.dark .chrome-br{color:rgba(255,255,255,.8);}
+
+  /* ===== 레이아웃 변형 (.lay-*) — 번들 §3 채택 ===== */
+  .lay-cover{display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;height:100%;gap:16px;padding:64px;}
+  .lay-cover .msg{font-size:clamp(34px,4.6vw,62px);}
+
+  .lay-statement{display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;height:100%;padding:64px;}
+  .lay-statement .msg{font-size:clamp(32px,4.8vw,64px);max-width:20ch;}
+
+  .lay-divider{display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;height:100%;padding:64px;
+    background:linear-gradient(135deg,var(--blue),var(--purple));}
+  .lay-divider .msg{color:#fff;font-size:clamp(34px,4.6vw,62px);}
+  .lay-divider .sub{color:rgba(255,255,255,.85);}
+  .lay-divider .chip{background:rgba(255,255,255,.14);border-color:rgba(255,255,255,.55);color:#fff;}
+  .lay-divider .chip .n{background:#fff;color:var(--purple);}
+
+  .lay-split{display:grid;grid-template-columns:1.05fr .95fr;gap:40px;align-items:center;height:100%;padding:72px 64px;}
+  .lay-split.rev{grid-template-columns:.95fr 1.05fr;}
+  .lay-split.rev .text{order:2;} .lay-split.rev .media{order:1;}
+  .lay-split .media{height:100%;display:flex;align-items:center;justify-content:center;border-radius:14px;
+    background:var(--soft);border:1px solid var(--line);overflow:hidden;position:relative;}
+  .lay-split .media img{max-width:100%;max-height:100%;object-fit:contain;}
+  /* 세로(9:16) 쇼츠: 미디어를 9:16 프레임으로, 플레이어를 키워 양옆 검은 띠 크롭 */
+  .lay-split .media.short{aspect-ratio:9/16;height:100%;width:auto;max-width:100%;margin:0 auto;background:#000;border:0;padding:0;}
+  .lay-split .media.short iframe{position:absolute;top:0;left:50%;transform:translateX(-50%);height:100%;width:auto;aspect-ratio:16/9;}
+
+  .lay-twocol{display:flex;flex-direction:column;justify-content:center;height:100%;padding:72px 64px;gap:24px;}
+  .lay-twocol .cols{display:grid;grid-template-columns:1fr 1fr;gap:28px;}
+  .lay-twocol .col{background:var(--soft);border:1px solid var(--line);border-radius:14px;padding:26px;}
+  .lay-twocol .col h3{margin:0 0 10px;font:700 22px/1.2 sans-serif;color:var(--ink);}
+  .lay-twocol .col p{margin:0;font:500 15px/1.5 sans-serif;color:var(--muted);}
+
+  /* 헤드라인 클립 콜라주 (환기 — 외부 인용·기사 카드 6개) */
+  .lay-clips{display:flex;flex-direction:column;justify-content:center;height:100%;padding:52px 60px;gap:16px;}
+  .lay-clips .head .msg{font-size:clamp(26px,3vw,38px);}
+  .lay-clips .head .sub{margin-top:8px;}
+  .lay-clips .clips{display:grid;grid-template-columns:repeat(3,1fr);gap:13px;}
+  .lay-clips .clip{background:var(--soft);border:1px solid var(--line);border-radius:12px;padding:13px 15px;
+    display:flex;flex-direction:column;gap:5px;}
+  .lay-clips .clip .src{font:800 11px/1 sans-serif;color:var(--blue);letter-spacing:.4px;text-transform:uppercase;}
+  .lay-clips .clip .hl{font:700 14.5px/1.32 sans-serif;color:var(--ink);}
+  .lay-clips .clip .gl{font:500 12px/1.4 sans-serif;color:var(--muted);}
+  .lay-clips .clip.accent{background:#fff7e6;border-color:var(--amber);}
+  .lay-clips .clip.accent .src{color:#9a6200;}
+
+  .lay-list{display:flex;flex-direction:column;justify-content:center;height:100%;padding:72px 64px;gap:16px;}
+  .lay-list ul{margin:0;padding:0;list-style:none;display:grid;gap:12px;}
+  .lay-list li{font:600 22px/1.35 sans-serif;padding-left:28px;position:relative;color:var(--ink);}
+  .lay-list li span{font-weight:500;color:var(--muted);font-size:16px;}
+  .lay-list li::before{content:"";position:absolute;left:0;top:.5em;width:10px;height:10px;border-radius:3px;background:var(--blue);}
+
+  .lay-cue{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;padding:64px;}
+  .lay-cue .quote{max-width:24ch;text-align:center;font:700 clamp(26px,3.4vw,46px)/1.32 sans-serif;color:var(--ink);
+    padding:38px 44px;border-radius:18px;background:var(--soft);border:1px solid var(--line);position:relative;}
+  .lay-cue .quote::before{content:"\201C";position:absolute;left:20px;top:2px;font-size:64px;color:var(--blue);opacity:.35;}
+  .lay-cue .attr{margin-top:16px;font:600 15px/1.4 sans-serif;color:var(--muted);}
+
+  .lay-bleed{height:100%;position:relative;overflow:hidden;}
+  .lay-bleed img{width:100%;height:100%;object-fit:cover;display:block;}
+  .lay-bleed .overlay{position:absolute;left:0;bottom:0;width:100%;padding:48px 64px;background:linear-gradient(transparent,rgba(20,24,40,.8));}
+  .lay-bleed .overlay .msg{color:#fff;}
+
+  .lay-checklist{display:flex;flex-direction:column;justify-content:center;height:100%;padding:72px 64px;gap:24px;}
+  .lay-checklist .grid{display:grid;grid-template-columns:1fr 1fr;gap:14px 30px;}
+  .lay-checklist .it{display:flex;gap:12px;align-items:flex-start;font:600 19px/1.35 sans-serif;color:var(--ink);}
+  .lay-checklist .it .k{flex:0 0 28px;height:28px;border-radius:8px;background:var(--blue);color:#fff;
+    display:flex;align-items:center;justify-content:center;font:700 14px/1 ui-monospace,monospace;}
+  .lay-checklist .it.accent .k{background:var(--amber);}
+
+  .ribbon{position:absolute;top:12px;right:-34px;transform:rotate(38deg);background:var(--amber);color:#fff;
+    font:700 11px/1 sans-serif;padding:6px 40px;letter-spacing:.5px;z-index:2;}
+  .hint{position:fixed;bottom:14px;left:50%;transform:translateX(-50%);color:#5a6172;font:500 12px/1 sans-serif;letter-spacing:.3px;}
+
+  /* ===== 마스코트 데코레이터 (clawd-on-desk · 레이아웃 독립 · 코너 액센트) =====
+     작게·은은하게 · pointer-events 없음(클릭 네비 통과) · 코너 크롬과 비충돌(top-right) */
+  /* 전 포즈 동일 viewBox(-15 -25 45 45) → 단일 규칙으로 전 슬라이드 동일 위치 정렬.
+     viewBox에 말풍선/점프용 빈 공간이 넓어 몸통은 박스 중앙·하단(빈 공간 투명 → 코너에 바짝). */
+  .deco{position:absolute;top:2px;right:45px;width:165px;height:165px;z-index:2;
+    pointer-events:none;filter:drop-shadow(0 3px 6px rgba(20,24,40,.16));}
+</style>
+</head>
+<body>
+<div class="deck" id="deck">
+
+  <!-- ┌─ 마스코트 데코레이터 규약 (clawd-on-desk) ──────────────────────────────
+       슬라이드를 추가할 때마다 <section class="slide"> 안, chrome-tl 바로 다음에
+       마스코트 1개를 함께 넣는다. 빠뜨리지 말 것 — 덱 전반 일관 배치가 의도.
+
+         <object class="deco" type="image/svg+xml" data="clawd-<pose>.svg"
+                 aria-hidden="true" tabindex="-1"></object>
+
+       · 위치·크기: 위 <style>의 .deco 단일 규칙이 전 슬라이드를 지배(현재 튜닝값 right:45px).
+         개별 슬라이드만 옮기려면 그 object에 보조 클래스(.deco.move-xx)를 더해 덮어쓴다.
+       · 포즈 선택: 슬라이드 내용·감정에 맞춰 고른다. 전체 41종 라이브러리는
+         ~/Downloads/github/oss/clawd-on-desk/assets/svg/ 참고.
+       · 새 포즈를 쓰면 해당 SVG를 이 폴더(.write/)에 플랫 복사하고
+         viewBox를 "-15 -25 45 45"로 맞출 것(about-hero는 정규화 완료). 안 맞추면 위치가 어긋남.
+       · ⚠ 권위(source of truth)는 각 슬라이드의 인라인 <object data="clawd-*.svg">.
+         아래는 이 템플릿의 기본 포즈 배정(중립 포즈 위주). 새 덱에서 자유 교체.
+       └───────────────────────────────────────────────────────────────────── -->
+
+  <!-- ┌─ 병렬 추가 규약 (ZONE) ──────────────────────────────────────────────
+       새 슬라이드는 자기 존의 "<!-- ══ /ZONE: X ══ -->" 바로 앞에 insert한다.
+       존 경계 앵커는 존마다 유일 → 다른 존끼리는 동시에 추가해도 충돌하지 않는다.
+       "누가 어느 존"의 오너십은 이 파일이 아니라 Task(owner 필드)로 관리 → 파일 무경합 claim.
+       한 존 내부는 한 오너가 직렬 진행. S번호는 콘텐츠 라벨일 뿐 삽입 키가 아니다(위치와 무관).
+       └──────────────────────────────────────────────────────────────────── -->
+
+  <!-- ══════ ZONE: 오프닝 (소개·오리엔테이션) ══════ -->
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       [LAYOUT 1/10] lay-cover · 산 약속 (표지)
+       · 서사 기능: 제목 + 부제로 "오늘 무엇을 약속하는가"를 한 화면에. 발표 시작점.
+       · 권장 사용처: 표지, 클로징 cover(있다면)
+       · 변형: <span style="color:var(--amber)">…</span> 으로 핵심어 강조 / chip 추가로 일정·장소 표시
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide">
+    <div class="chrome-tl"><span class="badge">표지</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-about-hero.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-cover">
+      <div class="msg">{{발표 제목 — <span style="color:var(--amber)">핵심어</span>는 앰버로 강조}}<br>{{서브 라인}}</div>
+      <div class="sub">{{일시 · 장소 · 행사명}}</div>
+    </div>
+    <div class="chrome-bl">{{슬라이드 한 줄 라벨 — 예: "산 약속으로 오픈"}}</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       [LAYOUT 2/10] lay-statement · 한 줄 명제
+       · 서사 기능: 한 슬라이드 = 한 문장. 비유 도입·핵심 주장·전환 다리에 사용.
+       · 권장 사용처: 여는 이야기(비유), 본론 진입 명제, Part 사이 다리(예: Part1→2)
+       · 변형: chip으로 액션 번호 부여 / .em 인라인 강조 / sub로 부연 설명
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide">
+    <div class="chrome-tl"><span class="part">여는 이야기</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-mini-enter.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-statement">
+      <div class="msg">{{비유 한 줄 — <span class="em">핵심어</span>는 블루 강조}}</div>
+      <div class="sub" style="margin-top:12px;">{{비유 풀어 쓰기 1문장}}</div>
+      <div class="sub" style="margin-top:10px;font-size:21px;font-weight:700;color:var(--ink);">{{비유→주제 매핑 한 줄}}</div>
+      <div class="sub" style="margin-top:8px;">{{오늘 할 일 한 줄}}</div>
+      <div class="talk"><b>말하기</b> · {{발표자 노트 — 어디까지 풀고, 다음 슬라이드로 어떻게 받을지}}</div>
+    </div>
+    <div class="chrome-bl">{{슬라이드 라벨 — 예: "오늘 한 줄"}}</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       [LAYOUT 3/10] lay-clips · 헤드라인 콜라주 (외부 인용 카드 6개)
+       · 서사 기능: 외부 기사·발언으로 "실태"를 한 화면에 누적. 환기·문제 정의.
+       · 권장 사용처: 여는 환기(비유→실태 증거), Part1 도입(시장 실태 카드)
+       · 변형: 6번째 카드에 .accent (앰버) — "공통 진단"·요약 카드로 사용
+       · 출처 형식: src(매체명·대문자) / hl(헤드라인) / gl(부연·숫자)
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide">
+    <div class="chrome-tl"><span class="part">여는 환기</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-working-juggling.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-clips">
+      <div class="head">
+        <div class="msg">{{환기 헤드라인 — <span class="em">한 줄로</span>}}</div>
+        <div class="sub">{{실태를 짚는 부연 1줄}}</div>
+      </div>
+      <div class="clips">
+        <div class="clip"><div class="src">{{매체 1}}</div><div class="hl">{{헤드라인 1}}</div><div class="gl">{{부연·수치 1}}</div></div>
+        <div class="clip"><div class="src">{{매체 2}}</div><div class="hl">{{헤드라인 2}}</div><div class="gl">{{부연·수치 2}}</div></div>
+        <div class="clip"><div class="src">{{매체 3}}</div><div class="hl">{{헤드라인 3}}</div><div class="gl">{{부연·수치 3}}</div></div>
+        <div class="clip"><div class="src">{{매체 4}}</div><div class="hl">{{헤드라인 4}}</div><div class="gl">{{부연·수치 4}}</div></div>
+        <div class="clip"><div class="src">{{매체 5}}</div><div class="hl">{{헤드라인 5}}</div><div class="gl">{{부연·수치 5}}</div></div>
+        <div class="clip accent"><div class="src">공통 진단</div><div class="hl">{{여섯 카드를 묶는 한 줄}}</div><div class="gl">{{한 줄 의미}}</div></div>
+      </div>
+      <div class="talk"><b>말하기</b> · {{카드 빠르게 훑고 다음 장으로 받는 멘트}}</div>
+    </div>
+    <div class="chrome-bl">{{슬라이드 라벨 — 예: "지금 벌어지는 일"}}</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       [LAYOUT 4/10] lay-cue · 청중 활동 큐 (인용 박스)
+       · 서사 기능: 청중에게 "지금 이걸 떠올려 두세요" — 강의 흐름에 액션 큐 삽입.
+       · 권장 사용처: 들어가기 전(실습 prep), Part 3 대화 진입(질문 던지기)
+       · 변형: quote 한 줄/두 줄 / attr에 부연 설명 또는 다음 단계 안내
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide">
+    <div class="chrome-tl"><span class="part">들어가기 전에</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-idle-bubble.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-cue">
+      <div class="quote">{{청중 활동 큐 — <b>핵심어</b>는 굵게}}</div>
+      <div class="attr">{{큐의 맥락·다음 단계 안내}}</div>
+    </div>
+    <div class="chrome-bl">{{슬라이드 라벨 — 예: "각자 한 편"}}</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ══════ /ZONE: 오프닝 ══════ -->
+
+  <!-- ══════ ZONE: Part1 (왜) ══════ -->
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       [LAYOUT 5/10] lay-split · 텍스트 + 미디어 (좌:우 ≈ 1.05:0.95)
+       · 서사 기능: 비유 그림/실측 이미지/영상 + 그것을 푸는 텍스트. 본론 카드의 주력.
+       · 권장 사용처: 본론 환기(영상 .media.short), 비유 카드(이미지+해설), 실습 프롬프트
+       · 변형: .media에 <img> 대신 텍스트 카드(프롬프트 박스) 가능 — S9-S11 idiom
+       · .media.short — 9:16 유튜브 쇼츠 (iframe 자동 16:9 크롭)
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide">
+    <div class="chrome-tl"><span class="badge">S1</span><span class="part">Part 1 · 왜</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-working-thinking.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-split">
+      <div class="text">
+        <div class="msg">{{한 줄 명제 — <span class="em">핵심어</span> 강조}}</div>
+        <div class="sub">{{비유/근거를 한 문장으로}}</div>
+        <div class="chip"><span class="n">1</span> {{이 슬라이드의 액션 한 줄}}</div>
+        <div class="talk"><b>말하기</b> · {{발표자 노트}}</div>
+      </div>
+      <div class="media">
+        <img src="{{이미지 파일명.png}}" alt="{{대체 텍스트}}">
+        <!-- 변형: 텍스트 카드를 .media 안에 넣으려면 (S9-S11 idiom):
+          <div style="text-align:left;padding:30px 34px;">
+            <div style="color:var(--purple);font-weight:800;font-size:13px;letter-spacing:.3px;margin-bottom:12px;">{{카드 라벨}}</div>
+            <div style="font:700 clamp(19px,2.1vw,29px)/1.42 sans-serif;color:var(--ink);">{{카드 본문}}</div>
+          </div>
+          영상(쇼츠): <div class="media short"><iframe src="..." allowfullscreen></iframe></div> -->
+      </div>
+    </div>
+    <div class="chrome-bl">{{슬라이드 라벨}}</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       [LAYOUT 6/10] lay-split.rev · 미디어 + 텍스트 (좌:우 ≈ 0.95:1.05, 미디어 좌측)
+       · 서사 기능: lay-split과 동일하나 시선 방향 변경 — 좌우 교차로 단조로움 방지.
+       · 권장 사용처: 연속된 split 카드 사이 교대(S2 → S3.rev → S4 → S6.rev 패턴)
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide">
+    <div class="chrome-tl"><span class="badge">S2</span><span class="part">Part 1 · 왜</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-working-ultrathink.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-split rev">
+      <div class="text">
+        <div class="msg">{{한 줄 명제 — <span class="em">핵심어</span> 강조}}</div>
+        <div class="sub">{{비유/근거}}</div>
+        <div class="chip"><span class="n">2</span> {{액션 한 줄}}</div>
+        <div class="talk"><b>말하기</b> · {{발표자 노트}}</div>
+      </div>
+      <div class="media"><img src="{{이미지 파일명.png}}" alt="{{대체 텍스트}}"></div>
+    </div>
+    <div class="chrome-bl">{{슬라이드 라벨}}</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       [LAYOUT 7/10] lay-list · 항목 리스트 (블루 사각 불릿)
+       · 서사 기능: 개념을 3-4개 핵심 항목으로 분해. 정의·원칙·체크포인트.
+       · 권장 사용처: 개념 정의(점진공개·핵심 원칙), 액션 항목, 명령어 카탈로그
+       · 변형: li 안 <span>으로 부연 설명 추가 / 항목 사이 grid gap 조정
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide">
+    <div class="chrome-tl"><span class="badge">S3</span><span class="part">Part 1 · 개념</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-idle-reading.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-list">
+      <div class="msg">{{개념명}} <span class="em">({{영문/부연}})</span></div>
+      <ul>
+        <li>{{핵심 항목 1}} <span>({{부연·예시}})</span></li>
+        <li>{{핵심 항목 2}} <span>({{부연·예시}})</span></li>
+        <li>{{핵심 항목 3}} <span>({{부연·예시}})</span></li>
+      </ul>
+      <div class="talk"><b>말하기</b> · {{발표자 노트}}</div>
+    </div>
+    <div class="chrome-bl">{{슬라이드 라벨}}</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       [LAYOUT 8/10] lay-twocol · 두 카드 나란히
+       · 서사 기능: 대조(✗/✓), 두 가지 씨앗, 비교 표. 두 옵션의 우열·트레이드오프.
+       · 권장 사용처: 비교(잘못된 방식 vs 권장 방식), 닫는 씨앗(다음으로 가져갈 것 2개)
+       · 변형: col 내부 h3+p 단순 카드 / 복잡한 인포그래픽(다이어그램·박스 스택) 가능
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide">
+    <div class="chrome-tl"><span class="badge">S4</span><span class="part">Part 1 · 비교</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-working-juggling.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-twocol">
+      <div class="msg">{{비교의 한 줄 제목}}</div>
+      <div class="cols">
+        <div class="col"><h3>{{왼쪽 카드 제목}}</h3><p>{{왼쪽 카드 본문 — 단점·문제·"이렇게는 X"}}</p></div>
+        <div class="col"><h3>{{오른쪽 카드 제목}}</h3><p>{{오른쪽 카드 본문 — 장점·해결·"이렇게는 ✓"}}</p></div>
+      </div>
+      <div class="talk"><b>말하기</b> · {{발표자 노트 — 어느 쪽이 왜 나은지}}</div>
+    </div>
+    <div class="chrome-bl">{{슬라이드 라벨}}</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ══════ /ZONE: Part1 ══════ -->
+
+  <!-- ══════ ZONE: Part2 (실습) ══════ -->
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       [LAYOUT 9/10] lay-divider · 강의→실습 전환 (블루↔퍼플 그라데이션)
+       · 서사 기능: 큰 챕터 전환. 색 변화로 모드 전환을 시각적으로 표식.
+       · 권장 사용처: Part1→Part2 사이, Part2→Part3 사이
+       · 변형: slide.dark 클래스로 talk 큐도 다크 변형 / chip 색상 자동 반전
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide dark">
+    <div class="chrome-tl"><span class="badge p2">S5</span><span class="part">Part 2 · 실습</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-working-typing.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-divider">
+      <div class="msg">{{전환 한 줄 — 예: "이제, 직접 해봅니다"}}</div>
+      <div class="sub">{{앞 챕터→다음 챕터 다리 한 줄}}</div>
+      <div class="talk"><b>말하기</b> · {{모드 전환 멘트}}</div>
+    </div>
+    <div class="chrome-bl">{{슬라이드 라벨 — 예: "강의 → 실습"}}</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       [LAYOUT 10/10] lay-bleed · 풀블리드 이미지 (오버레이 텍스트)
+       · 서사 기능: 한 화면을 이미지가 통째로 차지. 강한 감정·기념 컷·환경 사진.
+       · 권장 사용처: 강한 시각 임팩트 슬라이드(키노트), 챕터 표지 변형
+       · 주의: 소스 덱(2026-04-20)에는 CSS만 정의되어 있고 미사용 — 새 덱에서 시도 가능
+       · 변형: overlay 없는 풀이미지 / overlay msg만 / msg+sub 둘 다
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide">
+    <div class="chrome-tl"><span class="badge p2">S6</span><span class="part">Part 2 · 시각 임팩트</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-headphones-groove.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-bleed">
+      <img src="{{풀블리드 이미지.jpg}}" alt="{{대체 텍스트}}">
+      <div class="overlay">
+        <div class="msg">{{오버레이 메시지 — 흰색 자동}}</div>
+        <div class="sub" style="color:rgba(255,255,255,.85);">{{부연 — 흰 톤}}</div>
+      </div>
+    </div>
+    <div class="chrome-bl">{{슬라이드 라벨}}</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       lay-split 변형 · 실습 프롬프트 카드 (S9-S11 idiom 재현용)
+       · .media 안을 <img> 대신 보라색 라벨 + 굵은 본문 카드로 교체.
+       · 청중이 그대로 따라 칠 수 있는 "이렇게 말해보세요" 슬라이드.
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide">
+    <div class="chrome-tl"><span class="badge p2">실습</span><span class="part">Part 2 · 실습 X</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-react-double.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-split">
+      <div class="media">
+        <div style="text-align:left;padding:30px 34px;">
+          <div style="color:var(--purple);font-weight:800;font-size:13px;letter-spacing:.3px;margin-bottom:12px;">이렇게 말해보세요</div>
+          <div style="font:700 clamp(19px,2.1vw,29px)/1.42 sans-serif;color:var(--ink);">{{청중이 그대로 칠 프롬프트 문장 — 두 줄 정도}}</div>
+        </div>
+      </div>
+      <div class="text">
+        <div class="msg" style="font-size:clamp(24px,2.7vw,38px);">{{이 프롬프트가 무엇을 하는지 — <span class="em">한 줄</span>}}</div>
+        <div class="sub">{{왜 이게 통하는지·발견점}}</div>
+        <div class="sub" style="margin-top:10px;">{{① 단계 → ② 단계 → ③ 단계}}</div>
+        <div class="talk"><b>말하기</b> · {{discovery-first — 명령어 이름 노출 안하고 결핍부터}}</div>
+      </div>
+    </div>
+    <div class="chrome-bl">{{슬라이드 라벨}}</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ══════ /ZONE: Part2 ══════ -->
+
+  <!-- ══════ ZONE: Part3+마무리 ══════ -->
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       lay-cue 재사용 · 대화 진입 (질문 던지기)
+       · 청중 활동 큐와 동일 레이아웃이지만 클로징 맥락에서 사용.
+       · 정해진 슬라이드가 아닌 대화 단계의 시작.
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide">
+    <div class="chrome-tl"><span class="part">Part 3 · 대화</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-react-double.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-cue">
+      <div class="quote">{{청중에게 던지는 질문 — <b>핵심어</b> 굵게}}<br>{{필요시 두 번째 질문}}</div>
+      <div class="attr">여기서부턴 정해진 슬라이드가 아닙니다 — 여러분 질문 + 제 워크플로</div>
+    </div>
+    <div class="chrome-bl">💬 대화 시작 — 정해진 슬라이드 아님</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ─────────────────────────────────────────────────────────────────────
+       lay-checklist · 마무리 요약 (액션 N개 그리드 2열)
+       · 서사 기능: 발표 전체 액션을 한 화면에. "그래서 이걸 하자" — 가져갈 것.
+       · 권장 사용처: 마지막 슬라이드 (혹은 마지막 직전)
+       · 변형: it.accent (앰버 키) 로 핵심 액션 한두 개 강조 / 키는 1-N 번호
+       ───────────────────────────────────────────────────────────────────── -->
+  <section class="slide">
+    <div class="chrome-tl"><span class="badge">S마무리</span><span class="part">마무리</span></div>
+    <object class="deco" type="image/svg+xml" data="clawd-mini-happy.svg" aria-hidden="true" tabindex="-1"></object>
+    <div class="lay-checklist">
+      <div class="msg">{{주제}} — <span class="em">그래서 이걸 하자</span></div>
+      <div class="grid">
+        <div class="it"><span class="k">1</span><span>{{액션 1}}</span></div>
+        <div class="it accent"><span class="k">2</span><span>{{액션 2 — 앰버 강조}}</span></div>
+        <div class="it"><span class="k">3</span><span>{{액션 3}}</span></div>
+        <div class="it"><span class="k">4</span><span>{{액션 4}}</span></div>
+        <div class="it"><span class="k">5</span><span>{{액션 5}}</span></div>
+        <div class="it"><span class="k">6</span><span>{{액션 6}}</span></div>
+      </div>
+    </div>
+    <div class="chrome-bl">{{한 줄 본질 — 예: "재작업을 줄이는 것"}}</div><div class="chrome-br count"></div>
+  </section>
+
+  <!-- ══════ /ZONE: Part3+마무리 ══════ -->
+
+</div>
+<div class="hint">← → 이동 · 슬롯 <span class="slot-total">–</span>개 · 템플릿 골격 · 10종 레이아웃</div>
+<script>
+  const slides=[...document.querySelectorAll('.slide')];
+  document.querySelectorAll('.slot-total').forEach(e=>e.textContent=slides.length);
+  let i=0;
+  function show(n){
+    i=Math.max(0,Math.min(slides.length-1,n));
+    slides.forEach((s,k)=>s.classList.toggle('active',k===i));
+    document.querySelectorAll('.count').forEach(c=>c.textContent=(i+1)+' / '+slides.length);
+  }
+  addEventListener('keydown',e=>{
+    if(e.key==='ArrowRight'||e.key==='PageDown'||e.key===' ')show(i+1);
+    else if(e.key==='ArrowLeft'||e.key==='PageUp')show(i-1);
+    else if(e.key==='Home')show(0); else if(e.key==='End')show(slides.length-1);
+  });
+  document.getElementById('deck').addEventListener('click',e=>show(e.clientX>innerWidth/2?i+1:i-1));
+  show(0);
+</script>
+</body>
+</html>

--- a/make-deck/skills/make-deck/references/dimensions.md
+++ b/make-deck/skills/make-deck/references/dimensions.md
@@ -1,0 +1,73 @@
+# Deck Dimensions — what to elicit before generating slides
+
+These are the dimensions that actually shaped a real 20-minute study-deck build
+(CKA / Kustomize, session `c7922aba`). They are the **substrate seed** for the
+progressive elicitation step in SKILL.md. Surface them **progressively** — density/form
+first, then scope, then refine by feedback — **not all up front** (that is how the real
+session converged; an all-at-once panel over-asks and mis-orders).
+
+For every dimension: cite evidence from the *notes themselves* when proposing a default,
+present recognizable options, and let the user steer. Recognition over recall.
+
+---
+
+## 1. 청중 (Audience) — who, specifically
+
+Not "developers" but *which* developers, and what they already know. This single
+coordinate gets refined more than any other in practice.
+
+- Ask: who is in the room, and what is their prior familiarity with the topic?
+- Real example: first "Kubernetes 입문자" → refined to "CKA 시험을 준비하는, K8s에 익숙하지
+  않은 개발자". The refinement changed slide content materially.
+- Drives: vocabulary, how much is assumed, which analogies land.
+
+## 2. 난이도 / 기술 깊이 (Difficulty / technical depth)
+
+How deep do concrete artifacts go — analogy-only, or real working code/YAML/commands?
+
+- Ask: should slides carry runnable snippets (real YAML, commands), or stay
+  concept/analogy-centric with detail deferred?
+- Real example: "난이도 조정이 필요합니다 … 실제 동작하는 yaml 스니펫을 슬라이드에 넣어야"
+  shifted the deck from analogy-sparse toward real working YAML pulled from official docs.
+- Drives: presence and density of code blocks, whether to fetch authoritative sources.
+
+## 3. 간략 형태 / 밀도 (Brevity / density)
+
+How condensed is each slide, and is there a backing layer?
+
+- Ask: presentation-core only, or a 2-layer structure (slide-ready core + detailed
+  appendix/backup)?
+- Real example: chose "발표용 핵심 + 상세 부록 (2층)" — the core became slides, the
+  appendix stayed as a reference doc.
+- Drives: words-per-slide, whether to also emit a companion notes doc.
+
+## 4. 발표 시간 (Presentation time) → slide count
+
+Time is the input; slide count is **derived**, not asked separately.
+
+- Ask: how long is the talk?
+- Derivation: ~1 slide per 1.3–1.7 min. 20 min ≈ 12–16 slides (real deck landed at 14).
+  Scale **within** the 4 ZONEs (grow Part1/Part2), never break the ZONE structure.
+- Drives: how many slides each ZONE gets via the parallel-add convention.
+
+## 5. 재구성 범위 / 앵글 (Scope / reconstruction angle)
+
+Faithful to the source, or reframed toward the audience's actual goal?
+
+- Ask: stay faithful to the source material, or reframe toward a goal (e.g. exam-aligned,
+  decision-aligned), which may *add* content not in the notes and drop tangents?
+- Real example: "CKA 시험 정렬 (권장)" added official syntax + "in the exam room" tips and
+  set the slide count, vs. "섹션 충실 + 실YAML" vs. "시험 특화 압축".
+- Drives: inclusion/exclusion, what external authoritative content to graft in.
+
+---
+
+## Mascot pose library (asset note)
+
+Bundled poses live flat in `../assets/clawd-*.svg` (19 normalized poses, viewBox
+`-15 -25 45 45`). For more poses, the full library is at
+`~/Downloads/github/oss/clawd-on-desk/assets/svg/` (47 raw poses) — **normalize the
+viewBox before bundling** a new one. Neutral poses suitable for most decks:
+`about-hero`, `mini-enter`, `working-thinking`, `working-typing`, `working-juggling`,
+`working-ultrathink`, `idle-reading`, `idle-bubble`, `headphones-groove`, `react-double`,
+`mini-happy`.


### PR DESCRIPTION
Generate self-contained HTML slide decks from organized notes.

## What

A new `make-deck` plugin: turns an already-organized notes doc into a presentation-ready, single-file HTML deck.

## Design

- **Progressive dimension elicitation** — surfaces audience / difficulty / density / time / scope one cluster at a time (not an all-at-once panel), grounded in the source notes. The reverse-elicitation *method* is embedded inline in `SKILL.md`, so the plugin is **portable** — no cross-plugin dependency.
- **Bundled assets** — layout-catalog skeleton (10 layouts, 4 narrative ZONEs, mascot decorators) + 19 normalized clawd poses + a dimension reference doc. Self-contained.
- **Build** — slide count derived from talk length (~1.3–1.7 min/slide); outline gate before generating; output is one portable HTML file with mascot SVGs inlined as data-URIs.

## Provenance

Dimension set distilled from a real 20-min study-deck session (CKA / Kustomize). Skeleton generalized from a prior context-efficiency deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
