### PR TITLE
feat: add hourly-digest plugin (migrated from user-level skill)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -83,6 +83,11 @@
       "name": "make-deck",
       "source": "./make-deck",
       "description": "Generate self-contained HTML slide decks from organized notes (progressive dimension elicitation, bundled layout-catalog skeleton, mascot decorators)"
+    },
+    {
+      "name": "hourly-digest",
+      "source": "./hourly-digest",
+      "description": "Consolidated hourly Slack and Gmail digest with /loop scheduling"
     }
   ]
 }

--- a/hourly-digest/.claude-plugin/plugin.json
+++ b/hourly-digest/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "hourly-digest",
+  "description": "Consolidated hourly Slack and Gmail digest with /loop scheduling",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/hourly-digest/skills/hourly-digest/SKILL.md
+++ b/hourly-digest/skills/hourly-digest/SKILL.md
@@ -21,24 +21,23 @@ The cadences differ by source constraint: Gmail's `newer_than:` search operator 
 
 ## Argument Parsing
 
-Parse `ARGUMENTS` for an optional subcommand:
+Each invocation runs exactly one section. Parse `ARGUMENTS` for the subcommand:
 
 | Input | Behavior |
 |-------|----------|
-| (empty) | Run both sections: Slack (past hour), Gmail (past day) |
-| `slack` | Slack hourly digest only |
-| `gmail` | Gmail daily digest only |
+| (empty) | Ask the user which section to run (`slack` or `gmail`) — do not run both |
+| `slack` | Slack hourly digest |
+| `gmail` | Gmail daily digest |
 
 ## Execution
 
-Run each requested section independently. On failure, report `[ERROR] Source: {message}` and continue to the next section.
+Run the requested section. On failure, report `[ERROR] Source: {message}`.
 
-Load the MCP tools for the requested sections upfront in a single ToolSearch call — only the tools the requested sections need, so a missing connector can only fail its own section:
+Load the MCP tools for the requested section upfront in a single ToolSearch call — only the tools that section needs, so a missing connector fails fast:
 
 ```
 Slack section:  ToolSearch("select:mcp__claude_ai_Slack__slack_search_public_and_private")
 Gmail section:  ToolSearch("select:mcp__claude_ai_Gmail__gmail_search_messages,mcp__claude_ai_Gmail__gmail_read_message")
-Both sections:  one ToolSearch call selecting all three tools
 ```
 
 ### 1. Slack Hourly Digest (past hour)
@@ -64,12 +63,12 @@ Construct Gmail links from the messageId returned by search results. Use the `#a
 
 ## Output Format
 
-Each section gets its own header carrying its own time window:
+Each invocation emits one section, with a header carrying its own time window:
 
 - Slack: `## Slack Hourly Digest (HH:MM-HH:MM KST)`
 - Gmail: `## Gmail Daily Digest (past 24h, as of YYYY-MM-DD HH:MM KST)` — `newer_than:1d` is a rolling 24-hour window, not a calendar day
 
-Example structure:
+Example structure (one per section — a single invocation emits only its own):
 
 ```
 ## Slack Hourly Digest (14:00-15:00 KST)
@@ -81,8 +80,7 @@ Example structure:
 - **Project kickoff** (2): ["Thread topic"](https://mail.google.com/mail/u/0/#all/msg456) from another@example.com, ["Re: Thread topic"](https://mail.google.com/mail/u/0/#all/msg789) from third@example.com
 ```
 
-When a section has no results, use a single line indicating nothing new.
-When running a single section via subcommand, omit the other section entirely.
+When the section has no results, use a single line indicating nothing new.
 
 ## Cron Usage
 

--- a/hourly-digest/skills/hourly-digest/SKILL.md
+++ b/hourly-digest/skills/hourly-digest/SKILL.md
@@ -39,8 +39,8 @@ ToolSearch("select:mcp__claude_ai_Slack__slack_search_public_and_private,mcp__cl
 
 1. Compute today's date via Bash: `date '+%Y-%m-%d'` (Slack `after:` excludes the given date; use `on:` to include it)
 2. Use `slack_search_public_and_private` with query `on:{date}` to find today's messages, then filter results to the past hour by message timestamp
-3. Group results by channel
-4. Per channel: `[#channel-name](https://{workspace}.slack.com/archives/{channel_id}) (N): key topics discussed`
+3. Group results by topic — cluster messages about the same subject together, even when they span multiple channels
+4. Per topic: `**Topic** (N): key points — [#channel-name](https://{workspace}.slack.com/archives/{channel_id})`
 5. For notable messages with threads, link to the thread: `[thread](https://{workspace}.slack.com/archives/{channel_id}/p{timestamp_no_dot})`
 6. If no messages found, state that there are none
 
@@ -50,8 +50,8 @@ Construct Slack links from search result metadata: channel ID for channel links,
 
 1. Use `gmail_search_messages` with query `newer_than:1h`
 2. If search results already include sender and subject, use them directly. Only call `gmail_read_message` for items missing these details (avoid N+1 reads)
-3. Group by sender or thread
-4. Per item: `From: sender -- ["Subject"](https://mail.google.com/mail/u/0/#inbox/{messageId}) (N)`
+3. Group by topic — cluster related subjects and threads together
+4. Per topic: `**Topic** (N): From: sender -- ["Subject"](https://mail.google.com/mail/u/0/#inbox/{messageId})`
 5. If no emails found, state that there are none
 
 Construct Gmail links from the messageId returned by search results.
@@ -65,12 +65,12 @@ Each source gets its own `###` subheader. Example structure:
 ## Hourly Digest (HH:MM-HH:MM KST)
 
 ### Slack
-- [#channel-a](https://workspace.slack.com/archives/C0123) (3): deployment discussion, auth service [hotfix thread](https://workspace.slack.com/archives/C0123/p1234567890)
-- [#channel-b](https://workspace.slack.com/archives/C0456) (1): standup reminder
+- **Auth service hotfix** (3): deployment discussion and rollout decision — [#channel-a](https://workspace.slack.com/archives/C0123), [hotfix thread](https://workspace.slack.com/archives/C0123/p1234567890)
+- **Standup** (1): reminder — [#channel-b](https://workspace.slack.com/archives/C0456)
 
 ### Gmail
-- From: sender@example.com -- ["Subject line"](https://mail.google.com/mail/u/0/#inbox/msg123) (1)
-- From: another@example.com -- ["Thread topic"](https://mail.google.com/mail/u/0/#inbox/msg456) (2)
+- **Billing renewal** (1): From: sender@example.com -- ["Subject line"](https://mail.google.com/mail/u/0/#inbox/msg123)
+- **Project kickoff** (2): From: another@example.com -- ["Thread topic"](https://mail.google.com/mail/u/0/#inbox/msg456)
 ```
 
 When a section has no results, use a single line indicating nothing new.

--- a/hourly-digest/skills/hourly-digest/SKILL.md
+++ b/hourly-digest/skills/hourly-digest/SKILL.md
@@ -9,7 +9,7 @@ description: |
   via /loop 1h /hourly-digest:hourly-digest slack and
   /loop 1d /hourly-digest:hourly-digest gmail.
   Distinct from per-channel Slack digest or single-source summaries.
-  For GitHub/Linear activity sync, use /loop 1h /github-activity separately.
+  GitHub/Linear activity sync is out of scope for this skill.
 argument-hint: "[slack|gmail]"
 ---
 
@@ -44,7 +44,7 @@ Both sections:  one ToolSearch call selecting all three tools
 ### 1. Slack Hourly Digest (past hour)
 
 1. Compute today's date and the Unix timestamp of one hour ago via Bash: `date '+%Y-%m-%d'` and `date -v-1H +%s` (Slack query `after:` excludes the given date; use `on:` to include it)
-2. Use `slack_search_public_and_private` with query `on:{date}` plus parameters `after={unix_ts_one_hour_ago}`, `sort="timestamp"`, `sort_dir="desc"` — the `after` parameter windows results server-side, so result-count truncation cannot drop in-window messages; paginate with `cursor` while a full page (20 results) comes back. During the first hour of the day (00:00-00:59), also run a second query with `on:{yesterday}` and the same `after` timestamp so the window spanning midnight is covered
+2. Use `slack_search_public_and_private` with query `on:{date}` plus parameters `after={unix_ts_one_hour_ago}`, `sort="timestamp"`, `sort_dir="desc"` — the `after` parameter windows results server-side, so result-count truncation cannot drop in-window messages; paginate by passing the returned `cursor` until the response no longer returns one (a partial page can still carry a next cursor). During the first hour of the day (00:00-00:59), also run a second query with `on:{yesterday}` and the same `after` timestamp so the window spanning midnight is covered
 3. Group results by topic — cluster messages about the same subject together, even when they span multiple channels
 4. Per topic: `**Topic** (N): key points — [#channel-name](https://{workspace}.slack.com/archives/{channel_id})`
 5. For notable messages with threads, link to the thread: `[thread](https://{workspace}.slack.com/archives/{channel_id}/p{timestamp_no_dot})`
@@ -54,7 +54,7 @@ Construct Slack links from search result metadata: channel ID for channel links,
 
 ### 2. Gmail Daily Digest (past day)
 
-1. Use `gmail_search_messages` with query `newer_than:1d`
+1. Use `gmail_search_messages` with query `newer_than:1d`; if the response indicates more results (next-page token or cursor), keep fetching until exhausted — a busy 24h window can exceed the first page
 2. If search results already include sender and subject, use them directly. Only call `gmail_read_message` for items missing these details (avoid N+1 reads)
 3. Group by topic — cluster related subjects and threads together
 4. Per topic: `**Topic** (N): key points — ["Subject"](https://mail.google.com/mail/u/0/#all/{messageId}) from sender`, listing a link for every message in the topic (do not collapse to a single link when N > 1)

--- a/hourly-digest/skills/hourly-digest/SKILL.md
+++ b/hourly-digest/skills/hourly-digest/SKILL.md
@@ -2,18 +2,22 @@
 name: hourly-digest
 description: |
   This skill should be used when the user asks to "check hourly updates",
-  "hourly digest", "hourly slack gmail summary", "what happened in the last hour",
-  "hourly monitoring", or needs a consolidated hourly summary from Slack
-  and Gmail. Also triggers for automated invocation via /loop 1h /hourly-digest.
-  Distinct from per-channel Slack digest or single-source summaries -- this is
-  the unified cross-source hourly rollup. For GitHub/Linear activity sync,
-  use /loop 1h /github-activity separately.
+  "hourly digest", "slack hourly summary", "gmail daily summary",
+  "what happened in the last hour", "hourly monitoring", or needs a periodic
+  digest from Slack or Gmail. Runs as two independent loops on different
+  cadences: Slack hourly, Gmail daily. Also triggers for automated invocation
+  via /loop 1h /hourly-digest:hourly-digest slack and
+  /loop 1d /hourly-digest:hourly-digest gmail.
+  Distinct from per-channel Slack digest or single-source summaries.
+  For GitHub/Linear activity sync, use /loop 1h /github-activity separately.
 argument-hint: "[slack|gmail]"
 ---
 
 # Hourly Digest
 
-Consolidate Slack messages and Gmail from the past hour into a single grouped summary. Respond in the user's language.
+Two independent digest loops on different cadences: Slack messages from the past hour, Gmail from the past day. Respond in the user's language.
+
+The cadences differ by source constraint: Gmail's `newer_than:` search operator only supports day/month/year units (no hour granularity), so the Gmail loop runs daily while the Slack loop runs hourly.
 
 ## Argument Parsing
 
@@ -21,9 +25,9 @@ Parse `ARGUMENTS` for an optional subcommand:
 
 | Input | Behavior |
 |-------|----------|
-| (empty) | Run all sections: Slack, Gmail |
-| `slack` | Slack digest only |
-| `gmail` | Gmail digest only |
+| (empty) | Run both sections: Slack (past hour), Gmail (past day) |
+| `slack` | Slack hourly digest only |
+| `gmail` | Gmail daily digest only |
 
 ## Execution
 
@@ -35,10 +39,10 @@ Load all needed MCP tools upfront in a single call before starting any section:
 ToolSearch("select:mcp__claude_ai_Slack__slack_search_public_and_private,mcp__claude_ai_Gmail__gmail_search_messages,mcp__claude_ai_Gmail__gmail_read_message")
 ```
 
-### 1. Slack Digest
+### 1. Slack Hourly Digest (past hour)
 
 1. Compute today's date via Bash: `date '+%Y-%m-%d'` (Slack `after:` excludes the given date; use `on:` to include it)
-2. Use `slack_search_public_and_private` with query `on:{date}` to find today's messages, then filter results to the past hour by message timestamp
+2. Use `slack_search_public_and_private` with query `on:{date}` to find today's messages. During the first hour of the day (00:00-00:59), also run a second query with `on:{yesterday}` so the window spanning midnight is covered. Filter combined results to the past hour by message timestamp
 3. Group results by topic — cluster messages about the same subject together, even when they span multiple channels
 4. Per topic: `**Topic** (N): key points — [#channel-name](https://{workspace}.slack.com/archives/{channel_id})`
 5. For notable messages with threads, link to the thread: `[thread](https://{workspace}.slack.com/archives/{channel_id}/p{timestamp_no_dot})`
@@ -46,38 +50,43 @@ ToolSearch("select:mcp__claude_ai_Slack__slack_search_public_and_private,mcp__cl
 
 Construct Slack links from search result metadata: channel ID for channel links, channel ID + message timestamp (remove the dot) for thread permalinks.
 
-### 2. Gmail Digest
+### 2. Gmail Daily Digest (past day)
 
-1. Use `gmail_search_messages` with query `newer_than:1h`
+1. Use `gmail_search_messages` with query `newer_than:1d`
 2. If search results already include sender and subject, use them directly. Only call `gmail_read_message` for items missing these details (avoid N+1 reads)
 3. Group by topic — cluster related subjects and threads together
-4. Per topic: `**Topic** (N): From: sender -- ["Subject"](https://mail.google.com/mail/u/0/#inbox/{messageId})`
+4. Per topic: `**Topic** (N): key points — ["Subject"](https://mail.google.com/mail/u/0/#inbox/{messageId}) from sender`, listing a link for every message in the topic (do not collapse to a single link when N > 1)
 5. If no emails found, state that there are none
 
 Construct Gmail links from the messageId returned by search results.
 
 ## Output Format
 
-Present all results under a header with the time range (e.g., `## Hourly Digest (14:00-15:00 KST)`).
-Each source gets its own `###` subheader. Example structure:
+Each section gets its own header carrying its own time window:
+
+- Slack: `## Slack Hourly Digest (HH:MM-HH:MM KST)`
+- Gmail: `## Gmail Daily Digest (YYYY-MM-DD)`
+
+Example structure:
 
 ```
-## Hourly Digest (HH:MM-HH:MM KST)
-
-### Slack
+## Slack Hourly Digest (14:00-15:00 KST)
 - **Auth service hotfix** (3): deployment discussion and rollout decision — [#channel-a](https://workspace.slack.com/archives/C0123), [hotfix thread](https://workspace.slack.com/archives/C0123/p1234567890)
 - **Standup** (1): reminder — [#channel-b](https://workspace.slack.com/archives/C0456)
 
-### Gmail
-- **Billing renewal** (1): From: sender@example.com -- ["Subject line"](https://mail.google.com/mail/u/0/#inbox/msg123)
-- **Project kickoff** (2): From: another@example.com -- ["Thread topic"](https://mail.google.com/mail/u/0/#inbox/msg456)
+## Gmail Daily Digest (2026-06-12)
+- **Billing renewal** (1): ["Subject line"](https://mail.google.com/mail/u/0/#inbox/msg123) from sender@example.com
+- **Project kickoff** (2): ["Thread topic"](https://mail.google.com/mail/u/0/#inbox/msg456) from another@example.com, ["Re: Thread topic"](https://mail.google.com/mail/u/0/#inbox/msg789) from third@example.com
 ```
 
 When a section has no results, use a single line indicating nothing new.
-When running a single section via subcommand, omit the other section headers entirely.
+When running a single section via subcommand, omit the other section entirely.
 
 ## Cron Usage
 
 ```
-/loop 1h /hourly-digest
+/loop 1h /hourly-digest:hourly-digest slack
+/loop 1d /hourly-digest:hourly-digest gmail
 ```
+
+Plugin skills are namespaced as `{plugin-name}:{skill-name}`; the bare `/hourly-digest` form only resolves for a user-level skill installation.

--- a/hourly-digest/skills/hourly-digest/SKILL.md
+++ b/hourly-digest/skills/hourly-digest/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: hourly-digest
+description: |
+  This skill should be used when the user asks to "check hourly updates",
+  "hourly digest", "hourly slack gmail summary", "what happened in the last hour",
+  "hourly monitoring", or needs a consolidated hourly summary from Slack
+  and Gmail. Also triggers for automated invocation via /loop 1h /hourly-digest.
+  Distinct from per-channel Slack digest or single-source summaries -- this is
+  the unified cross-source hourly rollup. For GitHub/Linear activity sync,
+  use /loop 1h /github-activity separately.
+argument-hint: "[slack|gmail]"
+---
+
+# Hourly Digest
+
+Consolidate Slack messages and Gmail from the past hour into a single grouped summary. Respond in the user's language.
+
+## Argument Parsing
+
+Parse `ARGUMENTS` for an optional subcommand:
+
+| Input | Behavior |
+|-------|----------|
+| (empty) | Run all sections: Slack, Gmail |
+| `slack` | Slack digest only |
+| `gmail` | Gmail digest only |
+
+## Execution
+
+Run each requested section independently. On failure, report `[ERROR] Source: {message}` and continue to the next section.
+
+Load all needed MCP tools upfront in a single call before starting any section:
+
+```
+ToolSearch("select:mcp__claude_ai_Slack__slack_search_public_and_private,mcp__claude_ai_Gmail__gmail_search_messages,mcp__claude_ai_Gmail__gmail_read_message")
+```
+
+### 1. Slack Digest
+
+1. Compute today's date via Bash: `date '+%Y-%m-%d'` (Slack `after:` excludes the given date; use `on:` to include it)
+2. Use `slack_search_public_and_private` with query `on:{date}` to find today's messages, then filter results to the past hour by message timestamp
+3. Group results by channel
+4. Per channel: `[#channel-name](https://{workspace}.slack.com/archives/{channel_id}) (N): key topics discussed`
+5. For notable messages with threads, link to the thread: `[thread](https://{workspace}.slack.com/archives/{channel_id}/p{timestamp_no_dot})`
+6. If no messages found, state that there are none
+
+Construct Slack links from search result metadata: channel ID for channel links, channel ID + message timestamp (remove the dot) for thread permalinks.
+
+### 2. Gmail Digest
+
+1. Use `gmail_search_messages` with query `newer_than:1h`
+2. If search results already include sender and subject, use them directly. Only call `gmail_read_message` for items missing these details (avoid N+1 reads)
+3. Group by sender or thread
+4. Per item: `From: sender -- ["Subject"](https://mail.google.com/mail/u/0/#inbox/{messageId}) (N)`
+5. If no emails found, state that there are none
+
+Construct Gmail links from the messageId returned by search results.
+
+## Output Format
+
+Present all results under a header with the time range (e.g., `## Hourly Digest (14:00-15:00 KST)`).
+Each source gets its own `###` subheader. Example structure:
+
+```
+## Hourly Digest (HH:MM-HH:MM KST)
+
+### Slack
+- [#channel-a](https://workspace.slack.com/archives/C0123) (3): deployment discussion, auth service [hotfix thread](https://workspace.slack.com/archives/C0123/p1234567890)
+- [#channel-b](https://workspace.slack.com/archives/C0456) (1): standup reminder
+
+### Gmail
+- From: sender@example.com -- ["Subject line"](https://mail.google.com/mail/u/0/#inbox/msg123) (1)
+- From: another@example.com -- ["Thread topic"](https://mail.google.com/mail/u/0/#inbox/msg456) (2)
+```
+
+When a section has no results, use a single line indicating nothing new.
+When running a single section via subcommand, omit the other section headers entirely.
+
+## Cron Usage
+
+```
+/loop 1h /hourly-digest
+```

--- a/hourly-digest/skills/hourly-digest/SKILL.md
+++ b/hourly-digest/skills/hourly-digest/SKILL.md
@@ -33,16 +33,18 @@ Parse `ARGUMENTS` for an optional subcommand:
 
 Run each requested section independently. On failure, report `[ERROR] Source: {message}` and continue to the next section.
 
-Load all needed MCP tools upfront in a single call before starting any section:
+Load the MCP tools for the requested sections upfront in a single ToolSearch call — only the tools the requested sections need, so a missing connector can only fail its own section:
 
 ```
-ToolSearch("select:mcp__claude_ai_Slack__slack_search_public_and_private,mcp__claude_ai_Gmail__gmail_search_messages,mcp__claude_ai_Gmail__gmail_read_message")
+Slack section:  ToolSearch("select:mcp__claude_ai_Slack__slack_search_public_and_private")
+Gmail section:  ToolSearch("select:mcp__claude_ai_Gmail__gmail_search_messages,mcp__claude_ai_Gmail__gmail_read_message")
+Both sections:  one ToolSearch call selecting all three tools
 ```
 
 ### 1. Slack Hourly Digest (past hour)
 
-1. Compute today's date via Bash: `date '+%Y-%m-%d'` (Slack `after:` excludes the given date; use `on:` to include it)
-2. Use `slack_search_public_and_private` with query `on:{date}` to find today's messages. During the first hour of the day (00:00-00:59), also run a second query with `on:{yesterday}` so the window spanning midnight is covered. Filter combined results to the past hour by message timestamp
+1. Compute today's date and the Unix timestamp of one hour ago via Bash: `date '+%Y-%m-%d'` and `date -v-1H +%s` (Slack query `after:` excludes the given date; use `on:` to include it)
+2. Use `slack_search_public_and_private` with query `on:{date}` plus parameters `after={unix_ts_one_hour_ago}`, `sort="timestamp"`, `sort_dir="desc"` — the `after` parameter windows results server-side, so result-count truncation cannot drop in-window messages; paginate with `cursor` while a full page (20 results) comes back. During the first hour of the day (00:00-00:59), also run a second query with `on:{yesterday}` and the same `after` timestamp so the window spanning midnight is covered
 3. Group results by topic — cluster messages about the same subject together, even when they span multiple channels
 4. Per topic: `**Topic** (N): key points — [#channel-name](https://{workspace}.slack.com/archives/{channel_id})`
 5. For notable messages with threads, link to the thread: `[thread](https://{workspace}.slack.com/archives/{channel_id}/p{timestamp_no_dot})`
@@ -55,17 +57,17 @@ Construct Slack links from search result metadata: channel ID for channel links,
 1. Use `gmail_search_messages` with query `newer_than:1d`
 2. If search results already include sender and subject, use them directly. Only call `gmail_read_message` for items missing these details (avoid N+1 reads)
 3. Group by topic — cluster related subjects and threads together
-4. Per topic: `**Topic** (N): key points — ["Subject"](https://mail.google.com/mail/u/0/#inbox/{messageId}) from sender`, listing a link for every message in the topic (do not collapse to a single link when N > 1)
+4. Per topic: `**Topic** (N): key points — ["Subject"](https://mail.google.com/mail/u/0/#all/{messageId}) from sender`, listing a link for every message in the topic (do not collapse to a single link when N > 1)
 5. If no emails found, state that there are none
 
-Construct Gmail links from the messageId returned by search results.
+Construct Gmail links from the messageId returned by search results. Use the `#all/` (All Mail) view in link URLs — `#inbox/` breaks for archived, sent, or labeled-out messages that the search still returns.
 
 ## Output Format
 
 Each section gets its own header carrying its own time window:
 
 - Slack: `## Slack Hourly Digest (HH:MM-HH:MM KST)`
-- Gmail: `## Gmail Daily Digest (YYYY-MM-DD)`
+- Gmail: `## Gmail Daily Digest (past 24h, as of YYYY-MM-DD HH:MM KST)` — `newer_than:1d` is a rolling 24-hour window, not a calendar day
 
 Example structure:
 
@@ -74,9 +76,9 @@ Example structure:
 - **Auth service hotfix** (3): deployment discussion and rollout decision — [#channel-a](https://workspace.slack.com/archives/C0123), [hotfix thread](https://workspace.slack.com/archives/C0123/p1234567890)
 - **Standup** (1): reminder — [#channel-b](https://workspace.slack.com/archives/C0456)
 
-## Gmail Daily Digest (2026-06-12)
-- **Billing renewal** (1): ["Subject line"](https://mail.google.com/mail/u/0/#inbox/msg123) from sender@example.com
-- **Project kickoff** (2): ["Thread topic"](https://mail.google.com/mail/u/0/#inbox/msg456) from another@example.com, ["Re: Thread topic"](https://mail.google.com/mail/u/0/#inbox/msg789) from third@example.com
+## Gmail Daily Digest (past 24h, as of 2026-06-12 15:00 KST)
+- **Billing renewal** (1): ["Subject line"](https://mail.google.com/mail/u/0/#all/msg123) from sender@example.com
+- **Project kickoff** (2): ["Thread topic"](https://mail.google.com/mail/u/0/#all/msg456) from another@example.com, ["Re: Thread topic"](https://mail.google.com/mail/u/0/#all/msg789) from third@example.com
 ```
 
 When a section has no results, use a single line indicating nothing new.


### PR DESCRIPTION
## Summary

Migrates the user-level `hourly-digest` skill (`~/.claude/skills/hourly-digest/`) into the marketplace as an installable plugin.

- New plugin: `hourly-digest/` (`.claude-plugin/plugin.json` + `skills/hourly-digest/SKILL.md`, copied verbatim)
- Registered in `.claude-plugin/marketplace.json`

## Test

```
/plugin marketplace add https://github.com/jongwony/cc-plugin
/plugin install hourly-digest
```
