### PR TITLE
feat(remote-spawn): initial prompt auto-submit + return spawned session id

### DIFF
--- a/remote-spawn/README.md
+++ b/remote-spawn/README.md
@@ -15,6 +15,12 @@ bash scripts/rc-spawn.sh kill foo                     # SIGTERM + drop tmux sess
 One tmux session per name (`rc-<name>`), idempotent. The session lives until its claude
 exits (no auto-restart by design).
 
+On a fresh spawn the script generates the new session's id (a lowercased UUID, passed
+to claude as `--session-id`) and prints it as a `SESSION <uuid>` line right after
+`STARTED`. An initial prompt, when given, is passed after a `--` end-of-options separator
+(`claude --remote-control --name <name> --session-id <uuid> -- "<prompt>"`) so an
+arbitrary prompt can never be misparsed as a flag.
+
 ## Why tmux + ps/SIGTERM
 - **tmux, not nohup/launchd** — `claude --remote-control` is an interactive TUI that wants
   a PTY, and a tmux server launched from your terminal inherits its TCC grant, so sessions

--- a/remote-spawn/scripts/rc-spawn.sh
+++ b/remote-spawn/scripts/rc-spawn.sh
@@ -4,7 +4,10 @@
 # Claude app (claude.ai/code + mobile). No Telegram, no bridge.
 #
 # Subcommands:
-#   spawn <dir> [name]   start a remote-control session in <dir> (idempotent)
+#   spawn <dir> [name] [prompt]   start a remote-control session in <dir> (idempotent);
+#                                 [prompt], if given, is auto-submitted as the first
+#                                 message (passed positionally to claude). To pass a
+#                                 prompt you must also pass a name.
 #   list                 list running rc-* sessions and their dirs
 #   kill  <name>         SIGTERM the claude session, then drop its tmux session
 #
@@ -27,8 +30,8 @@ unset TMUX  # target the tmux daemon, not a nested client, if invoked from insid
 sanitize() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-' | sed 's/--*/-/g; s/^-//; s/-$//'; }
 
 spawn() {
-  local dir="$1" name="$2"
-  [ -n "$dir" ] || { echo "usage: rc-spawn.sh spawn <dir> [name]" >&2; return 2; }
+  local dir="$1" name="$2" prompt="$3"
+  [ -n "$dir" ] || { echo "usage: rc-spawn.sh spawn <dir> [name] [prompt]" >&2; return 2; }
   dir="$(cd "$dir" 2>/dev/null && pwd)" || { echo "ERROR: no such dir: $1" >&2; return 1; }
   [ -n "$name" ] || name="$(basename "$dir")"
   name="$(sanitize "$name")"
@@ -42,13 +45,25 @@ spawn() {
     [ "$rdir" = "$dir" ] || echo "  note: requested $dir but rc-$name already runs in ${rdir:-?} — pass an explicit name to run a second session"
     return 0
   fi
+  # Build the claude command. name is sanitized to [A-Za-z0-9._-] so it needs no
+  # quoting; an optional prompt is arbitrary text, so single-quote it for the
+  # `sh -c` that tmux runs. Escape embedded ' as '\'' via bash expansion (no sed).
+  local cmd="claude --remote-control --name $name"
+  if [ -n "$prompt" ]; then
+    # Escape each ' as '\'' in a standalone assignment (embedding the expansion
+    # inside the double-quoted cmd "...'${p//.../...}'..." mangles the backslashes).
+    local esc=${prompt//\'/\'\\\'\'}
+    cmd="$cmd '$esc'"
+  fi
   # Detached tmux session running claude directly; when claude exits the session ends.
-  tmux new-session -d -s "$sess" -x 220 -y 55 -c "$dir" "claude --remote-control --name $name"
+  tmux new-session -d -s "$sess" -x 220 -y 55 -c "$dir" "$cmd"
   echo "STARTED $name  (dir: $dir)"
+  [ -n "$prompt" ] && echo "  -> initial prompt queued (auto-submits once the session is ready)"
   echo "  -> now reachable in the Claude app (claude.ai/code + mobile)"
   echo "  -> attach: tmux attach -t $sess   |   kill: rc-spawn.sh kill $name"
-  echo "  note: first launch in a never-opened dir may show a one-time folder-trust"
-  echo "        prompt inside the session — attach once, press Enter, detach (Ctrl-b d)."
+  echo "  note: first launch in a never-opened dir shows a one-time folder-trust prompt"
+  echo "        inside the session (any queued prompt waits behind it) — attach once,"
+  echo "        press Enter, detach (Ctrl-b d); the prompt then submits."
 }
 
 list() {
@@ -92,8 +107,8 @@ kill_one() {
 }
 
 case "${1:-}" in
-  spawn) spawn "${2:-}" "${3:-}";;
+  spawn) spawn "${2:-}" "${3:-}" "${4:-}";;
   list)  list;;
   kill)  kill_one "${2:-}";;
-  *) echo "usage: rc-spawn.sh {spawn <dir> [name] | list | kill <name>}" >&2; exit 2;;
+  *) echo "usage: rc-spawn.sh {spawn <dir> [name] [prompt] | list | kill <name>}" >&2; exit 2;;
 esac

--- a/remote-spawn/scripts/rc-spawn.sh
+++ b/remote-spawn/scripts/rc-spawn.sh
@@ -45,19 +45,28 @@ spawn() {
     [ "$rdir" = "$dir" ] || echo "  note: requested $dir but rc-$name already runs in ${rdir:-?} — pass an explicit name to run a second session"
     return 0
   fi
+  # Fresh session id, minted only once we're actually spawning (below the
+  # idempotency guard, so the ALREADY-RUNNING path stays untouched). Claude Code
+  # validates --session-id as a UUID and stores the session file lowercase, but
+  # uuidgen emits uppercase — lowercase it; bail if it comes back empty.
+  local sid; sid="$(uuidgen | tr 'A-Z' 'a-z')"
+  [ -n "$sid" ] || { echo "ERROR: failed to generate a session id (is uuidgen available?)" >&2; return 1; }
   # Build the claude command. name is sanitized to [A-Za-z0-9._-] so it needs no
   # quoting; an optional prompt is arbitrary text, so single-quote it for the
   # `sh -c` that tmux runs. Escape embedded ' as '\'' via bash expansion (no sed).
-  local cmd="claude --remote-control --name $name"
+  local cmd="claude --remote-control --name $name --session-id $sid"
   if [ -n "$prompt" ]; then
     # Escape each ' as '\'' in a standalone assignment (embedding the expansion
     # inside the double-quoted cmd "...'${p//.../...}'..." mangles the backslashes).
+    # '--' ends option parsing so an arbitrary prompt can't be misread as a flag
+    # or as the `--remote-control [name]` optional positional.
     local esc=${prompt//\'/\'\\\'\'}
-    cmd="$cmd '$esc'"
+    cmd="$cmd -- '$esc'"
   fi
   # Detached tmux session running claude directly; when claude exits the session ends.
   tmux new-session -d -s "$sess" -x 220 -y 55 -c "$dir" "$cmd"
   echo "STARTED $name  (dir: $dir)"
+  echo "SESSION $sid"
   [ -n "$prompt" ] && echo "  -> initial prompt queued (auto-submits once the session is ready)"
   echo "  -> now reachable in the Claude app (claude.ai/code + mobile)"
   echo "  -> attach: tmux attach -t $sess   |   kill: rc-spawn.sh kill $name"

--- a/remote-spawn/skills/remote-spawn/SKILL.md
+++ b/remote-spawn/skills/remote-spawn/SKILL.md
@@ -20,7 +20,8 @@ Run the script and report the result concisely:
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> [name]
 
 # Spawn WITH an initial prompt — auto-submitted as the session's first message.
-# To pass a prompt you must also pass a name (it is the 3rd positional arg).
+# To pass a prompt you must also pass a name (it is the 3rd positional arg). The
+# prompt is passed to claude after a `--` separator (claude --remote-control ... -- "<prompt>").
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> <name> "<prompt>"
 
 # List running sessions
@@ -31,7 +32,9 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" kill <name>
 ```
 
 - `STARTED <name>` → a remote-control session is now live in `<dir>` and appears in
-  the Claude app. Relay the attach/kill hints from the output.
+  the Claude app. The accompanying `SESSION <uuid>` line is the new session's id
+  (a lowercased UUID, passed to claude as `--session-id`). Relay the attach/kill
+  hints from the output.
 - `ALREADY-RUNNING <name>` → idempotent; a session for that name already exists.
 - `NOT-FOUND <name>` → nothing matched on kill.
 

--- a/remote-spawn/skills/remote-spawn/SKILL.md
+++ b/remote-spawn/skills/remote-spawn/SKILL.md
@@ -19,6 +19,10 @@ Run the script and report the result concisely:
 # Spawn in a directory (name defaults to the dir's basename)
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> [name]
 
+# Spawn WITH an initial prompt — auto-submitted as the session's first message.
+# To pass a prompt you must also pass a name (it is the 3rd positional arg).
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> <name> "<prompt>"
+
 # List running sessions
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" list
 
@@ -35,7 +39,8 @@ Notes to pass on when relevant:
 - The session lives until its claude exits (no auto-restart by design).
 - First launch in a directory Claude has never opened may show a one-time
   folder-trust prompt **inside** the tmux session — `tmux attach -t rc-<name>`,
-  press Enter, then detach with `Ctrl-b d`.
+  press Enter, then detach with `Ctrl-b d`. **A queued initial prompt waits
+  behind this trust gate** and submits only after trust is confirmed.
 - tmux is used (not nohup/launchd) so sessions work under TCC-protected dirs
   (`~/Downloads`, `~/Documents`, `~/Desktop`); kill uses `ps`+SIGTERM so SessionEnd
   hooks (e.g. anamnesis memory) flush before exit.


### PR DESCRIPTION
## What

Two improvements to the `remote-spawn` plugin (one tmux-backed `claude --remote-control` session per directory):

1. **Return the spawned session's id.** `spawn` now pre-generates a lowercase UUID, injects it via `--session-id`, and prints a `SESSION <uuid>` line — so the caller knows the new conversation session id deterministically at spawn time, no post-hoc lookup.
2. **Harden the initial prompt.** The optional initial prompt is now passed after a `--` end-of-options separator (`claude --remote-control ... -- "<prompt>"`), so an arbitrary prompt can't be misparsed as a flag or as the `--remote-control [name]` optional positional.

(Builds on the earlier commit that added the auto-submitted initial prompt.)

## Why this approach

- `--session-id` is honored alongside `--remote-control` (confirmed from the CLI's option handling), so generating the id ourselves closes the loop at the source — no reading another process's env, no polling the session file.
- The UUID is lowercased because Claude Code validates `--session-id` as a UUID and stores session files lowercase (`uuidgen` emits uppercase).
- A fresh UUID per spawn plus the existing `tmux has-session` idempotency guard means a `--session-id` collision — which Claude Code hard-errors on, fail-safe, rather than overwriting — is unreachable.
- `sid` is generated below the idempotency guard, so the `ALREADY-RUNNING` path is untouched; an empty `uuidgen` result is rejected.
- `--name` stays immediately after `--remote-control`, so the existing `kill_one` matcher is unchanged.

## Verification

- `bash -n` passes; argv shape checked (no bare trailing `--`; the prompt survives leading-dash / single-quotes / newlines as a single argument); `kill_one` grep still matches.
- codex review (gpt-5.5, high effort): 2 rounds, converged clean — one minor finding on `sid` placement, fixed.

Scope: spawn output only — `list` / `ALREADY-RUNNING` id recovery intentionally left out.
