### PR TITLE
fix(codex-plus): align session extraction + wrapper with Codex CLI 0.139.0

### DIFF
--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/scripts/codex-run.sh
+++ b/codex-plus/scripts/codex-run.sh
@@ -15,6 +15,7 @@ SANDBOX="$DEFAULT_SANDBOX"
 FULL_AUTO=false
 SESSION_ID=""
 CWD=""
+OUTPUT_FILE=""
 
 usage() {
   cat <<'USAGE'
@@ -27,6 +28,9 @@ Options:
   -C, --cwd DIR          Working directory for codex
   -S, --session-id ID    Resume a specific session by UUID (deterministic;
                          the only resume path — there is no --last fallback)
+  -o, --output-last-message FILE
+                         Also write codex's final message to FILE (deterministic
+                         capture, decoupled from stdout banner noise)
   --full-auto            Enable full auto mode
   -h, --help             Show this help
 
@@ -52,6 +56,7 @@ while [[ $# -gt 0 ]]; do
     -s|--sandbox) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; SANDBOX="$2"; shift 2 ;;
     -C|--cwd) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; CWD="$2"; shift 2 ;;
     -S|--session-id) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; SESSION_ID="$2"; shift 2 ;;
+    -o|--output-last-message) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; OUTPUT_FILE="$2"; shift 2 ;;
     --full-auto) FULL_AUTO=true; shift ;;
     -h|--help) usage 0 ;;
     -*) echo "Unknown option: $1" >&2; usage 1 ;;
@@ -72,6 +77,7 @@ fi
 
 # Build codex argv. Resume iff a session id was given.
 CODEX_ARGS=(exec --skip-git-repo-check)
+[[ -n "$OUTPUT_FILE" ]] && CODEX_ARGS+=(--output-last-message "$OUTPUT_FILE")
 if [[ -n "$SESSION_ID" ]]; then
   # Warn if non-default options are passed with resume (they are ignored —
   # the session keeps its original settings).

--- a/codex-plus/scripts/codex-session-extract.py
+++ b/codex-plus/scripts/codex-session-extract.py
@@ -76,13 +76,24 @@ def parse_session(path: Path, include_reasoning: bool = False) -> dict:
                         elif isinstance(c, str):
                             user_prompts.append(c)
                 item_type = payload.get("type")
-                if item_type == "function_call":
+                if item_type in ("function_call", "custom_tool_call"):
+                    # function_call carries `arguments`; custom_tool_call (e.g.
+                    # apply_patch) carries `input`. Both expose an explicit name.
                     function_calls.append(
                         {
-                            "name": payload.get("name", ""),
-                            "arguments": payload.get("arguments", ""),
+                            "name": payload.get("name", item_type),
+                            "arguments": payload.get("arguments")
+                            or payload.get("input", ""),
                         }
                     )
+                elif item_type in (
+                    "web_search_call",
+                    "tool_search_call",
+                    "image_generation_call",
+                ):
+                    # Codex 0.139.0 tool activity with no explicit name field;
+                    # record the call type so the summary reflects it.
+                    function_calls.append({"name": item_type, "arguments": ""})
                 elif item_type == "reasoning":
                     # Codex 0.139.0 moved reasoning from event_msg(agent_reasoning)
                     # to response_item(type=reasoning). Plaintext (when present) is in
@@ -192,7 +203,7 @@ def format_summary(data: dict) -> str:
             lines.append(f"**Block {i}:** {preview}\n")
 
     if data["function_calls"]:
-        lines.append("### Function Calls")
+        lines.append("### Tool Calls")
         lines.append(f"Total: {len(data['function_calls'])} calls")
         for fc in data["function_calls"][:10]:
             lines.append(f"- `{fc['name']}`")

--- a/codex-plus/scripts/codex-session-extract.py
+++ b/codex-plus/scripts/codex-session-extract.py
@@ -10,7 +10,6 @@ Usage:
 
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -19,23 +18,16 @@ SESSIONS_DIR = Path.home() / ".codex" / "sessions"
 
 def find_sessions(partial_uuid: str) -> list[Path]:
     """Find session files matching a partial UUID."""
-    result = subprocess.run(
-        ["find", str(SESSIONS_DIR), "-name", f"*{partial_uuid}*", "-type", "f"],
-        capture_output=True,
-        text=True,
-    )
-    paths = [Path(p) for p in result.stdout.strip().splitlines() if p]
-    return sorted(paths)
+    if not SESSIONS_DIR.is_dir():
+        return []
+    return sorted(p for p in SESSIONS_DIR.rglob(f"*{partial_uuid}*") if p.is_file())
 
 
 def recent_sessions(n: int = 5) -> list[Path]:
     """Return the N most recently modified session files."""
-    result = subprocess.run(
-        ["find", str(SESSIONS_DIR), "-name", "*.jsonl", "-type", "f"],
-        capture_output=True,
-        text=True,
-    )
-    paths = [Path(p) for p in result.stdout.strip().splitlines() if p]
+    if not SESSIONS_DIR.is_dir():
+        return []
+    paths = [p for p in SESSIONS_DIR.rglob("*.jsonl") if p.is_file()]
     return sorted(paths, key=lambda p: p.stat().st_mtime, reverse=True)[:n]
 
 
@@ -69,8 +61,6 @@ def parse_session(path: Path, include_reasoning: bool = False) -> dict:
                 sub_type = payload.get("type", "")
                 if sub_type == "agent_message":
                     messages.append(payload.get("message", ""))
-                elif sub_type == "agent_reasoning":
-                    reasoning.append(payload.get("text", ""))
                 elif sub_type == "token_count":
                     info = payload.get("info")
                     if info:
@@ -93,6 +83,16 @@ def parse_session(path: Path, include_reasoning: bool = False) -> dict:
                             "arguments": payload.get("arguments", ""),
                         }
                     )
+                elif item_type == "reasoning":
+                    # Codex 0.139.0 moved reasoning from event_msg(agent_reasoning)
+                    # to response_item(type=reasoning). Plaintext (when present) is in
+                    # summary[].text; encrypted_content is opaque and is often the only
+                    # payload, so this may legitimately yield nothing.
+                    for part in payload.get("summary", []):
+                        if isinstance(part, dict) and part.get("text"):
+                            reasoning.append(part["text"])
+                        elif isinstance(part, str):
+                            reasoning.append(part)
 
             elif event_type == "turn_context":
                 turns.append(payload)
@@ -125,7 +125,8 @@ def format_meta(meta: dict | None) -> str:
         lines.append(
             f"- **Git**: `{git.get('branch', '?')}` @ `{git.get('commit_hash', '?')[:12]}`"
         )
-    instructions = meta.get("instructions", "")
+    _bi = meta.get("base_instructions", "") or meta.get("instructions", "")
+    instructions = _bi.get("text", "") if isinstance(_bi, dict) else _bi
     if instructions:
         preview = instructions[:200].replace("\n", " ")
         if len(instructions) > 200:

--- a/codex-plus/skills/codex-session/SKILL.md
+++ b/codex-plus/skills/codex-session/SKILL.md
@@ -15,7 +15,7 @@ Retrieve context from Codex CLI session history stored at `~/.codex/sessions/`.
 ```
 
 Each JSONL file contains:
-- `session_meta`: id, cwd, model, cli_version, base_instructions, git info
+- `session_meta`: id, cwd, model_provider, cli_version, base_instructions, git info
 - `event_msg` (agent_message): final agent output
 - `response_item` (type=reasoning): reasoning blocks — plaintext in `summary[].text`; `encrypted_content` is opaque
 - `response_item`: user prompts, function calls

--- a/codex-plus/skills/codex-session/SKILL.md
+++ b/codex-plus/skills/codex-session/SKILL.md
@@ -18,7 +18,7 @@ Each JSONL file contains:
 - `session_meta`: id, cwd, model_provider, cli_version, base_instructions, git info
 - `event_msg` (agent_message): final agent output
 - `response_item` (type=reasoning): reasoning blocks — plaintext in `summary[].text`; `encrypted_content` is opaque
-- `response_item`: user prompts, function calls
+- `response_item`: user prompts, tool calls (function/custom/search/image)
 - `turn_context`: per-turn metadata (model, effort, sandbox)
 
 ## Workflow
@@ -59,10 +59,10 @@ grep -rl "keyword" ~/.codex/sessions/ --include="*.jsonl" | head -10
 ### 3. Present Results
 
 Summarize the extracted context:
-- Session metadata (model, cwd, git branch, instructions)
+- Session metadata (model_provider, cwd, git branch, instructions)
 - User prompts that initiated the session
 - Agent output (final messages)
-- Function calls summary
+- Tool calls summary
 - Token usage stats
 
 ### 4. Follow-up Options

--- a/codex-plus/skills/codex-session/SKILL.md
+++ b/codex-plus/skills/codex-session/SKILL.md
@@ -15,9 +15,9 @@ Retrieve context from Codex CLI session history stored at `~/.codex/sessions/`.
 ```
 
 Each JSONL file contains:
-- `session_meta`: id, cwd, model, cli_version, instructions, git info
+- `session_meta`: id, cwd, model, cli_version, base_instructions, git info
 - `event_msg` (agent_message): final agent output
-- `event_msg` (agent_reasoning): thinking/reasoning blocks
+- `response_item` (type=reasoning): reasoning blocks — plaintext in `summary[].text`; `encrypted_content` is opaque
 - `response_item`: user prompts, function calls
 - `turn_context`: per-turn metadata (model, effort, sandbox)
 

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -92,6 +92,7 @@ Each command below runs **inside a Bash subagent**, which returns the outcome su
 | Resume a session | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> /tmp/codex_prompt_<suffix>.txt` (only resume path; deterministic, no --last) |
 | Different dir | Add `-C <DIR>` to non-resume patterns above |
 | Custom model | Add `-m gpt-5.4 -r high` to any pattern above |
+| Capture answer to file | Add `-o <FILE>` to write codex's final message to FILE (deterministic) |
 
 ## Following Up
 After `codex` completes, use `AskUserQuestion` to confirm next steps. Restate model/reasoning/sandbox when proposing actions.


### PR DESCRIPTION
## What
Aligns `codex-plus` with the installed Codex CLI **0.139.0** session-rollout schema and adds a deterministic answer-capture option. Verified against a real rollout JSONL on disk.

## Fixes (silent failures — no error, just empty output)
- **Reasoning extraction was dead.** Parser looked for `event_msg(agent_reasoning)`, which 0.139.0 no longer emits. Reasoning now lives in `response_item(type=reasoning)`; plaintext is in `summary[].text`. Parser updated. NOTE: 0.139.0 often stores reasoning in `encrypted_content` (opaque) with an empty `summary`, so `--full` may still legitimately show little — this fix corrects the location, not the encryption.
- **Session `instructions` preview always empty.** `session_meta` key was renamed `instructions` → `base_instructions` (and is now an object `{"text": "..."}` rather than a bare string). Reads `base_instructions.text` with a fallback to the old key.
- **Docs (`codex-session` SKILL) updated** to match the corrected schema.

## Improvements
- `codex-session-extract.py`: replaced `subprocess` + `find` with stdlib `pathlib.rglob` (stdlib-only, no external process), plus a guard when the sessions dir is absent.
- `codex-run.sh`: added optional `-o/--output-last-message FILE` passthrough for deterministic final-message capture, decoupled from stdout banner noise (additive; default behavior unchanged). Documented in the `codex` SKILL Quick Reference.

## Verification (CLI 0.139.0)
- `bash -n codex-run.sh` OK; python AST parse OK; `--recent` smoke OK.
- `codex exec resume <id>` confirmed valid; `-m/-c/-s/-C/--skip-git-repo-check/--full-auto` confirmed accepted.
