### PR TITLE
fix(cdp-attach): 동결 탭 복구(revive) + 불확실 결과 표면화 (#47, #50)

### DIFF
--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/scripts/cdp_client.py
+++ b/cdp-attach/scripts/cdp_client.py
@@ -22,8 +22,9 @@ import json
 import os
 import tempfile
 import time
-import urllib.request
 import urllib.error
+import urllib.parse
+import urllib.request
 
 # State file location
 STATE_DIR = os.path.expanduser("~/.cache/cdp-attach")
@@ -57,6 +58,14 @@ def _log_error(category, payload):
 
 class CDPError(Exception):
     """CDP protocol or connection error."""
+    pass
+
+
+class CDPConnectionError(CDPError):
+    """Transport-level failure (WebSocket send/recv), as opposed to a CDP
+    method error. Best-effort handlers that swallow CDPError for individual
+    method failures must re-raise this — a dead connection cannot recover
+    by continuing to the next call."""
     pass
 
 
@@ -143,6 +152,11 @@ class CDPClient:
 
     def new_tab(self, url=""):
         """Open a new tab. Chrome 115+ requires PUT for /json/new."""
+        if url:
+            # Escape characters that are illegal in an HTTP request-target
+            # (space, non-ASCII). '%' stays safe so already-encoded URLs are
+            # not double-encoded; Chrome unescapes the query before use.
+            url = urllib.parse.quote(url, safe="%/:?#[]@!$&'()*+,;=~.-_")
         path = f"/json/new?{url}" if url else "/json/new"
         full_url = f"{self._base_url}{path}"
         try:
@@ -219,7 +233,20 @@ class CDPClient:
         if params:
             payload["params"] = params
 
-        self._ws.send(json.dumps(payload))
+        try:
+            self._ws.send(json.dumps(payload))
+        except Exception as e:
+            _log_error("send", {
+                "method": method,
+                "params": params or {},
+                "error": f"{type(e).__name__}: {e}",
+                "kind": "ws_send_error",
+            })
+            raise CDPConnectionError(
+                f"WebSocket send failed for {method}: {type(e).__name__}: {e}\n"
+                "The command was NOT sent — the connection was already dead. "
+                "Re-select the tab ('list' + 'select') or run 'revive'."
+            ) from e
 
         deadline = time.time() + timeout
         while time.time() < deadline:
@@ -259,7 +286,7 @@ class CDPClient:
                 })
                 # The command was already sent — losing the response channel
                 # does not mean the browser did not execute it (#50).
-                raise CDPError(
+                raise CDPConnectionError(
                     f"WebSocket error during {method}: {type(e).__name__}: {e}\n"
                     "Outcome unknown — the command was sent and may have "
                     "executed. Verify the side effect (re-read the resource) "
@@ -315,7 +342,7 @@ class CDPClient:
         except websocket.WebSocketTimeoutException:
             return None
         except (websocket.WebSocketConnectionClosedException, ConnectionError) as e:
-            raise CDPError(f"WebSocket closed during recv: {e}")
+            raise CDPConnectionError(f"WebSocket closed during recv: {e}")
 
     def query_selector_node_id(self, selector):
         """Resolve a CSS selector to a DOM nodeId.

--- a/cdp-attach/scripts/cdp_client.py
+++ b/cdp-attach/scripts/cdp_client.py
@@ -257,11 +257,21 @@ class CDPClient:
                     "error": f"{type(e).__name__}: {e}",
                     "kind": "ws_error",
                 })
-                raise
+                # The command was already sent — losing the response channel
+                # does not mean the browser did not execute it (#50).
+                raise CDPError(
+                    f"WebSocket error during {method}: {type(e).__name__}: {e}\n"
+                    "Outcome unknown — the command was sent and may have "
+                    "executed. Verify the side effect (re-read the resource) "
+                    "before treating this as a failure or retrying a "
+                    "mutating action."
+                ) from e
 
         timeout_msg = (
             f"Timeout waiting for response to {method} ({timeout}s). "
-            "Tab may be frozen or suspended."
+            "Tab may be frozen or suspended. Outcome unknown — the command "
+            "was sent and may have executed; verify the side effect before "
+            "treating this as a failure or retrying a mutating action."
         )
         _log_error("send", {
             "method": method,

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -272,6 +272,35 @@ def cmd_evaluate(client, args):
         client.close()
 
 
+def _post_nav_probe(client, timeout=5):
+    """Bounded renderer-liveness probe after navigate/reload.
+
+    A reload issued while the renderer had pending/blocked cross-origin
+    fetches can leave the tab permanently unresponsive — every later CDP
+    call then burns its full 30s timeout (#47). Probing right after the
+    navigation surfaces the wedge immediately and points at recovery.
+
+    Returns True when the renderer answered.
+    """
+    try:
+        result = client.send(
+            "Runtime.evaluate",
+            {"expression": "1", "returnByValue": True},
+            timeout=timeout,
+        )
+        if result.get("result", {}).get("value") == 1:
+            return True
+    except CDPError:
+        pass
+    print(
+        f"Error: tab unresponsive after navigation (renderer probe timed out "
+        f"after {timeout}s). The renderer may be wedged — run 'revive' to "
+        "close and reopen this tab via the HTTP API.",
+        file=sys.stderr,
+    )
+    return False
+
+
 def cmd_navigate(client, args):
     """Navigate to a URL."""
     client.connect()
@@ -293,6 +322,8 @@ def cmd_navigate(client, args):
                     "Warning: Page load event not received within 30s — page may not be fully loaded",
                     file=sys.stderr,
                 )
+            if not _post_nav_probe(client):
+                sys.exit(1)
 
         frame_id = result.get("frameId", "")
         print(f"Navigated to: {args.url}")
@@ -316,8 +347,62 @@ def cmd_reload(client, args):
                     "Warning: Page load event not received within 30s",
                     file=sys.stderr,
                 )
+            if not _post_nav_probe(client):
+                sys.exit(1)
 
         print(f"Reloaded{' (cache bypassed)' if args.hard else ''}")
+    finally:
+        client.close()
+
+
+def cmd_revive(client, args):
+    """Recover a wedged tab: close it and reopen its URL via the HTTP API.
+
+    The HTTP endpoints (/json/list, /json/close, /json/new) are served by
+    the browser process, so they work even when the tab's renderer no
+    longer answers CDP WebSocket calls (#47). Renderer-local state
+    (session history, sessionStorage, in-memory JS state) is lost;
+    cookies and localStorage survive in the profile.
+    """
+    target_id = client.get_selected_target()
+    if not target_id:
+        print("Error: No tab selected. Use 'select' first.", file=sys.stderr)
+        sys.exit(1)
+
+    tabs = client.list_tabs(type_filter=None)
+    tab = next((t for t in tabs if t.get("id") == target_id), None)
+    if tab is None:
+        print(
+            f"Error: Selected target {target_id} not found in tab list. "
+            "Use 'list' + 'select' to pick a tab.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    url = args.url or tab.get("url", "")
+    if not url:
+        print("Error: Tab has no URL and no --url override given.", file=sys.stderr)
+        sys.exit(1)
+
+    client.close_tab(target_id)
+    new_tab = client.new_tab(url)
+    new_id = new_tab.get("id")
+    if not new_id:
+        print(f"Error: /json/new returned no target id: {new_tab}", file=sys.stderr)
+        sys.exit(1)
+
+    client.save_state(new_id)
+    client.activate_tab(new_id)
+    print(f"Revived tab: closed {target_id[:8]}..., reopened as {new_id[:8]}...")
+    print(f"  URL: {url}")
+
+    # Confirm the fresh renderer answers before handing control back.
+    try:
+        client.connect(target_id=new_id)
+        if _post_nav_probe(client, timeout=10):
+            print("  Renderer responsive.")
+        else:
+            sys.exit(1)
     finally:
         client.close()
 
@@ -779,6 +864,14 @@ def main():
     p_reload.add_argument("--wait-for", choices=["load", "none"], default="load",
                           help="Wait condition (default: load)")
 
+    # revive
+    p_revive = sub.add_parser(
+        "revive",
+        help="Recover a wedged tab: close + reopen its URL via the HTTP API",
+    )
+    p_revive.add_argument("--url", default=None,
+                          help="Reopen with this URL instead of the tab's current URL")
+
     # back
     p_back = sub.add_parser("back", help="Navigate back in history")
     p_back.add_argument("--wait-for", choices=["load", "none"], default="none",
@@ -838,6 +931,7 @@ def main():
         "evaluate": cmd_evaluate,
         "navigate": cmd_navigate,
         "reload": cmd_reload,
+        "revive": cmd_revive,
         "back": cmd_back,
         "forward": cmd_forward,
         "wait": cmd_wait,

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -272,7 +272,7 @@ def cmd_evaluate(client, args):
         client.close()
 
 
-def _post_nav_probe(client, timeout=5):
+def _post_nav_probe(client, timeouts=(5, 10)):
     """Bounded renderer-liveness probe after navigate/reload.
 
     A reload issued while the renderer had pending/blocked cross-origin
@@ -280,25 +280,49 @@ def _post_nav_probe(client, timeout=5):
     call then burns its full 30s timeout (#47). Probing right after the
     navigation surfaces the wedge immediately and points at recovery.
 
+    A busy renderer is not a wedged one: Runtime.evaluate queues behind
+    long main-thread tasks (heavy hydration, analytics), so the probe
+    retries with a longer timeout before declaring the tab unresponsive.
+
     Returns True when the renderer answered.
     """
-    try:
-        result = client.send(
-            "Runtime.evaluate",
-            {"expression": "1", "returnByValue": True},
-            timeout=timeout,
-        )
-        if result.get("result", {}).get("value") == 1:
-            return True
-    except CDPError:
-        pass
+    reason = "no response"
+    for timeout in timeouts:
+        try:
+            result = client.send(
+                "Runtime.evaluate",
+                {"expression": "1", "returnByValue": True},
+                timeout=timeout,
+            )
+            value = result.get("result", {}).get("value")
+            if value == 1:
+                return True
+            reason = f"unexpected probe result: {value!r}"
+        except CDPError as e:
+            reason = str(e).splitlines()[0]
     print(
-        f"Error: tab unresponsive after navigation (renderer probe timed out "
-        f"after {timeout}s). The renderer may be wedged — run 'revive' to "
-        "close and reopen this tab via the HTTP API.",
+        f"Error: tab unresponsive after navigation ({reason}; "
+        f"{len(timeouts)} attempt(s), {sum(timeouts)}s total). The renderer "
+        "may be wedged — or still busy with a long task. Re-check with "
+        "`evaluate \"1\"`; if it stays silent, run 'revive' to close and "
+        "reopen this tab via the HTTP API (discards renderer state: "
+        "sessionStorage, in-memory JS).",
         file=sys.stderr,
     )
     return False
+
+
+def _await_load_and_probe(client):
+    """Shared --wait-for load epilogue: load-event wait, then renderer probe.
+
+    Returns False when the renderer probe fails (caller exits non-zero).
+    """
+    if not _wait_for_load_event(client):
+        print(
+            "Warning: Page load event not received within 30s — page may not be fully loaded",
+            file=sys.stderr,
+        )
+    return _post_nav_probe(client)
 
 
 def cmd_navigate(client, args):
@@ -317,12 +341,7 @@ def cmd_navigate(client, args):
             sys.exit(1)
 
         if args.wait_for == "load":
-            if not _wait_for_load_event(client):
-                print(
-                    "Warning: Page load event not received within 30s — page may not be fully loaded",
-                    file=sys.stderr,
-                )
-            if not _post_nav_probe(client):
+            if not _await_load_and_probe(client):
                 sys.exit(1)
 
         frame_id = result.get("frameId", "")
@@ -342,12 +361,7 @@ def cmd_reload(client, args):
         client.send("Page.reload", {"ignoreCache": args.hard})
 
         if args.wait_for == "load":
-            if not _wait_for_load_event(client):
-                print(
-                    "Warning: Page load event not received within 30s",
-                    file=sys.stderr,
-                )
-            if not _post_nav_probe(client):
+            if not _await_load_and_probe(client):
                 sys.exit(1)
 
         print(f"Reloaded{' (cache bypassed)' if args.hard else ''}")
@@ -384,12 +398,20 @@ def cmd_revive(client, args):
         print("Error: Tab has no URL and no --url override given.", file=sys.stderr)
         sys.exit(1)
 
-    client.close_tab(target_id)
+    # Open-then-close: if /json/new fails, the wedged tab still exists and
+    # state.json keeps pointing at a live (if unresponsive) target.
     new_tab = client.new_tab(url)
     new_id = new_tab.get("id")
     if not new_id:
         print(f"Error: /json/new returned no target id: {new_tab}", file=sys.stderr)
         sys.exit(1)
+
+    if not client.close_tab(target_id):
+        print(
+            f"Warning: /json/close did not confirm for {target_id[:8]}... — "
+            "the wedged tab may still be open.",
+            file=sys.stderr,
+        )
 
     client.save_state(new_id)
     client.activate_tab(new_id)
@@ -399,7 +421,7 @@ def cmd_revive(client, args):
     # Confirm the fresh renderer answers before handing control back.
     try:
         client.connect(target_id=new_id)
-        if _post_nav_probe(client, timeout=10):
+        if _post_nav_probe(client, timeouts=(10,)):
             print("  Renderer responsive.")
         else:
             sys.exit(1)
@@ -434,11 +456,8 @@ def _history_nav(client, wait_for, direction, label):
         client.send("Page.navigateToHistoryEntry", {"entryId": entry.get("id")})
 
         if wait_for == "load":
-            if not _wait_for_load_event(client):
-                print(
-                    "Warning: Page load event not received within 30s",
-                    file=sys.stderr,
-                )
+            if not _await_load_and_probe(client):
+                sys.exit(1)
 
         print(f"Navigated {label} to: {entry.get('url', '')}")
     finally:

--- a/cdp-attach/scripts/v2_interact.py
+++ b/cdp-attach/scripts/v2_interact.py
@@ -17,7 +17,7 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from cdp_client import CDPClient, CDPError
+from cdp_client import CDPClient, CDPConnectionError, CDPError
 
 
 def _resolve_selector(client, selector):
@@ -148,10 +148,14 @@ def _get_node_description(client, node_id=None, backend_node_id=None):
                     "returnByValue": True,
                 })
                 text = text_result.get("result", {}).get("value", "")
+        except CDPConnectionError:
+            raise
         except CDPError:
             pass
 
         return tag, text
+    except CDPConnectionError:
+        raise
     except CDPError:
         return "unknown", ""
 
@@ -177,6 +181,8 @@ def _get_node_bounds(client, node_id=None, backend_node_id=None, scroll=True,
     if scroll:
         try:
             client.send("DOM.scrollIntoViewIfNeeded", params)
+        except CDPConnectionError:
+            raise
         except CDPError:
             pass  # Non-scrollable or detached; continue
 
@@ -192,6 +198,8 @@ def _get_node_bounds(client, node_id=None, backend_node_id=None, scroll=True,
             if len(values) >= 8:
                 quad_values = values
                 break
+        except CDPConnectionError:
+            raise
         except CDPError:
             pass
 
@@ -247,11 +255,15 @@ def _dom_search(client, query, include_shadow_dom=False, limit=20):
                     "backendNodeId": node_info.get("backendNodeId"),
                     "tag": node_info.get("localName", node_info.get("nodeName", "")).lower(),
                 })
+            except CDPConnectionError:
+                raise
             except CDPError:
                 pass
 
     try:
         client.send("DOM.discardSearchResults", {"searchId": search_id})
+    except CDPConnectionError:
+        raise
     except CDPError:
         pass
 
@@ -719,6 +731,8 @@ def cmd_scan_interactive(client, args):
                 vp = layout.get("cssVisualViewport", {})
                 vw = vp.get("clientWidth", 1920)
                 vh = vp.get("clientHeight", 1080)
+            except CDPConnectionError:
+                raise
             except CDPError:
                 pass
 
@@ -744,6 +758,8 @@ def cmd_scan_interactive(client, args):
                     "x": info["x"],
                     "y": info["y"],
                 })
+            except CDPConnectionError:
+                raise
             except CDPError:
                 continue
 

--- a/cdp-attach/scripts/v3_advanced.py
+++ b/cdp-attach/scripts/v3_advanced.py
@@ -18,7 +18,7 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from cdp_client import CDPClient, CDPError
+from cdp_client import CDPClient, CDPConnectionError, CDPError
 
 CACHE_DIR = os.path.expanduser("~/.cache/cdp-attach")
 NETWORK_EVENTS = os.path.join(CACHE_DIR, "network-events.jsonl")
@@ -669,11 +669,15 @@ def cmd_emulate_reset(client, args):
         try:
             client.send("Emulation.clearDeviceMetricsOverride")
             reset.append("device")
+        except CDPConnectionError:
+            raise
         except CDPError:
             pass
         try:
             client.send("Emulation.clearGeolocationOverride")
             reset.append("geolocation")
+        except CDPConnectionError:
+            raise
         except CDPError:
             pass
         try:
@@ -685,6 +689,8 @@ def cmd_emulate_reset(client, args):
                 "uploadThroughput": -1,
             })
             reset.append("offline")
+        except CDPConnectionError:
+            raise
         except CDPError:
             pass
         print(f"Emulation reset: {', '.join(reset) or 'none'}")

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -82,6 +82,8 @@ $V1 navigate "https://example.com"             # Navigate
 $V1 navigate "https://example.com" --wait-for none
 $V1 reload                                     # Reload current page (wait for load)
 $V1 reload --hard                              # Bypass cache (Page.reload ignoreCache=true)
+$V1 revive                                     # Close + reopen a wedged tab via HTTP API
+$V1 revive --url "https://example.com"         # Reopen with a different URL
 $V1 back                                       # Navigate back (default: no wait — bfcache may skip load event)
 $V1 forward                                    # Navigate forward (default: no wait)
 $V1 back --wait-for load                       # Opt-in load wait (use when fresh load expected)
@@ -351,9 +353,14 @@ Or use `--host` / `--port` flags on any command.
 | Error | Cause | Resolution |
 |-------|-------|------------|
 | CDP HTTP endpoint unreachable | Browser not running with `--remote-debugging-port` | Start browser with CDP enabled |
-| Timeout waiting for response | Tab frozen/suspended | Select a different active tab |
+| Timeout waiting for response | Tab frozen/suspended | `v1 revive` (close + reopen via HTTP API), or select a different tab |
+| Tab unresponsive after navigate/reload | Renderer wedged (e.g., reload with pending blocked fetches) | `v1 revive` — WebSocket re-attach won't help; the HTTP endpoints still work |
 | WebSocket connection failed | Tab closed or navigated away | Re-select tab with `list` + `select` |
 | Element not found | Invalid CSS selector | Check selector with `evaluate` + `querySelector` |
+
+`navigate` and `reload` (with the default `--wait-for load`) run a bounded renderer probe after the load wait and exit with the `revive` hint when the tab is wedged, instead of letting every subsequent call burn its full 30s timeout.
+
+**Uncertain outcomes on mutating actions**: a timeout or WebSocket error *after* a command was sent does not prove the action failed — the browser (or the server behind the page) may have committed it before the response channel was lost. The same applies to harness-level errors (e.g., `API Error: Unable to connect to API`), which are not CDP failures at all. Before reporting failure on a save/submit/delete, verify the side effect (re-read the resource); if verification is impossible, report "outcome unknown — verify" rather than "failed".
 
 ### Bug Triage
 
@@ -370,6 +377,7 @@ Tab attachment and screenshot capture are inherently flaky. When a CDP operation
 | Symptom | 1st fallback (stay in CDP) | 2nd fallback (leave CDP) |
 |---------|---------------------------|--------------------------|
 | Tab attachment fails | `v1 list` → re-select a different tab index | Ask user to manually navigate, then retry |
+| Tab wedged (every call times out) | `v1 revive` — close + reopen the tab via HTTP API (renderer-immune) | Ask user to close/reopen the tab manually |
 | Screenshot capture times out | `v1 evaluate "document.title"` to extract DOM text directly | Ask user to capture screenshot manually |
 | DOM navigation unreliable (react-select, dynamic SPAs) | `v2 scan_interactive` or `v2 find_element --name/--role` to discover elements via CDP DOM/Accessibility API | Vision fallback: screenshot → Read → click coordinates |
 | HTTP/TLS inspection needed | `v1 evaluate` with `fetch()` to inspect responses | `curl` / `openssl s_client` as CLI alternative |

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -353,12 +353,13 @@ Or use `--host` / `--port` flags on any command.
 | Error | Cause | Resolution |
 |-------|-------|------------|
 | CDP HTTP endpoint unreachable | Browser not running with `--remote-debugging-port` | Start browser with CDP enabled |
-| Timeout waiting for response | Tab frozen/suspended | `v1 revive` (close + reopen via HTTP API), or select a different tab |
+| Timeout waiting for response | Tab frozen/suspended — or just slow | Mutating action? Verify the side effect first (outcome unknown). Then confirm the wedge with `v1 evaluate "1"` before `v1 revive` (revive discards renderer state), or select a different tab |
 | Tab unresponsive after navigate/reload | Renderer wedged (e.g., reload with pending blocked fetches) | `v1 revive` — WebSocket re-attach won't help; the HTTP endpoints still work |
+| WebSocket send failed (command NOT sent) | Connection already dead before the call | Safe to re-select (`list` + `select`) and retry — nothing was executed |
 | WebSocket connection failed | Tab closed or navigated away | Re-select tab with `list` + `select` |
 | Element not found | Invalid CSS selector | Check selector with `evaluate` + `querySelector` |
 
-`navigate` and `reload` (with the default `--wait-for load`) run a bounded renderer probe after the load wait and exit with the `revive` hint when the tab is wedged, instead of letting every subsequent call burn its full 30s timeout.
+`navigate`, `reload`, and `back`/`forward` (with `--wait-for load`) run a bounded renderer probe after the load wait — two attempts (5s, then 10s), since a renderer busy with a long main-thread task is not wedged — and exit with the `revive` hint only when both attempts stay silent, instead of letting every subsequent call burn its full 30s timeout.
 
 **Uncertain outcomes on mutating actions**: a timeout or WebSocket error *after* a command was sent does not prove the action failed — the browser (or the server behind the page) may have committed it before the response channel was lost. The same applies to harness-level errors (e.g., `API Error: Unable to connect to API`), which are not CDP failures at all. Before reporting failure on a save/submit/delete, verify the side effect (re-read the resource); if verification is impossible, report "outcome unknown — verify" rather than "failed".
 
@@ -377,7 +378,7 @@ Tab attachment and screenshot capture are inherently flaky. When a CDP operation
 | Symptom | 1st fallback (stay in CDP) | 2nd fallback (leave CDP) |
 |---------|---------------------------|--------------------------|
 | Tab attachment fails | `v1 list` → re-select a different tab index | Ask user to manually navigate, then retry |
-| Tab wedged (every call times out) | `v1 revive` — close + reopen the tab via HTTP API (renderer-immune) | Ask user to close/reopen the tab manually |
+| Tab wedged (every call times out) | Confirm with `v1 evaluate "1"`, then `v1 revive` — close + reopen the tab via HTTP API (renderer-immune; discards sessionStorage/in-memory JS) | Ask user to close/reopen the tab manually |
 | Screenshot capture times out | `v1 evaluate "document.title"` to extract DOM text directly | Ask user to capture screenshot manually |
 | DOM navigation unreliable (react-select, dynamic SPAs) | `v2 scan_interactive` or `v2 find_element --name/--role` to discover elements via CDP DOM/Accessibility API | Vision fallback: screenshot → Read → click coordinates |
 | HTTP/TLS inspection needed | `v1 evaluate` with `fetch()` to inspect responses | `curl` / `openssl s_client` as CLI alternative |


### PR DESCRIPTION
#47 — reload 후 렌더러 동결 시 모든 CDP 호출이 30s 타임아웃을 소진하던 문제:
- navigate/reload(--wait-for load)에 bounded 렌더러 probe 추가, 동결 즉시 감지
- v1 revive 신설: HTTP API(/json/close, /json/new)로 동결 탭 close + 재생성
  (렌더러가 죽어도 브라우저 프로세스가 응답하므로 동작)

#50 — 응답 채널 유실을 액션 실패로 오인하던 문제:
- send() timeout/WebSocket 에러 메시지에 "outcome unknown — verify" 명시
  (명령은 이미 전송되어 실행됐을 수 있음)
- SKILL.md에 mutating action 실패 보고 전 side-effect 검증 지침 추가

cdp-attach 1.5.1 → 1.6.0

https://claude.ai/code/session_01TNHKV3Aeme3SMjteUJ4K3B