### PR TITLE
feat: add handwriting plugin (migrated from hermeneutic-assistant project skill)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,6 +88,11 @@
       "name": "hourly-digest",
       "source": "./hourly-digest",
       "description": "Consolidated hourly Slack and Gmail digest with /loop scheduling"
+    },
+    {
+      "name": "handwriting",
+      "source": "./handwriting",
+      "description": "Apple Notes handwriting reader — scan Apple Pencil drawings via NoteStore.sqlite and read them multimodally"
     }
   ]
 }

--- a/handwriting/.claude-plugin/plugin.json
+++ b/handwriting/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "handwriting",
+  "description": "Apple Notes handwriting reader — scans Apple Pencil drawings via NoteStore.sqlite and reads them multimodally",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/handwriting/skills/handwriting/SKILL.md
+++ b/handwriting/skills/handwriting/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: handwriting
+description: Read and interpret Apple Pencil handwriting from Apple Notes (including iPad Quick Note popups) by scanning the local Notes database and reading the rendered drawing images multimodally. Use whenever the user mentions handwritten notes, Apple Notes, Quick Note, Apple Pencil, 노트 필기, 손글씨, 아이패드 메모, or asks "what did I write/jot down", "새 필기 있어?", "노트 봐줘" — even if they don't name the app. Also the substrate for any scheduled polling loop that consumes new handwriting.
+---
+
+# Apple Notes Handwriting Reader
+
+Apple Pencil drawings in Notes are invisible to AppleScript and every Notes MCP
+server — but each drawing is rendered to a `FallbackImage.png` on disk, and the
+local `NoteStore.sqlite` knows which drawings exist, when they changed, and which
+note they belong to. Claude reads those images directly (multimodal), which beats
+Apple's built-in handwriting OCR in accuracy, Korean included.
+
+## Workflow
+
+1. **Scan** — run the bundled scanner (Python stdlib only, read-only, headless):
+
+   ```bash
+   uv run "<skill-dir>/scripts/scan_handwriting.py"            # new since watermark (loop mode)
+   uv run "<skill-dir>/scripts/scan_handwriting.py" --all --limit 10   # browse recent (on-demand)
+   ```
+
+   Each output line is JSON: `note_title`, `modified`, `modified_raw` (the raw
+   cursor value — keep it for the watermark step), `image_path`, `image_bytes`,
+   `handwriting_text` (Apple's recognition text — a noisy hint), `attachment_id`.
+   Loop mode emits oldest-first so a truncated batch is resumed next poll;
+   `--all` browsing is newest-first.
+
+2. **Read** — for each row, Read `image_path` (it is an image; Claude sees the
+   strokes). Skip rows where `image_bytes` is under ~10 KB — those are blank or
+   near-blank canvases; say so instead of inventing content.
+
+3. **Interpret** — transcribe faithfully, then add a one-line reading of what the
+   note is about. Trust the image over `handwriting_text`: Apple's recognizer
+   produces errors like "Menory" for "Memory"; use its text only as a hint for
+   ambiguous strokes or as a cheap pre-filter. Present per note: title, modified
+   time, transcription, interpretation. When running as 마틴, emit the result over
+   the Telegram `reply` channel as usual.
+
+4. **Advance the watermark — only in loop mode.** After new handwriting has been
+   successfully consumed (interpreted and delivered), run
+   `--update-watermark <max modified_raw of the consumed rows>`. The value comes
+   from the batch you actually consumed — never from a fresh scan — so notes that
+   arrived in between are picked up next poll instead of being skipped. On-demand
+   browsing must NOT advance the watermark. State lives at
+   `~/.local/state/notes-handwriting/watermark`.
+
+## Edge cases
+
+- **`image_path` null**: the fallback render doesn't exist yet (drawing very fresh,
+  or created on iPad and image not synced). Report the note by title and
+  `handwriting_text` if present; it usually resolves on the next scan.
+- **Empty `handwriting_text` + tiny image (~7.5 KB blank render)**: either a
+  genuinely empty canvas, or a placeholder whose real strokes haven't synced from
+  the iPad yet (verified 2026-06: fresh iPad drawings can sit at a blank
+  generation-3 render while older ones reach rich generation-14 renders). The
+  stroke source of truth is a CloudKit asset, not the local DB
+  (`ZMERGEABLEDATA1` is empty for all drawings). Treat as pending: surface the
+  note title, say the ink hasn't landed, and recheck on the next scan rather
+  than concluding the note is empty.
+- **Locked notes**: encrypted in the database and in fallback images — inaccessible
+  by design; don't try to work around it.
+- **Schema drift**: `NoteStore.sqlite` is a private schema. If the scanner errors
+  after a macOS major update, check columns with
+  `PRAGMA table_info(ZICCLOUDSYNCINGOBJECT)` — the load-bearing ones are
+  `ZTYPEUTI`, `ZHANDWRITINGSUMMARY`, `ZNOTE`, `ZTITLE1`, `ZMODIFICATIONDATE`.
+- **Sync lag**: the Mac sees handwriting only after iCloud syncs it from the iPad
+  (NoteStore.sqlite mtime shows last sync). "I just wrote it" + no result usually
+  means sync hasn't landed yet, not a bug.
+
+## Loop reuse contract
+
+A future polling loop (cron / /loop) should call exactly: scan (no `--all`) →
+if rows: read + interpret + deliver → `--update-watermark <max modified_raw of
+those rows>`. No other state is needed; the watermark file is the single cursor
+shared by all consumers. The polling loop is the watermark's **single writer**
+(on-demand browsing never advances it); the monotonic check is not atomic across
+processes, so never run two consumers that both advance the cursor.

--- a/handwriting/skills/handwriting/scripts/scan_handwriting.py
+++ b/handwriting/skills/handwriting/scripts/scan_handwriting.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env uv run --quiet --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = []
+# ///
+"""Scan Apple Notes for Apple-Pencil handwriting (drawing attachments).
+
+Reads a consistent snapshot of NoteStore.sqlite (including WAL, via the sqlite
+backup API), lists drawing attachments (com.apple.paper / com.apple.drawing*)
+with their note title, Apple's on-device handwriting-recognition text, and the
+on-disk rendered FallbackImage path. Emits one JSON object per line.
+
+Watermark state (for the polling loop) lives outside the repo so on-demand
+browsing and scheduled polling share it:
+  ~/.local/state/notes-handwriting/watermark   (Core Data epoch float)
+
+The watermark only moves via an explicit `--update-watermark VALUE` call —
+the caller passes the max `modified_raw` of the rows it actually consumed,
+so rows that arrive between scan and consumption are never skipped.
+"""
+import argparse
+import glob
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from datetime import datetime, timezone
+
+GROUP = os.path.expanduser("~/Library/Group Containers/group.com.apple.notes")
+STATE_FILE = os.path.expanduser("~/.local/state/notes-handwriting/watermark")
+APPLE_EPOCH = 978307200  # Core Data reference date offset to Unix epoch
+DRAWING_UTIS = ("com.apple.paper", "com.apple.drawing.2", "com.apple.drawing")
+
+
+def snapshot_db(tmpdir: str) -> str:
+    """Consistent snapshot of the live DB (WAL frames included) via the sqlite backup API."""
+    dst_path = os.path.join(tmpdir, "NoteStore.sqlite")
+    try:
+        src = sqlite3.connect(f"file:{os.path.join(GROUP, 'NoteStore.sqlite')}?mode=ro", uri=True)
+        try:
+            dst = sqlite3.connect(dst_path)
+            try:
+                src.backup(dst)
+            finally:
+                dst.close()
+        finally:
+            src.close()
+    except sqlite3.Error as exc:
+        sys.exit(f"cannot open Notes database under {GROUP} ({exc}) — "
+                 "either Notes has no local data on this Mac, or this process "
+                 "lacks Full Disk Access (System Settings > Privacy & Security)")
+    return dst_path
+
+
+def find_image(identifier: str):
+    """Map attachment ZIDENTIFIER to its rendered fallback image (newest generation)."""
+    pattern = os.path.join(GROUP, "Accounts", "*", "FallbackImages", identifier, "*", "FallbackImage.*")
+    hits = glob.glob(pattern)
+    return max(hits, key=os.path.getmtime) if hits else None
+
+
+def read_watermark() -> float:
+    try:
+        with open(STATE_FILE) as f:
+            return float(f.read().strip())
+    except (OSError, ValueError):
+        return 0.0
+
+
+def write_watermark(value: float) -> None:
+    os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
+    with open(STATE_FILE, "w") as f:
+        f.write(repr(value))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--all", action="store_true", help="ignore watermark, list every drawing (newest first)")
+    ap.add_argument("--limit", type=int, default=20, help="max rows")
+    ap.add_argument("--update-watermark", type=float, metavar="MODIFIED_RAW",
+                    help="write the watermark to this value and exit (pass the max "
+                         "modified_raw of the rows actually consumed); no scan is performed")
+    args = ap.parse_args()
+
+    if args.update_watermark is not None:
+        current = read_watermark()
+        if args.update_watermark > current:
+            write_watermark(args.update_watermark)
+            print(f"watermark advanced to {args.update_watermark}", file=sys.stderr)
+        else:
+            print(f"watermark unchanged ({current} >= {args.update_watermark})", file=sys.stderr)
+        return 0
+
+    since = 0.0 if args.all else read_watermark()
+    # Loop mode walks oldest-first so a LIMIT-truncated batch leaves the newer rows
+    # above the watermark for the next poll; --all browsing stays newest-first.
+    order = "DESC" if args.all else "ASC"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = snapshot_db(tmpdir)
+        con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+        placeholders = ",".join("?" * len(DRAWING_UTIS))
+        base_select = f"""
+            SELECT a.Z_PK, a.ZIDENTIFIER, a.ZTYPEUTI, a.ZMODIFICATIONDATE,
+                   a.ZHANDWRITINGSUMMARY, n.ZTITLE1
+            FROM ZICCLOUDSYNCINGOBJECT a
+            LEFT JOIN ZICCLOUDSYNCINGOBJECT n ON a.ZNOTE = n.Z_PK
+            WHERE a.ZTYPEUTI IN ({placeholders})
+              AND IFNULL(a.ZMARKEDFORDELETION, 0) = 0
+        """
+        rows = con.execute(
+            base_select +
+            f" AND a.ZMODIFICATIONDATE > ? ORDER BY a.ZMODIFICATIONDATE {order} LIMIT ?",
+            (*DRAWING_UTIS, since, args.limit),
+        ).fetchall()
+        if not args.all and rows and len(rows) == args.limit:
+            # Complete the tie group at the boundary timestamp: the scalar watermark
+            # (`> cursor`) would otherwise strand unconsumed rows that share the
+            # boundary's ZMODIFICATIONDATE behind it forever.
+            boundary, seen = rows[-1][3], {r[0] for r in rows}
+            extra = con.execute(
+                base_select + " AND a.ZMODIFICATIONDATE = ?",
+                (*DRAWING_UTIS, boundary),
+            ).fetchall()
+            rows += [r for r in extra if r[0] not in seen]
+        con.close()
+
+    for pk, identifier, uti, mod, summary, title in rows:
+        image = find_image(identifier)
+        print(json.dumps({
+            "attachment_pk": pk,
+            "attachment_id": identifier,
+            "uti": uti,
+            "modified": datetime.fromtimestamp((mod or 0) + APPLE_EPOCH, tz=timezone.utc)
+                        .astimezone().isoformat(timespec="seconds"),
+            "modified_raw": mod,
+            "note_title": title,
+            "handwriting_text": summary or None,
+            "image_path": image,
+            "image_bytes": os.path.getsize(image) if image else None,
+        }, ensure_ascii=False))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

hermeneutic-assistant 프로젝트 스킬 `notes-handwriting`을 마켓플레이스 플러그인 `handwriting`으로 마이그레이션합니다 (#62 hourly-digest와 같은 패턴).

- **기능**: Apple Notes의 Apple Pencil 필기를 읽는다 — `NoteStore.sqlite`에서 드로잉 첨부를 스캔하고, 렌더된 `FallbackImage.png`를 멀티모달로 직접 읽어 Apple 내장 OCR보다 정확하게 전사 (한국어 포함).
- **사전 검증**: 마이그레이션 전 codex(gpt-5.5) 리뷰 루프 3라운드로 경화 — 워터마크 재스캔 경합/LIMIT 절단 소실(high 2건)을 명시값 커서 + 오래된 순 정렬로 재설계, sqlite 백업 API 스냅샷, tie-group 완성, 에러 가드 적용 후 verdict=approve 수렴.
- **컨벤션 적용**: 스크립트를 PEP 723 inline metadata + `uv run` 호출로 전환 (`dependencies = []`), `uv run` 스모크 테스트 통과.
- 워터마크 상태 파일은 기존 경로(`~/.local/state/notes-handwriting/watermark`)를 유지해 이전 상태와 연속성 보장.

## Test plan

- [x] `uv run handwriting/skills/handwriting/scripts/scan_handwriting.py --all --limit 1` → JSON 행 + `modified_raw` 필드 방출 확인 (PR 생성 전 검증 완료)
- [x] `--update-watermark 0` no-op 분기 + marketplace/plugin JSON 유효성 확인 (PR 생성 전 검증 완료)
- [ ] 머지 후 `/plugin marketplace update cc-plugin` → `/plugin install handwriting` → 새 세션에서 `/handwriting` 호출 확인
- [ ] 플러그인 설치 확인 후 hermeneutic-assistant의 로컬 사본 `.claude/skills/handwriting/` 제거 (중복 등록 방지)
