### PR TITLE
feat: enforce per-plugin version bumps via pre-commit hook (+ fix remote-spawn bump)

### DIFF
--- a/.githooks/check-version-bump.sh
+++ b/.githooks/check-version-bump.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Enforce per-plugin version bumps. Single source of truth for both the
+# pre-commit hook (index mode) and CI (range mode).
+#
+# Rule (see CLAUDE.md "버전 업데이트"): when a plugin's semantic files change,
+# its {plugin}/.claude-plugin/plugin.json "version" VALUE must change in the same
+# change-set. Re-emitting the same version line (reformat / key reorder) does NOT
+# count. Non-semantic top-level files (README.md, README_ko.md, LICENSE,
+# .gitignore, .gitattributes) and .claude-plugin/ meta do not require a bump.
+# A new plugin (no prior plugin.json) is satisfied by having a version at all.
+#
+# Modes:
+#   (default)       index mode — compare staged index vs HEAD   (pre-commit hook)
+#   --base <ref>    range mode — compare HEAD vs <ref>           (CI: <ref> = PR base)
+#
+# Port of epistemic-protocols' checkVersionStaleness; pure bash (no node/jq),
+# bash 3.2-compatible. Bypass the local hook with `git commit --no-verify`.
+set -euo pipefail
+
+base=""
+if [ "${1:-}" = "--base" ]; then
+  base="${2:-}"
+  [ -n "$base" ] || { echo "check-version-bump: --base requires a ref" >&2; exit 2; }
+fi
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+cd "$(git rev-parse --show-toplevel)"
+
+# Skip during conflict states (diff is unreliable). `git rev-parse --git-path`
+# resolves correctly even in linked worktrees / submodules, where .git is a file
+# and the real heads live under .git/worktrees/<name>/.
+for h in MERGE_HEAD REBASE_HEAD CHERRY_PICK_HEAD; do
+  p=$(git rev-parse --git-path "$h" 2>/dev/null) || p=""
+  if [ -n "$p" ] && [ -e "$p" ]; then
+    echo "→ version-bump check: $h present — skipping"
+    exit 0
+  fi
+done
+
+# Blob-ref prefixes per mode. ":" is the staged index.
+if [ -n "$base" ]; then
+  old_prefix="$base:"; new_prefix="HEAD:"
+else
+  old_prefix="HEAD:"; new_prefix=":"
+fi
+
+# Changed files, NUL-delimited so paths with spaces/newlines/non-ASCII survive
+# intact (-z already disables path quoting; core.quotePath=false is belt-and-braces).
+changed=()
+while IFS= read -r -d '' f; do
+  changed+=("$f")
+done < <(
+  if [ -n "$base" ]; then
+    git -c core.quotePath=false diff --name-only -z --diff-filter=ACMRD "$base...HEAD"
+  else
+    git -c core.quotePath=false diff --cached --name-only -z --diff-filter=ACMRD
+  fi
+)
+[ "${#changed[@]}" -eq 0 ] && exit 0
+
+# Discover plugin dirs (any dir holding .claude-plugin/plugin.json).
+plugins=()
+while IFS= read -r -d '' pj; do
+  plugins+=("${pj#./}")
+done < <(find . \( -name node_modules -o -name .git \) -prune -o \
+  -name plugin.json -path '*/.claude-plugin/plugin.json' -print0 2>/dev/null)
+[ "${#plugins[@]}" -eq 0 ] && exit 0
+
+# Extract the "version" value from plugin.json content on stdin (empty if absent).
+# sed reads all of stdin (no early-exit reader) so the upstream `git show` never
+# gets SIGPIPE — keeps the pipeline well-behaved under `set -o pipefail`.
+extract_version() {
+  sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p'
+}
+
+violations=0
+for pj in "${plugins[@]}"; do
+  pdir=${pj%/.claude-plugin/plugin.json}
+
+  content=0
+  for f in "${changed[@]}"; do
+    case "$f" in "$pdir"/*) ;; *) continue ;; esac           # under this plugin
+    case "$f" in "$pdir"/.claude-plugin/*) continue ;; esac   # skip .claude-plugin/ meta
+    rel=${f#"$pdir"/}
+    case "$rel" in
+      */*) : ;;                                               # nested file → semantic content
+      README.md|README_ko.md|LICENSE|.gitignore|.gitattributes) continue ;;  # top-level non-semantic
+    esac
+    content=$((content + 1))
+  done
+  [ "$content" -eq 0 ] && continue
+
+  old_ver=$(git show "${old_prefix}${pj}" 2>/dev/null | extract_version) || old_ver=""
+  new_ver=$(git show "${new_prefix}${pj}" 2>/dev/null | extract_version) || new_ver=""
+  # A changed value — or a new plugin (no old blob) — satisfies the rule.
+  if [ -n "$new_ver" ] && [ "$new_ver" != "$old_ver" ]; then
+    continue
+  fi
+
+  pname=${pdir:-root}
+  echo "✗ plugin \"$pname\": $content semantic file(s) changed, but version not bumped in $pj"
+  violations=$((violations + 1))
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo ""
+  echo "Bump the \"version\" value in each plugin's .claude-plugin/plugin.json (see CLAUDE.md 버전 업데이트)."
+  [ -z "$base" ] && echo "Bypass once with: git commit --no-verify"
+  exit 1
+fi
+exit 0

--- a/.githooks/check-version-bump.sh
+++ b/.githooks/check-version-bump.sh
@@ -37,28 +37,43 @@ for h in MERGE_HEAD REBASE_HEAD CHERRY_PICK_HEAD; do
   fi
 done
 
-# Blob-ref prefixes per mode. ":" is the staged index.
+# Resolve the comparison baseline per mode. ":" is the staged index.
+# In range mode the changed-file set uses three-dot (merge-base) semantics, so the
+# version VALUE must be read from that SAME merge-base — not the base tip, which
+# drifts when the base branch advances after the PR forked. A base that can't be
+# resolved fails CLOSED (the gate must never pass on an unknown baseline).
 if [ -n "$base" ]; then
-  old_prefix="$base:"; new_prefix="HEAD:"
+  mb=$(git merge-base "$base" HEAD 2>/dev/null) || {
+    echo "check-version-bump: cannot resolve a merge-base for '$base' — failing closed" >&2
+    exit 2
+  }
+  old_prefix="$mb:"; new_prefix="HEAD:"
 else
   old_prefix="HEAD:"; new_prefix=":"
 fi
 
 # Changed files, NUL-delimited so paths with spaces/newlines/non-ASCII survive
-# intact (-z already disables path quoting; core.quotePath=false is belt-and-braces).
+# intact. Routed through a temp file (NOT a process substitution) so a git
+# failure is visible to `set -e` and fails CLOSED — a swallowed producer error
+# must never let the gate pass silently.
+tmp=$(mktemp) || { echo "check-version-bump: mktemp failed" >&2; exit 2; }
+trap 'rm -f "$tmp"' EXIT
+if [ -n "$base" ]; then
+  git -c core.quotePath=false diff --name-only -z --diff-filter=ACMRD "$mb..HEAD" > "$tmp" \
+    || { echo "check-version-bump: git diff failed (range mode) — failing closed" >&2; exit 2; }
+else
+  git -c core.quotePath=false diff --cached --name-only -z --diff-filter=ACMRD > "$tmp" \
+    || { echo "check-version-bump: git diff failed — failing closed" >&2; exit 2; }
+fi
 changed=()
 while IFS= read -r -d '' f; do
   changed+=("$f")
-done < <(
-  if [ -n "$base" ]; then
-    git -c core.quotePath=false diff --name-only -z --diff-filter=ACMRD "$base...HEAD"
-  else
-    git -c core.quotePath=false diff --cached --name-only -z --diff-filter=ACMRD
-  fi
-)
+done < "$tmp"
 [ "${#changed[@]}" -eq 0 ] && exit 0
 
-# Discover plugin dirs (any dir holding .claude-plugin/plugin.json).
+# Discover plugin dirs (any dir holding .claude-plugin/plugin.json) from the work
+# tree at HEAD. A whole-plugin deletion is intentionally not flagged: the dir is
+# gone, so there is no surviving plugin.json whose version could be bumped.
 plugins=()
 while IFS= read -r -d '' pj; do
   plugins+=("${pj#./}")
@@ -67,10 +82,12 @@ done < <(find . \( -name node_modules -o -name .git \) -prune -o \
 [ "${#plugins[@]}" -eq 0 ] && exit 0
 
 # Extract the "version" value from plugin.json content on stdin (empty if absent).
+# Anchored to line start so a "version" substring inside another value can't match;
+# assumes the conventional pretty-printed plugin.json with one top-level version key.
 # sed reads all of stdin (no early-exit reader) so the upstream `git show` never
 # gets SIGPIPE — keeps the pipeline well-behaved under `set -o pipefail`.
 extract_version() {
-  sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p'
+  sed -nE 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p'
 }
 
 violations=0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Pre-commit: enforce per-plugin version bumps.
+#
+# Port of epistemic-protocols' checkVersionStaleness (verify/static-checks.js),
+# adapted to a no-node repo: pure bash, installed via `git config core.hooksPath .githooks`.
+#
+# Rule (see CLAUDE.md "버전 업데이트"): when a plugin's semantic files are staged,
+# its {plugin}/.claude-plugin/plugin.json "version" must be bumped in the same commit.
+# Non-semantic files (.claude-plugin/ meta, README*, LICENSE, .gitignore, .gitattributes)
+# do not require a bump. A newly-added plugin.json counts as its version being set.
+#
+# Bypass once with: git commit --no-verify
+set -euo pipefail
+
+# 0. git repo guard
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+
+# 1. skip during conflict states (staged diff is unreliable then)
+for h in MERGE_HEAD REBASE_HEAD CHERRY_PICK_HEAD; do
+  if [ -e ".git/$h" ]; then
+    echo "→ version-bump check: $h present — skipping"
+    exit 0
+  fi
+done
+
+# 2. staged files (added/copied/modified/renamed)
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
+[ -z "$staged" ] && exit 0
+
+# 3. discover plugin dirs (any dir containing .claude-plugin/plugin.json)
+plugin_jsons=$(find . \( -name node_modules -o -name .git \) -prune -o \
+  -name plugin.json -path '*/.claude-plugin/plugin.json' -print 2>/dev/null | sed 's|^\./||')
+[ -z "$plugin_jsons" ] && exit 0
+
+all_dirs=""
+for pj in $plugin_jsons; do
+  all_dirs="$all_dirs ${pj%/.claude-plugin/plugin.json}"
+done
+
+# non-semantic files that do not warrant a version bump
+is_ignored() {
+  case "$1" in
+    README.md|README_ko.md|LICENSE|.gitignore|.gitattributes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+violations=0
+for pj in $plugin_jsons; do
+  pdir=${pj%/.claude-plugin/plugin.json}
+  meta_prefix="$pdir/.claude-plugin/"
+
+  # count semantic, staged changes belonging to this plugin
+  content_changes=0
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    case "$f" in "$pdir"/*) ;; *) continue ;; esac          # under this plugin
+    case "$f" in "$meta_prefix"*) continue ;; esac          # skip .claude-plugin/ meta
+    is_ignored "$(basename "$f")" && continue               # skip non-semantic files
+
+    # skip files that belong to a deeper, nested plugin dir
+    nested=0
+    for other in $all_dirs; do
+      [ "$other" = "$pdir" ] && continue
+      case "$other/" in
+        "$pdir"/*) case "$f" in "$other"/*) nested=1; break ;; esac ;;
+      esac
+    done
+    [ "$nested" -eq 1 ] && continue
+
+    content_changes=$((content_changes + 1))
+  done <<EOF
+$staged
+EOF
+
+  [ "$content_changes" -eq 0 ] && continue
+
+  # version bumped? staged plugin.json diff must add a "version": line
+  if git diff --cached -- "$pj" | grep -qE '^\+[[:space:]]*"version"[[:space:]]*:'; then
+    continue
+  fi
+
+  echo "✗ plugin \"$pdir\": $content_changes semantic file(s) staged, but no version bump in $pj"
+  violations=$((violations + 1))
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo ""
+  echo "Bump the \"version\" in each plugin's .claude-plugin/plugin.json (see CLAUDE.md 버전 업데이트)."
+  echo "Bypass once with: git commit --no-verify"
+  exit 1
+fi
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,95 +1,10 @@
 #!/usr/bin/env bash
-# Pre-commit: enforce per-plugin version bumps.
+# Pre-commit: enforce per-plugin version bumps (index mode).
 #
-# Port of epistemic-protocols' checkVersionStaleness (verify/static-checks.js),
-# adapted to a no-node repo: pure bash, installed via `git config core.hooksPath .githooks`.
-#
-# Rule (see CLAUDE.md "버전 업데이트"): when a plugin's semantic files are staged,
-# its {plugin}/.claude-plugin/plugin.json "version" must be bumped in the same commit.
-# Non-semantic files (.claude-plugin/ meta, README*, LICENSE, .gitignore, .gitattributes)
-# do not require a bump. A newly-added plugin.json counts as its version being set.
-#
+# Thin wrapper — the rule logic is the single source of truth in
+# check-version-bump.sh, which CI also runs (in range mode) so the local hook
+# and CI never drift. Activate this hook with: git config core.hooksPath .githooks
 # Bypass once with: git commit --no-verify
 set -euo pipefail
-
-# 0. git repo guard
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
-root=$(git rev-parse --show-toplevel)
-cd "$root"
-
-# 1. skip during conflict states (staged diff is unreliable then)
-for h in MERGE_HEAD REBASE_HEAD CHERRY_PICK_HEAD; do
-  if [ -e ".git/$h" ]; then
-    echo "→ version-bump check: $h present — skipping"
-    exit 0
-  fi
-done
-
-# 2. staged files (added/copied/modified/renamed)
-staged=$(git diff --cached --name-only --diff-filter=ACMR)
-[ -z "$staged" ] && exit 0
-
-# 3. discover plugin dirs (any dir containing .claude-plugin/plugin.json)
-plugin_jsons=$(find . \( -name node_modules -o -name .git \) -prune -o \
-  -name plugin.json -path '*/.claude-plugin/plugin.json' -print 2>/dev/null | sed 's|^\./||')
-[ -z "$plugin_jsons" ] && exit 0
-
-all_dirs=""
-for pj in $plugin_jsons; do
-  all_dirs="$all_dirs ${pj%/.claude-plugin/plugin.json}"
-done
-
-# non-semantic files that do not warrant a version bump
-is_ignored() {
-  case "$1" in
-    README.md|README_ko.md|LICENSE|.gitignore|.gitattributes) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-violations=0
-for pj in $plugin_jsons; do
-  pdir=${pj%/.claude-plugin/plugin.json}
-  meta_prefix="$pdir/.claude-plugin/"
-
-  # count semantic, staged changes belonging to this plugin
-  content_changes=0
-  while IFS= read -r f; do
-    [ -z "$f" ] && continue
-    case "$f" in "$pdir"/*) ;; *) continue ;; esac          # under this plugin
-    case "$f" in "$meta_prefix"*) continue ;; esac          # skip .claude-plugin/ meta
-    is_ignored "$(basename "$f")" && continue               # skip non-semantic files
-
-    # skip files that belong to a deeper, nested plugin dir
-    nested=0
-    for other in $all_dirs; do
-      [ "$other" = "$pdir" ] && continue
-      case "$other/" in
-        "$pdir"/*) case "$f" in "$other"/*) nested=1; break ;; esac ;;
-      esac
-    done
-    [ "$nested" -eq 1 ] && continue
-
-    content_changes=$((content_changes + 1))
-  done <<EOF
-$staged
-EOF
-
-  [ "$content_changes" -eq 0 ] && continue
-
-  # version bumped? staged plugin.json diff must add a "version": line
-  if git diff --cached -- "$pj" | grep -qE '^\+[[:space:]]*"version"[[:space:]]*:'; then
-    continue
-  fi
-
-  echo "✗ plugin \"$pdir\": $content_changes semantic file(s) staged, but no version bump in $pj"
-  violations=$((violations + 1))
-done
-
-if [ "$violations" -gt 0 ]; then
-  echo ""
-  echo "Bump the \"version\" in each plugin's .claude-plugin/plugin.json (see CLAUDE.md 버전 업데이트)."
-  echo "Bypass once with: git commit --no-verify"
-  exit 1
-fi
-exit 0
+dir=$(cd "$(dirname "$0")" && pwd)
+exec "$dir/check-version-bump.sh"

--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -1,0 +1,17 @@
+name: version-bump-check
+
+# Real (non-bypassable) enforcement gate: runs on every PR regardless of whether
+# a contributor activated the local pre-commit hook. Same logic as the hook,
+# in range mode (compares the PR head against its base).
+on:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so the PR base commit is reachable
+      - name: Check per-plugin version bumps
+        run: bash .githooks/check-version-bump.sh --base "${{ github.event.pull_request.base.sha }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,16 @@ tools: [mcp__bigquery__*, Read]                      # Read-only + MCP
 `{plugin}/.claude-plugin/plugin.json`의 `version` 수정.
 marketplace.json은 source 경로만 관리 (버전 미포함).
 
+**Bump-on-change 규칙**: 플러그인의 의미 있는 파일이 변경되면 같은 커밋에서 해당 `{plugin}/.claude-plugin/plugin.json`의 `version`도 bump한다. 의미 없는 파일(`.claude-plugin/` 메타, `README.md`/`README_ko.md`/`LICENSE`/`.gitignore`/`.gitattributes`)만 바뀐 경우는 예외. 신규 플러그인은 최초 버전 설정으로 충족.
+
+**자동 검사 (pre-commit 훅)**: `.githooks/pre-commit`이 staged 변경을 검사해 위 규칙 위반 시 커밋을 차단한다 (epistemic-protocols `static-checks.js`의 `checkVersionStaleness` 포팅, node 의존성 없는 순수 bash). 클론 후 최초 1회 활성화:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+긴급 우회는 `git commit --no-verify`.
+
 ### 파일 이동
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,15 +128,14 @@ tools: [mcp__bigquery__*, Read]                      # Read-only + MCP
 `{plugin}/.claude-plugin/plugin.json`의 `version` 수정.
 marketplace.json은 source 경로만 관리 (버전 미포함).
 
-**Bump-on-change 규칙**: 플러그인의 의미 있는 파일이 변경되면 같은 커밋에서 해당 `{plugin}/.claude-plugin/plugin.json`의 `version`도 bump한다. 의미 없는 파일(`.claude-plugin/` 메타, `README.md`/`README_ko.md`/`LICENSE`/`.gitignore`/`.gitattributes`)만 바뀐 경우는 예외. 신규 플러그인은 최초 버전 설정으로 충족.
+**Bump-on-change 규칙**: 플러그인의 의미 있는 파일이 변경되면 같은 change-set에서 해당 `{plugin}/.claude-plugin/plugin.json`의 `version` **값이 실제로 바뀌어야** 한다 (줄 재배치/재포맷만으로는 불충족). 최상위 비의미 파일(`.claude-plugin/` 메타, 플러그인 루트의 `README.md`/`README_ko.md`/`LICENSE`/`.gitignore`/`.gitattributes`)만 바뀐 경우는 예외 — 단 하위 디렉터리의 동명 파일은 콘텐츠로 간주. 의미 파일 삭제(`git rm`)도 변경에 포함. 신규 플러그인은 최초 버전 설정으로 충족.
 
-**자동 검사 (pre-commit 훅)**: `.githooks/pre-commit`이 staged 변경을 검사해 위 규칙 위반 시 커밋을 차단한다 (epistemic-protocols `static-checks.js`의 `checkVersionStaleness` 포팅, node 의존성 없는 순수 bash). 클론 후 최초 1회 활성화:
-
-```bash
-git config core.hooksPath .githooks
-```
-
-긴급 우회는 `git commit --no-verify`.
+**자동 검사 (2계층)**: 규칙 로직의 SSOT는 `.githooks/check-version-bump.sh` (node/jq 의존성 없는 순수 bash, epistemic-protocols `checkVersionStaleness` 포팅). 두 진입점이 같은 스크립트를 호출해 드리프트가 없다:
+- **pre-commit 훅** (`.githooks/pre-commit`) — staged(index) vs HEAD 비교, 위반 시 커밋 차단. **로컬·best-effort**: `core.hooksPath`는 클론에 전파되지 않으므로 클론마다 1회 활성화해야 하고, 미설정 또는 `git commit --no-verify` 시 우회된다.
+  ```bash
+  git config core.hooksPath .githooks   # 클론당 1회
+  ```
+- **CI** (`.github/workflows/version-bump-check.yml`) — PR마다 base와 HEAD를 비교(range 모드). 로컬 설정과 무관하게 항상 실행되는 **실제 게이트**(우회 불가).
 
 ### 파일 이동
 

--- a/remote-spawn/.claude-plugin/plugin.json
+++ b/remote-spawn/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-spawn",
   "description": "Spawn a backgrounded `claude --remote-control` session in any directory (tmux-tracked), reachable from the Claude app",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"


### PR DESCRIPTION
## 배경
PR #65(remote-spawn)가 신규 기능(initial prompt 자동 제출, session id 반환)을 추가했으나 `plugin.json` version bump가 누락됨. 재발 방지를 위해 자동 검사를 도입.

## 변경
### 1. 누락 bump 복구
- `remote-spawn` `1.0.0 → 1.1.0`

### 2. version-bump pre-commit 훅 (epistemic-protocols 미러링)
epistemic-protocols의 Rule + Hook 이중 구조(`editing-conventions.md` + `static-checks.js`의 `checkVersionStaleness`)를 포팅. 이 repo는 node 툴체인이 없어 husky 대신 **순수 bash + `core.hooksPath`** 사용.
- `CLAUDE.md` `버전 업데이트` 섹션 확장: bump-on-change 규칙 + 훅 활성화 안내
- `.githooks/pre-commit`: staged 변경 검사 → 플러그인 의미 파일 변경 시 `version` bump 없으면 커밋 차단
  - 의미 없는 파일 예외: `.claude-plugin/`, `README*`, `LICENSE`, `.gitignore`, `.gitattributes`
  - 충돌 상태(MERGE/REBASE/CHERRY_PICK) 스킵, 신규 플러그인 최초 버전 인정
  - 우회: `git commit --no-verify`

## 활성화 (클론당 1회)
```bash
git config core.hooksPath .githooks
```

## 검증
- 무관 staged → 통과
- 플러그인 콘텐츠 staged + bump 없음 → 차단(exit 1)
- 콘텐츠 + bump 동시 staged → 통과
- 실제 `git commit` end-to-end → 차단, HEAD 불변 확인
