### PR TITLE
feat: add hotspot-toggle plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -93,6 +93,11 @@
       "name": "handwriting",
       "source": "./handwriting",
       "description": "Apple Notes handwriting reader — scan Apple Pencil drawings via NoteStore.sqlite and read them multimodally"
+    },
+    {
+      "name": "hotspot-toggle",
+      "source": "./hotspot-toggle",
+      "description": "Mac Wi-Fi toggle between iPhone Personal Hotspot and known networks via Control Center automation"
     }
   ]
 }

--- a/hotspot-toggle/.claude-plugin/plugin.json
+++ b/hotspot-toggle/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "hotspot-toggle",
+  "description": "Mac Wi-Fi toggle between iPhone Personal Hotspot and known networks via Control Center automation",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/hotspot-toggle/scripts/hotspot-toggle.sh
+++ b/hotspot-toggle/scripts/hotspot-toggle.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# hotspot-toggle.sh — toggle Mac Wi-Fi between iPhone Personal Hotspot and known networks.
+# Wake path verified on macOS 26.5.1 (2026-06-12): Control Center > Wi-Fi detail >
+# wifi-network-<SSID> AXPress wakes Instant Hotspot; direct `networksetup -setairportnetwork`
+# fails (-3900) because the hotspot SSID is not broadcast while off.
+# Requires Accessibility permission for the process chain running osascript (granted to tmux).
+# Usage: hotspot-toggle.sh [toggle|hotspot|wifi]   (default: toggle)
+set -u
+
+HOTSPOT_SSID="Jongwony"
+WIFI_IF="en0"
+
+gateway() { route -n get default 2>/dev/null | awk '/gateway/{print $2}'; }
+
+on_hotspot() {
+  case "$(gateway)" in
+    192.0.0.1|172.20.10.*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+ax_preflight() {
+  osascript -e 'tell application "System Events" to count menu bar items of menu bar 1 of process "ControlCenter"' >/dev/null 2>&1
+}
+
+connect_hotspot() {
+  osascript <<EOF
+tell application "System Events"
+  tell process "ControlCenter"
+    set ccItem to missing value
+    repeat with i from 1 to count of menu bar items of menu bar 1
+      try
+        if (value of attribute "AXIdentifier" of menu bar item i of menu bar 1) is "com.apple.menuextra.controlcenter" then
+          set ccItem to menu bar item i of menu bar 1
+          exit repeat
+        end if
+      end try
+    end repeat
+    if ccItem is missing value then error "Control Center menu bar item not found"
+    click ccItem
+    delay 1.2
+    set wifiModule to missing value
+    repeat with el in UI elements of group 1 of window 1
+      try
+        if (value of attribute "AXIdentifier" of el) is "controlcenter-wifi" then
+          set wifiModule to el
+          exit repeat
+        end if
+      end try
+    end repeat
+    if wifiModule is missing value then error "Wi-Fi module not found in Control Center"
+    set p to position of wifiModule
+    set s to size of wifiModule
+    click at {(item 1 of p) + (item 1 of s) - 20, (item 2 of p) + ((item 2 of s) div 2)}
+    delay 1.5
+    set sa to scroll area 1 of group 1 of window 1
+    set target to missing value
+    repeat with el in UI elements of sa
+      try
+        if (value of attribute "AXIdentifier" of el) is "wifi-network-${HOTSPOT_SSID}" then
+          set target to el
+          exit repeat
+        end if
+      end try
+    end repeat
+    if target is missing value then error "hotspot entry wifi-network-${HOTSPOT_SSID} not visible"
+    perform action "AXPress" of target
+    delay 0.5
+  end tell
+  key code 53
+end tell
+EOF
+}
+
+leg_hotspot() {
+  if on_hotspot; then
+    echo "Already on hotspot (gateway $(gateway))."
+    return 0
+  fi
+  echo "Connecting to hotspot ${HOTSPOT_SSID} via Control Center..."
+  if ! connect_hotspot; then
+    echo "FAIL: Control Center automation failed (UI structure may have changed after a macOS update)." >&2
+    return 1
+  fi
+  local t=0
+  while [ $t -lt 25 ]; do
+    on_hotspot && { echo "OK: connected to hotspot (gateway $(gateway))."; return 0; }
+    sleep 1; t=$((t+1))
+  done
+  echo "FAIL: hotspot not joined within 25s (is the iPhone nearby with Bluetooth on?)." >&2
+  return 1
+}
+
+leg_wifi() {
+  echo "Power-cycling Wi-Fi to rejoin the strongest known network..."
+  networksetup -setairportpower "$WIFI_IF" off
+  sleep 2
+  networksetup -setairportpower "$WIFI_IF" on
+  local t=0
+  while [ $t -lt 25 ]; do
+    if [ -n "$(gateway)" ]; then
+      if on_hotspot; then
+        echo "NOTE: rejoined the hotspot — it may be the only known network in range (gateway $(gateway))."
+      else
+        echo "OK: rejoined known network (gateway $(gateway), ip $(ipconfig getifaddr "$WIFI_IF" 2>/dev/null))."
+      fi
+      return 0
+    fi
+    sleep 1; t=$((t+1))
+  done
+  echo "FAIL: no network joined within 25s." >&2
+  return 1
+}
+
+if ! ax_preflight; then
+  echo "FAIL: Accessibility permission missing for this process chain (System Settings > Privacy & Security > Accessibility)." >&2
+  exit 2
+fi
+
+MODE="${1:-toggle}"
+case "$MODE" in
+  hotspot) leg_hotspot ;;
+  wifi)    leg_wifi ;;
+  toggle)  if on_hotspot; then leg_wifi; else leg_hotspot; fi ;;
+  *) echo "Usage: $0 [toggle|hotspot|wifi]" >&2; exit 64 ;;
+esac

--- a/hotspot-toggle/scripts/hotspot-toggle.sh
+++ b/hotspot-toggle/scripts/hotspot-toggle.sh
@@ -1,30 +1,20 @@
 #!/bin/bash
-# hotspot-toggle.sh — toggle Mac Wi-Fi between iPhone Personal Hotspot and known networks.
-# Wake path verified on macOS 26.5.1 (2026-06-12): Control Center > Wi-Fi detail >
-# wifi-network-<SSID> AXPress wakes Instant Hotspot; direct `networksetup -setairportnetwork`
-# fails (-3900) because the hotspot SSID is not broadcast while off.
-# Requires Accessibility permission for the process chain running osascript (granted to tmux).
-# Usage: hotspot-toggle.sh [toggle|hotspot|wifi]   (default: toggle)
-# Env:   HOTSPOT_SSID      hotspot network name (default: Jongwony)
-#        WIFI_IF           Wi-Fi interface (default: auto-detected from hardware ports)
+# hotspot-toggle.sh — deterministic legs for the hotspot-toggle skill.
+# The Control Center connect step (waking Instant Hotspot) is instruction-driven:
+# the skill composes and runs osascript per references/control-center-ax-path.md,
+# because direct `networksetup -setairportnetwork` fails (-3900) while the hotspot
+# SSID is not broadcast. This script keeps only the deterministic parts.
+# Usage: hotspot-toggle.sh [status|preflight|wait-hotspot|wifi]   (default: status)
+# Env:   WIFI_IF           Wi-Fi interface (default: auto-detected from hardware ports)
 #        HOTSPOT_GATEWAYS  space-separated glob patterns matching the hotspot's gateway
 #                          (default covers Apple's standard iPhone hotspot NAT addresses;
 #                          override for e.g. Android hotspots)
 # -f: HOTSPOT_GATEWAYS holds glob patterns that must not expand against the filesystem.
 set -uf
 
-HOTSPOT_SSID="${HOTSPOT_SSID:-Jongwony}"
 WIFI_IF="${WIFI_IF:-$(networksetup -listallhardwareports 2>/dev/null | awk '/^Hardware Port: (Wi-Fi|AirPort)/{getline; print $2; exit}')}"
 : "${WIFI_IF:=en0}"
 HOTSPOT_GATEWAYS="${HOTSPOT_GATEWAYS:-192.0.0.1 172.20.10.*}"
-
-# HOTSPOT_SSID is interpolated into the AppleScript heredoc below; these characters
-# would break or alter the generated script.
-case "$HOTSPOT_SSID" in
-  *'"'* | *'\'* | *'$'* | *'`'*)
-    echo "FAIL: HOTSPOT_SSID contains characters unsafe for script interpolation (\" \\ \$ \`)." >&2
-    exit 64 ;;
-esac
 
 gateway() { route -n get default 2>/dev/null | awk '/gateway/{print $2}'; }
 
@@ -44,69 +34,7 @@ ax_preflight() {
   osascript -e 'tell application "System Events" to count menu bar items of menu bar 1 of process "ControlCenter"' >/dev/null 2>&1
 }
 
-connect_hotspot() {
-  osascript <<EOF
-tell application "System Events"
-  tell process "ControlCenter"
-    set ccItem to missing value
-    repeat with i from 1 to count of menu bar items of menu bar 1
-      try
-        if (value of attribute "AXIdentifier" of menu bar item i of menu bar 1) is "com.apple.menuextra.controlcenter" then
-          set ccItem to menu bar item i of menu bar 1
-          exit repeat
-        end if
-      end try
-    end repeat
-    if ccItem is missing value then error "Control Center menu bar item not found"
-    click ccItem
-    delay 1.2
-    set wifiModule to missing value
-    repeat with el in UI elements of group 1 of window 1
-      try
-        if (value of attribute "AXIdentifier" of el) is "controlcenter-wifi" then
-          set wifiModule to el
-          exit repeat
-        end if
-      end try
-    end repeat
-    if wifiModule is missing value then error "Wi-Fi module not found in Control Center"
-    set p to position of wifiModule
-    set s to size of wifiModule
-    click at {(item 1 of p) + (item 1 of s) - 20, (item 2 of p) + ((item 2 of s) div 2)}
-    delay 1.5
-    set sa to scroll area 1 of group 1 of window 1
-    set target to missing value
-    repeat with el in UI elements of sa
-      try
-        if (value of attribute "AXIdentifier" of el) is "wifi-network-${HOTSPOT_SSID}" then
-          set target to el
-          exit repeat
-        end if
-      end try
-    end repeat
-    if target is missing value then error "hotspot entry wifi-network-${HOTSPOT_SSID} not visible"
-    perform action "AXPress" of target
-    delay 0.5
-  end tell
-  key code 53
-end tell
-EOF
-}
-
-leg_hotspot() {
-  if on_hotspot; then
-    echo "Already on hotspot (gateway $(gateway))."
-    return 0
-  fi
-  if ! ax_preflight; then
-    echo "FAIL: Accessibility permission missing for this process chain (System Settings > Privacy & Security > Accessibility)." >&2
-    exit 2
-  fi
-  echo "Connecting to hotspot ${HOTSPOT_SSID} via Control Center..."
-  if ! connect_hotspot; then
-    echo "FAIL: Control Center automation failed (UI structure may have changed after a macOS update)." >&2
-    return 1
-  fi
+wait_hotspot() {
   local t=0
   while [ $t -lt 25 ]; do
     on_hotspot && { echo "OK: connected to hotspot (gateway $(gateway))."; return 0; }
@@ -144,10 +72,24 @@ leg_wifi() {
   return 1
 }
 
-MODE="${1:-toggle}"
+MODE="${1:-status}"
 case "$MODE" in
-  hotspot) leg_hotspot ;;
-  wifi)    leg_wifi ;;
-  toggle)  if on_hotspot; then leg_wifi; else leg_hotspot; fi ;;
-  *) echo "Usage: $0 [toggle|hotspot|wifi]" >&2; exit 64 ;;
+  status)
+    if on_hotspot; then
+      echo "hotspot (gateway $(gateway))"
+    elif [ -n "$(gateway)" ]; then
+      echo "wifi (gateway $(gateway), ip $(ipconfig getifaddr "$WIFI_IF" 2>/dev/null))"
+    else
+      echo "none"
+    fi ;;
+  preflight)
+    if ax_preflight; then
+      echo "OK: Accessibility permission present."
+    else
+      echo "FAIL: Accessibility permission missing for this process chain (System Settings > Privacy & Security > Accessibility)." >&2
+      exit 2
+    fi ;;
+  wait-hotspot) wait_hotspot ;;
+  wifi)         leg_wifi ;;
+  *) echo "Usage: $0 [status|preflight|wait-hotspot|wifi]" >&2; exit 64 ;;
 esac

--- a/hotspot-toggle/scripts/hotspot-toggle.sh
+++ b/hotspot-toggle/scripts/hotspot-toggle.sh
@@ -10,6 +10,14 @@ set -u
 HOTSPOT_SSID="Jongwony"
 WIFI_IF="en0"
 
+# HOTSPOT_SSID is interpolated into the AppleScript heredoc below; these characters
+# would break or alter the generated script.
+case "$HOTSPOT_SSID" in
+  *'"'* | *'\'* | *'$'* | *'`'*)
+    echo "FAIL: HOTSPOT_SSID contains characters unsafe for script interpolation (\" \\ \$ \`)." >&2
+    exit 64 ;;
+esac
+
 gateway() { route -n get default 2>/dev/null | awk '/gateway/{print $2}'; }
 
 on_hotspot() {
@@ -77,6 +85,10 @@ leg_hotspot() {
     echo "Already on hotspot (gateway $(gateway))."
     return 0
   fi
+  if ! ax_preflight; then
+    echo "FAIL: Accessibility permission missing for this process chain (System Settings > Privacy & Security > Accessibility)." >&2
+    exit 2
+  fi
   echo "Connecting to hotspot ${HOTSPOT_SSID} via Control Center..."
   if ! connect_hotspot; then
     echo "FAIL: Control Center automation failed (UI structure may have changed after a macOS update)." >&2
@@ -93,16 +105,23 @@ leg_hotspot() {
 
 leg_wifi() {
   echo "Power-cycling Wi-Fi to rejoin the strongest known network..."
-  networksetup -setairportpower "$WIFI_IF" off
+  if ! networksetup -setairportpower "$WIFI_IF" off; then
+    echo "FAIL: could not power off Wi-Fi interface ${WIFI_IF} (is WIFI_IF correct?)." >&2
+    return 1
+  fi
   sleep 2
-  networksetup -setairportpower "$WIFI_IF" on
-  local t=0
+  if ! networksetup -setairportpower "$WIFI_IF" on; then
+    echo "FAIL: could not power on Wi-Fi interface ${WIFI_IF}." >&2
+    return 1
+  fi
+  local t=0 ip
   while [ $t -lt 25 ]; do
-    if [ -n "$(gateway)" ]; then
+    ip="$(ipconfig getifaddr "$WIFI_IF" 2>/dev/null)"
+    if [ -n "$ip" ]; then
       if on_hotspot; then
-        echo "NOTE: rejoined the hotspot — it may be the only known network in range (gateway $(gateway))."
+        echo "NOTE: back on the hotspot — the hotspot does not auto-rejoin here, so this reflects a manual connect (gateway $(gateway))."
       else
-        echo "OK: rejoined known network (gateway $(gateway), ip $(ipconfig getifaddr "$WIFI_IF" 2>/dev/null))."
+        echo "OK: rejoined known network (gateway $(gateway), ip $ip)."
       fi
       return 0
     fi
@@ -111,11 +130,6 @@ leg_wifi() {
   echo "FAIL: no network joined within 25s." >&2
   return 1
 }
-
-if ! ax_preflight; then
-  echo "FAIL: Accessibility permission missing for this process chain (System Settings > Privacy & Security > Accessibility)." >&2
-  exit 2
-fi
 
 MODE="${1:-toggle}"
 case "$MODE" in

--- a/hotspot-toggle/scripts/hotspot-toggle.sh
+++ b/hotspot-toggle/scripts/hotspot-toggle.sh
@@ -5,10 +5,18 @@
 # fails (-3900) because the hotspot SSID is not broadcast while off.
 # Requires Accessibility permission for the process chain running osascript (granted to tmux).
 # Usage: hotspot-toggle.sh [toggle|hotspot|wifi]   (default: toggle)
-set -u
+# Env:   HOTSPOT_SSID      hotspot network name (default: Jongwony)
+#        WIFI_IF           Wi-Fi interface (default: auto-detected from hardware ports)
+#        HOTSPOT_GATEWAYS  space-separated glob patterns matching the hotspot's gateway
+#                          (default covers Apple's standard iPhone hotspot NAT addresses;
+#                          override for e.g. Android hotspots)
+# -f: HOTSPOT_GATEWAYS holds glob patterns that must not expand against the filesystem.
+set -uf
 
-HOTSPOT_SSID="Jongwony"
-WIFI_IF="en0"
+HOTSPOT_SSID="${HOTSPOT_SSID:-Jongwony}"
+WIFI_IF="${WIFI_IF:-$(networksetup -listallhardwareports 2>/dev/null | awk '/^Hardware Port: (Wi-Fi|AirPort)/{getline; print $2; exit}')}"
+: "${WIFI_IF:=en0}"
+HOTSPOT_GATEWAYS="${HOTSPOT_GATEWAYS:-192.0.0.1 172.20.10.*}"
 
 # HOTSPOT_SSID is interpolated into the AppleScript heredoc below; these characters
 # would break or alter the generated script.
@@ -21,10 +29,15 @@ esac
 gateway() { route -n get default 2>/dev/null | awk '/gateway/{print $2}'; }
 
 on_hotspot() {
-  case "$(gateway)" in
-    192.0.0.1|172.20.10.*) return 0 ;;
-    *) return 1 ;;
-  esac
+  local gw pat
+  gw="$(gateway)"
+  [ -n "$gw" ] || return 1
+  for pat in $HOTSPOT_GATEWAYS; do
+    case "$gw" in
+      $pat) return 0 ;;
+    esac
+  done
+  return 1
 }
 
 ax_preflight() {

--- a/hotspot-toggle/skills/hotspot-toggle/SKILL.md
+++ b/hotspot-toggle/skills/hotspot-toggle/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: hotspot-toggle
+description: Toggle the Mac's Wi-Fi between the iPhone Personal Hotspot and known networks. Use when the user says "핫스팟", "hotspot", asks to switch to or from the iPhone hotspot, or wants to hand off the Mac's network before moving.
+---
+
+# Hotspot Toggle
+
+Run the toggle script and report the result:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/hotspot-toggle.sh" <mode>
+```
+
+Pick `<mode>` from the user's wording:
+- `toggle` (default) — flips based on current state
+- `hotspot` — force the hotspot leg (join the iPhone Personal Hotspot)
+- `wifi` — force the return to known networks
+
+Notes:
+- State detection is gateway-based (hotspot gateways: `192.0.0.1` or `172.20.10.x`)
+  because SSID reads are location-permission-gated on this macOS.
+- Report the script's stdout/stderr outcome to the user. Exit 2 means Accessibility
+  permission is missing — relay the script's guidance.
+- The network blips for a few seconds during either leg; warn the user when they are
+  conversing over this machine's connection (e.g., Telegram bridge).
+- Machine-specific constants (`HOTSPOT_SSID="Jongwony"`, `WIFI_IF="en0"`) live at the
+  top of the script.

--- a/hotspot-toggle/skills/hotspot-toggle/SKILL.md
+++ b/hotspot-toggle/skills/hotspot-toggle/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: hotspot-toggle
-description: Toggle the Mac's Wi-Fi between the iPhone Personal Hotspot and known networks. Use when the user says "핫스팟", "hotspot", asks to switch to or from the iPhone hotspot, or wants to hand off the Mac's network before moving.
+description: |
+  This skill should be used when the user says "핫스팟", "hotspot", asks to switch to or
+  from the iPhone hotspot, or wants to hand off the Mac's network before moving.
+  Toggles the Mac's Wi-Fi between the iPhone Personal Hotspot and known networks.
 ---
 
 # Hotspot Toggle
@@ -21,6 +24,9 @@ Notes:
   because SSID reads are location-permission-gated on this macOS.
 - Report the script's stdout/stderr outcome to the user. Exit 2 means Accessibility
   permission is missing — relay the script's guidance.
+- If `wifi` mode ends back on the hotspot, that is intentional (the hotspot does not
+  auto-rejoin on this machine, so it was connected manually): the script prints a NOTE
+  and exits 0.
 - The network blips for a few seconds during either leg; warn the user when they are
   conversing over this machine's connection (e.g., Telegram bridge).
 - Machine-specific constants (`HOTSPOT_SSID="Jongwony"`, `WIFI_IF="en0"`) live at the

--- a/hotspot-toggle/skills/hotspot-toggle/SKILL.md
+++ b/hotspot-toggle/skills/hotspot-toggle/SKILL.md
@@ -24,10 +24,20 @@ Notes:
   because SSID reads are location-permission-gated on this macOS.
 - Report the script's stdout/stderr outcome to the user. Exit 2 means Accessibility
   permission is missing — relay the script's guidance.
-- If `wifi` mode ends back on the hotspot, that is intentional (the hotspot does not
-  auto-rejoin on this machine, so it was connected manually): the script prints a NOTE
-  and exits 0.
+- If `wifi` mode ends back on the hotspot, the script prints a NOTE and exits 0. On
+  this machine that is intentional (the hotspot does not auto-rejoin, so it was
+  connected manually); on a machine where the hotspot auto-joins, the same outcome can
+  also mean an automatic rejoin.
 - The network blips for a few seconds during either leg; warn the user when they are
   conversing over this machine's connection (e.g., Telegram bridge).
-- Machine-specific constants (`HOTSPOT_SSID="Jongwony"`, `WIFI_IF="en0"`) live at the
-  top of the script.
+- Machine-specific values are environment-overridable: `HOTSPOT_SSID` (default
+  `Jongwony`), `WIFI_IF` (auto-detected from the hardware port list; override only if
+  detection fails), `HOTSPOT_GATEWAYS` (space-separated glob patterns; the default
+  covers iPhone hotspots — override for e.g. Android hotspots).
+
+Portability preconditions (not satisfied by installing the plugin):
+- Accessibility permission must be granted to the process chain running osascript
+  (System Settings > Privacy & Security > Accessibility) — exit 2 reports its absence.
+- The Control Center automation path is pinned to a verified macOS version (see the
+  script header). If it breaks after a macOS update, re-derive it with the recorded
+  discovery procedure in `references/control-center-ax-path.md`.

--- a/hotspot-toggle/skills/hotspot-toggle/SKILL.md
+++ b/hotspot-toggle/skills/hotspot-toggle/SKILL.md
@@ -24,12 +24,12 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/hotspot-toggle.sh" <mode>   # status|preflig
 3. **Join the iPhone hotspot** (hotspot leg):
    a. Run `preflight`. Exit 2 means Accessibility permission is missing — relay the
       script's guidance and stop.
-   b. Perform the Control Center connect: run the verified osascript recorded in
-      `references/control-center-ax-path.md`, substituting the hotspot SSID
-      (env `HOTSPOT_SSID`, default `Jongwony`; escape `"` and `\` when composing the
-      AppleScript string). If it errors, the macOS UI likely changed after an update —
-      re-derive the path with the discovery procedure in the same document, run the
-      corrected script, and update the document with what changed.
+   b. Perform the Control Center connect: compose an osascript from the formal
+      procedure in `references/control-center-ax-path.md` (hops + current known
+      values), substituting the hotspot SSID (env `HOTSPOT_SSID`, default `Jongwony`;
+      escape `"` and `\`), and run it. If a hop fails, the macOS UI likely changed
+      after an update — re-derive that hop per the same document and update its
+      known-values table.
    c. Run `wait-hotspot` to confirm the join within 25s.
 
 ## Notes
@@ -51,6 +51,6 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/hotspot-toggle.sh" <mode>   # status|preflig
 
 - Accessibility permission must be granted to the process chain running osascript
   (System Settings > Privacy & Security > Accessibility) — `preflight` checks this.
-- The verified connect script is pinned to a macOS version; after an update breaks it,
-  the discovery procedure in `references/control-center-ax-path.md` is the recovery
-  path.
+- The connect procedure's recorded values are pinned to a verified macOS version;
+  after an update breaks a hop, re-derivation per
+  `references/control-center-ax-path.md` is the recovery path.

--- a/hotspot-toggle/skills/hotspot-toggle/SKILL.md
+++ b/hotspot-toggle/skills/hotspot-toggle/SKILL.md
@@ -8,36 +8,49 @@ description: |
 
 # Hotspot Toggle
 
-Run the toggle script and report the result:
+The helper script provides the deterministic legs; the Control Center connect step is
+instruction-driven (this file + `references/control-center-ax-path.md`).
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/hotspot-toggle.sh" <mode>
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/hotspot-toggle.sh" <mode>   # status|preflight|wait-hotspot|wifi
 ```
 
-Pick `<mode>` from the user's wording:
-- `toggle` (default) — flips based on current state
-- `hotspot` — force the hotspot leg (join the iPhone Personal Hotspot)
-- `wifi` — force the return to known networks
+## Workflow
 
-Notes:
-- State detection is gateway-based (hotspot gateways: `192.0.0.1` or `172.20.10.x`)
-  because SSID reads are location-permission-gated on this macOS.
-- Report the script's stdout/stderr outcome to the user. Exit 2 means Accessibility
-  permission is missing — relay the script's guidance.
+1. **Determine the leg** from the user's wording and current state:
+   run `status` → `hotspot (…)` | `wifi (…)` | `none`. A toggle request flips the
+   current state; an explicit request forces that leg.
+2. **Return to known networks** (wifi leg): run `wifi` and report its outcome.
+3. **Join the iPhone hotspot** (hotspot leg):
+   a. Run `preflight`. Exit 2 means Accessibility permission is missing — relay the
+      script's guidance and stop.
+   b. Perform the Control Center connect: run the verified osascript recorded in
+      `references/control-center-ax-path.md`, substituting the hotspot SSID
+      (env `HOTSPOT_SSID`, default `Jongwony`; escape `"` and `\` when composing the
+      AppleScript string). If it errors, the macOS UI likely changed after an update —
+      re-derive the path with the discovery procedure in the same document, run the
+      corrected script, and update the document with what changed.
+   c. Run `wait-hotspot` to confirm the join within 25s.
+
+## Notes
+
+- State detection is gateway-based (env `HOTSPOT_GATEWAYS`, default covers iPhone
+  hotspot NAT addresses `192.0.0.1` / `172.20.10.x`) because SSID reads are
+  location-permission-gated on this macOS. Override the patterns for e.g. Android
+  hotspots.
+- `WIFI_IF` is auto-detected from the hardware port list; override via env only if
+  detection fails.
 - If `wifi` mode ends back on the hotspot, the script prints a NOTE and exits 0. On
   this machine that is intentional (the hotspot does not auto-rejoin, so it was
   connected manually); on a machine where the hotspot auto-joins, the same outcome can
   also mean an automatic rejoin.
 - The network blips for a few seconds during either leg; warn the user when they are
   conversing over this machine's connection (e.g., Telegram bridge).
-- Machine-specific values are environment-overridable: `HOTSPOT_SSID` (default
-  `Jongwony`), `WIFI_IF` (auto-detected from the hardware port list; override only if
-  detection fails), `HOTSPOT_GATEWAYS` (space-separated glob patterns; the default
-  covers iPhone hotspots — override for e.g. Android hotspots).
 
-Portability preconditions (not satisfied by installing the plugin):
+## Portability preconditions (not satisfied by installing the plugin)
+
 - Accessibility permission must be granted to the process chain running osascript
-  (System Settings > Privacy & Security > Accessibility) — exit 2 reports its absence.
-- The Control Center automation path is pinned to a verified macOS version (see the
-  script header). If it breaks after a macOS update, re-derive it with the recorded
-  discovery procedure in `references/control-center-ax-path.md`.
+  (System Settings > Privacy & Security > Accessibility) — `preflight` checks this.
+- The verified connect script is pinned to a macOS version; after an update breaks it,
+  the discovery procedure in `references/control-center-ax-path.md` is the recovery
+  path.

--- a/hotspot-toggle/skills/hotspot-toggle/references/control-center-ax-path.md
+++ b/hotspot-toggle/skills/hotspot-toggle/references/control-center-ax-path.md
@@ -17,8 +17,10 @@ Instant Hotspot — hence AX automation of that picker, and no non-UI alternativ
 
 ## Composition contract
 
-- Compose a single `osascript` run executing the hops below in order, inside
-  `tell application "System Events"` / `tell process "ControlCenter"`.
+- Compose a single `osascript` run executing the hops below in order, all inside
+  `tell application "System Events"`: hops 1-4 additionally nested inside
+  `tell process "ControlCenter"`; hop 5 at the System Events level, outside the
+  process block.
 - Locate every element by enumerating its container and matching `AXIdentifier` —
   never by localized title. Wrap per-element attribute reads in `try` (some elements
   lack the attribute).

--- a/hotspot-toggle/skills/hotspot-toggle/references/control-center-ax-path.md
+++ b/hotspot-toggle/skills/hotspot-toggle/references/control-center-ax-path.md
@@ -1,9 +1,70 @@
-# Control Center AX Path — Discovery Procedure
+# Control Center AX Path — Verified Script + Discovery Procedure
 
-How the automation path in `scripts/hotspot-toggle.sh` was derived, recorded so the
-path can be re-derived when a macOS update changes the Control Center UI.
-Provenance: reconstructed from the script structure and its header notes; the path
-itself is verified on macOS 26.5.1 (2026-06-12).
+The Control Center connect step is instruction-driven: the skill composes and runs
+the verified script below, and when a macOS update breaks it, re-derives the path
+with the discovery procedure that follows. The deterministic legs (state detection,
+wifi return, preflight, join polling) live in `scripts/hotspot-toggle.sh`.
+Provenance: the discovery procedure is reconstructed from the original script
+structure and its header notes; the path itself is verified on macOS 26.5.1
+(2026-06-12).
+
+## Verified connect script (macOS 26.5.1)
+
+Substitute `__HOTSPOT_SSID__` with the hotspot's network name (env `HOTSPOT_SSID`,
+default `Jongwony`); escape `"` and `\` if the SSID contains them, since it lands
+inside an AppleScript string literal.
+
+```bash
+osascript <<'EOF'
+tell application "System Events"
+  tell process "ControlCenter"
+    set ccItem to missing value
+    repeat with i from 1 to count of menu bar items of menu bar 1
+      try
+        if (value of attribute "AXIdentifier" of menu bar item i of menu bar 1) is "com.apple.menuextra.controlcenter" then
+          set ccItem to menu bar item i of menu bar 1
+          exit repeat
+        end if
+      end try
+    end repeat
+    if ccItem is missing value then error "Control Center menu bar item not found"
+    click ccItem
+    delay 1.2
+    set wifiModule to missing value
+    repeat with el in UI elements of group 1 of window 1
+      try
+        if (value of attribute "AXIdentifier" of el) is "controlcenter-wifi" then
+          set wifiModule to el
+          exit repeat
+        end if
+      end try
+    end repeat
+    if wifiModule is missing value then error "Wi-Fi module not found in Control Center"
+    set p to position of wifiModule
+    set s to size of wifiModule
+    click at {(item 1 of p) + (item 1 of s) - 20, (item 2 of p) + ((item 2 of s) div 2)}
+    delay 1.5
+    set sa to scroll area 1 of group 1 of window 1
+    set target to missing value
+    repeat with el in UI elements of sa
+      try
+        if (value of attribute "AXIdentifier" of el) is "wifi-network-__HOTSPOT_SSID__" then
+          set target to el
+          exit repeat
+        end if
+      end try
+    end repeat
+    if target is missing value then error "hotspot entry wifi-network-__HOTSPOT_SSID__ not visible"
+    perform action "AXPress" of target
+    delay 0.5
+  end tell
+  key code 53
+end tell
+EOF
+```
+
+After it succeeds, confirm the join with
+`bash "${CLAUDE_PLUGIN_ROOT}/scripts/hotspot-toggle.sh" wait-hotspot`.
 
 ## Why UI automation at all
 
@@ -66,4 +127,5 @@ settles returns partial trees.
   ```
 
 - Re-verify the chevron offset (hop 3) — layout changes move the clickable zone.
-- Update the verified-version line in the script header after re-verification.
+- After re-verification, update this document: the verified connect script above and
+  the macOS version in its heading and the provenance note.

--- a/hotspot-toggle/skills/hotspot-toggle/references/control-center-ax-path.md
+++ b/hotspot-toggle/skills/hotspot-toggle/references/control-center-ax-path.md
@@ -1,0 +1,69 @@
+# Control Center AX Path — Discovery Procedure
+
+How the automation path in `scripts/hotspot-toggle.sh` was derived, recorded so the
+path can be re-derived when a macOS update changes the Control Center UI.
+Provenance: reconstructed from the script structure and its header notes; the path
+itself is verified on macOS 26.5.1 (2026-06-12).
+
+## Why UI automation at all
+
+`networksetup -setairportnetwork <if> "<hotspot SSID>"` fails with error -3900 while
+the hotspot is off: an Instant Hotspot SSID is not broadcast until woken, so the
+direct join API cannot see it. The Wi-Fi picker in Control Center is what wakes
+Instant Hotspot — hence AX automation of that picker, and no non-UI alternative.
+
+## Discovery heuristic
+
+At each hop, enumerate the AX tree with System Events and select elements by stable
+`AXIdentifier` — never by localized title (breaks across UI languages). Fall back to
+a coordinate click only where no pressable AX element exists.
+
+1. **Control Center menu bar item** — enumerate identifiers, match the stable one:
+
+   ```bash
+   osascript -e 'tell application "System Events" to tell process "ControlCenter" to get value of attribute "AXIdentifier" of every menu bar item of menu bar 1'
+   ```
+
+   → `com.apple.menuextra.controlcenter`. Click it to open the panel.
+
+2. **Wi-Fi module in the opened panel** — enumerate the panel's elements:
+
+   ```bash
+   osascript -e 'tell application "System Events" to tell process "ControlCenter" to get value of attribute "AXIdentifier" of every UI element of group 1 of window 1'
+   ```
+
+   → `controlcenter-wifi`.
+
+3. **Opening the Wi-Fi detail view** — the chevron that expands the module is not a
+   separately pressable AX element, so this is the one coordinate-based fallback:
+   click near the module's right edge (right edge − 20px, vertical center), computed
+   from the module's AX `position`/`size`.
+
+4. **Network entries in the detail list** — enumerate the scroll area:
+
+   ```bash
+   osascript -e 'tell application "System Events" to tell process "ControlCenter" to get value of attribute "AXIdentifier" of every UI element of scroll area 1 of group 1 of window 1'
+   ```
+
+   → entries are `wifi-network-<SSID>`. `AXPress` on the hotspot's entry wakes
+   Instant Hotspot and joins it — this is the hop that `networksetup` cannot do.
+
+5. **Close the panel** — `key code 53` (Escape).
+
+Delays between hops (1.2s after opening the panel, 1.5s after opening the detail
+view) are empirical: the panel populates asynchronously and enumeration before it
+settles returns partial trees.
+
+## Re-derivation checklist after a macOS update
+
+- Re-run the enumeration snippets at each hop. Identifiers renaming or elements
+  moving one container level (`group`/`window` indices) are the usual breakage.
+- Keep matching by `AXIdentifier`; if an identifier disappears, dump every attribute
+  of the candidate elements to find its successor:
+
+  ```bash
+  osascript -e 'tell application "System Events" to tell process "ControlCenter" to get properties of every UI element of group 1 of window 1'
+  ```
+
+- Re-verify the chevron offset (hop 3) — layout changes move the clickable zone.
+- Update the verified-version line in the script header after re-verification.

--- a/hotspot-toggle/skills/hotspot-toggle/references/control-center-ax-path.md
+++ b/hotspot-toggle/skills/hotspot-toggle/references/control-center-ax-path.md
@@ -1,70 +1,12 @@
-# Control Center AX Path — Verified Script + Discovery Procedure
+# Control Center Connect — Formal Procedure
 
-The Control Center connect step is instruction-driven: the skill composes and runs
-the verified script below, and when a macOS update breaks it, re-derives the path
-with the discovery procedure that follows. The deterministic legs (state detection,
-wifi return, preflight, join polling) live in `scripts/hotspot-toggle.sh`.
-Provenance: the discovery procedure is reconstructed from the original script
-structure and its header notes; the path itself is verified on macOS 26.5.1
-(2026-06-12).
-
-## Verified connect script (macOS 26.5.1)
-
-Substitute `__HOTSPOT_SSID__` with the hotspot's network name (env `HOTSPOT_SSID`,
-default `Jongwony`); escape `"` and `\` if the SSID contains them, since it lands
-inside an AppleScript string literal.
-
-```bash
-osascript <<'EOF'
-tell application "System Events"
-  tell process "ControlCenter"
-    set ccItem to missing value
-    repeat with i from 1 to count of menu bar items of menu bar 1
-      try
-        if (value of attribute "AXIdentifier" of menu bar item i of menu bar 1) is "com.apple.menuextra.controlcenter" then
-          set ccItem to menu bar item i of menu bar 1
-          exit repeat
-        end if
-      end try
-    end repeat
-    if ccItem is missing value then error "Control Center menu bar item not found"
-    click ccItem
-    delay 1.2
-    set wifiModule to missing value
-    repeat with el in UI elements of group 1 of window 1
-      try
-        if (value of attribute "AXIdentifier" of el) is "controlcenter-wifi" then
-          set wifiModule to el
-          exit repeat
-        end if
-      end try
-    end repeat
-    if wifiModule is missing value then error "Wi-Fi module not found in Control Center"
-    set p to position of wifiModule
-    set s to size of wifiModule
-    click at {(item 1 of p) + (item 1 of s) - 20, (item 2 of p) + ((item 2 of s) div 2)}
-    delay 1.5
-    set sa to scroll area 1 of group 1 of window 1
-    set target to missing value
-    repeat with el in UI elements of sa
-      try
-        if (value of attribute "AXIdentifier" of el) is "wifi-network-__HOTSPOT_SSID__" then
-          set target to el
-          exit repeat
-        end if
-      end try
-    end repeat
-    if target is missing value then error "hotspot entry wifi-network-__HOTSPOT_SSID__ not visible"
-    perform action "AXPress" of target
-    delay 0.5
-  end tell
-  key code 53
-end tell
-EOF
-```
-
-After it succeeds, confirm the join with
-`bash "${CLAUDE_PLUGIN_ROOT}/scripts/hotspot-toggle.sh" wait-hotspot`.
+The connect step is composed at run time from this procedure; no verbatim script is
+pinned. The procedure's logic is durable across macOS updates — what drifts are the
+recorded values (identifiers, container paths, offsets, delays), kept separately as
+data below. Each hop locates its element by enumeration, so drift is detected at the
+failing hop and corrected in place.
+Provenance: the procedure is reconstructed from the original script structure and its
+header notes; values verified on macOS 26.5.1 (2026-06-12).
 
 ## Why UI automation at all
 
@@ -73,59 +15,81 @@ the hotspot is off: an Instant Hotspot SSID is not broadcast until woken, so the
 direct join API cannot see it. The Wi-Fi picker in Control Center is what wakes
 Instant Hotspot — hence AX automation of that picker, and no non-UI alternative.
 
-## Discovery heuristic
+## Composition contract
 
-At each hop, enumerate the AX tree with System Events and select elements by stable
-`AXIdentifier` — never by localized title (breaks across UI languages). Fall back to
-a coordinate click only where no pressable AX element exists.
+- Compose a single `osascript` run executing the hops below in order, inside
+  `tell application "System Events"` / `tell process "ControlCenter"`.
+- Locate every element by enumerating its container and matching `AXIdentifier` —
+  never by localized title. Wrap per-element attribute reads in `try` (some elements
+  lack the attribute).
+- Each hop raises a named error when its target is not found, so a failure identifies
+  the broken hop.
+- Parameter: the hotspot SSID (env `HOTSPOT_SSID`, default `Jongwony`). It lands
+  inside an AppleScript string literal — escape `"` and `\` when composing.
+- After success, confirm the join with
+  `bash "${CLAUDE_PLUGIN_ROOT}/scripts/hotspot-toggle.sh" wait-hotspot`.
 
-1. **Control Center menu bar item** — enumerate identifiers, match the stable one:
+## Hops
 
-   ```bash
-   osascript -e 'tell application "System Events" to tell process "ControlCenter" to get value of attribute "AXIdentifier" of every menu bar item of menu bar 1'
-   ```
+1. **Open Control Center** — enumerate `menu bar items of menu bar 1`, match the
+   menu-extra identifier, `click` it. Settle before the next hop: the panel populates
+   asynchronously, and enumerating too early returns partial trees.
+2. **Find the Wi-Fi module** — enumerate the opened panel's module container, match
+   the Wi-Fi module identifier. No action on the module itself.
+3. **Open the Wi-Fi detail view** — the expand chevron is not a separately pressable
+   AX element, so this is the procedure's one coordinate-based fallback: click near
+   the module's right edge, computed from the module's AX `position`/`size`. Settle
+   for list population.
+4. **Press the hotspot entry** — enumerate the detail view's network list; entries
+   carry per-SSID identifiers. `perform action "AXPress"` on the hotspot's entry —
+   the hop that wakes Instant Hotspot, which `networksetup` cannot do. Short settle.
+5. **Close the panel** — Escape, sent outside the process tell block.
 
-   → `com.apple.menuextra.controlcenter`. Click it to open the panel.
+## Current known values (macOS 26.5.1, verified 2026-06-12)
 
-2. **Wi-Fi module in the opened panel** — enumerate the panel's elements:
+| Hop | Value |
+|-----|-------|
+| 1 | `AXIdentifier` = `com.apple.menuextra.controlcenter`; settle 1.2 s |
+| 2 | `AXIdentifier` = `controlcenter-wifi` |
+| 3 | click at (right edge − 20 px, vertical center); settle 1.5 s |
+| 4 | `AXIdentifier` = `wifi-network-<SSID>`; settle 0.5 s |
+| 5 | `key code 53` |
 
-   ```bash
-   osascript -e 'tell application "System Events" to tell process "ControlCenter" to get value of attribute "AXIdentifier" of every UI element of group 1 of window 1'
-   ```
+Containers: panel = `window 1`; modules under `group 1 of window 1`; the detail
+list under `scroll area 1 of group 1 of window 1`.
 
-   → `controlcenter-wifi`.
+## Enumeration snippets (locate / diagnose)
 
-3. **Opening the Wi-Fi detail view** — the chevron that expands the module is not a
-   separately pressable AX element, so this is the one coordinate-based fallback:
-   click near the module's right edge (right edge − 20px, vertical center), computed
-   from the module's AX `position`/`size`.
+Menu bar items (hop 1):
 
-4. **Network entries in the detail list** — enumerate the scroll area:
+```bash
+osascript -e 'tell application "System Events" to tell process "ControlCenter" to get value of attribute "AXIdentifier" of every menu bar item of menu bar 1'
+```
 
-   ```bash
-   osascript -e 'tell application "System Events" to tell process "ControlCenter" to get value of attribute "AXIdentifier" of every UI element of scroll area 1 of group 1 of window 1'
-   ```
+Panel modules (hop 2):
 
-   → entries are `wifi-network-<SSID>`. `AXPress` on the hotspot's entry wakes
-   Instant Hotspot and joins it — this is the hop that `networksetup` cannot do.
+```bash
+osascript -e 'tell application "System Events" to tell process "ControlCenter" to get value of attribute "AXIdentifier" of every UI element of group 1 of window 1'
+```
 
-5. **Close the panel** — `key code 53` (Escape).
+Detail-view network list (hop 4):
 
-Delays between hops (1.2s after opening the panel, 1.5s after opening the detail
-view) are empirical: the panel populates asynchronously and enumeration before it
-settles returns partial trees.
+```bash
+osascript -e 'tell application "System Events" to tell process "ControlCenter" to get value of attribute "AXIdentifier" of every UI element of scroll area 1 of group 1 of window 1'
+```
 
-## Re-derivation checklist after a macOS update
+## Re-derivation after a macOS update
 
-- Re-run the enumeration snippets at each hop. Identifiers renaming or elements
-  moving one container level (`group`/`window` indices) are the usual breakage.
-- Keep matching by `AXIdentifier`; if an identifier disappears, dump every attribute
-  of the candidate elements to find its successor:
+- Re-run the enumeration snippets at the failing hop. Identifier renames and elements
+  moving one container level (`group`/`window` indices) are the usual breakage; the
+  hops themselves rarely change.
+- If an identifier disappears, dump every attribute of the candidate elements to find
+  its successor:
 
   ```bash
   osascript -e 'tell application "System Events" to tell process "ControlCenter" to get properties of every UI element of group 1 of window 1'
   ```
 
-- Re-verify the chevron offset (hop 3) — layout changes move the clickable zone.
-- After re-verification, update this document: the verified connect script above and
-  the macOS version in its heading and the provenance note.
+- Re-verify the hop-3 offset — layout changes move the clickable zone.
+- After re-verification, update the Current known values table (and its version
+  stamp). The hop sequence and composition contract stay as they are.


### PR DESCRIPTION
## What

New plugin `hotspot-toggle`: toggles the Mac's Wi-Fi between the iPhone Personal Hotspot and known networks, so a Telegram message like "핫스팟" can hand off the network before moving.

- `scripts/hotspot-toggle.sh` — modes `toggle` (default) / `hotspot` / `wifi`; gateway-based state detection (192.0.0.1 / 172.20.10.x) since SSID reads are location-permission-gated
- `skills/hotspot-toggle/SKILL.md` — trigger phrases and operating notes
- marketplace.json entry

## Why

Direct `networksetup -setairportnetwork` fails (-3900) because the hotspot SSID is not broadcast while Instant Hotspot is asleep. The Control Center accessibility path (Wi-Fi detail > `wifi-network-<SSID>` AXPress) wakes it reliably.

## Verification

- Wake path verified live on macOS 26.5.1 (2026-06-12)
- `bash -n` clean; both JSON files validate; script executable

Requires Accessibility permission for the osascript process chain (exit 2 with guidance if missing).
