### PR TITLE
chore(remote-spawn): include TMUX_TMPDIR in printed attach/ls hints

### DIFF
--- a/remote-spawn/.claude-plugin/plugin.json
+++ b/remote-spawn/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-spawn",
   "description": "Spawn a backgrounded `claude --remote-control` session in any directory (tmux-tracked), reachable from the Claude app",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-spawn/scripts/rc-spawn.sh
+++ b/remote-spawn/scripts/rc-spawn.sh
@@ -26,6 +26,11 @@ export TMUX_TMPDIR="${TMUX_TMPDIR:-$HOME/.tmux-sockets}"
 mkdir -p "$TMUX_TMPDIR"
 unset TMUX  # target the tmux daemon, not a nested client, if invoked from inside tmux
 
+# Copy-paste hint prefix. The user's interactive shell does NOT inherit the
+# relocated TMUX_TMPDIR above, so a bare `tmux attach`/`tmux ls` targets the
+# default socket and fails ("no server running"). Printed hints carry the socket.
+ATTACH_ENV="TMUX_TMPDIR=$TMUX_TMPDIR"
+
 # Reduce a path/name to a tmux- and shell-safe token: [A-Za-z0-9._-], no runs of '-'.
 sanitize() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-' | sed 's/--*/-/g; s/^-//; s/-$//'; }
 
@@ -41,7 +46,7 @@ spawn() {
     # report the dir the session is ACTUALLY running in (not the one just asked for),
     # and flag a basename collision so it isn't a silent no-op.
     local rdir; rdir="$(tmux display-message -p -t "$sess" '#{session_path}' 2>/dev/null)"
-    echo "ALREADY-RUNNING $name  (running in: ${rdir:-?})  attach: tmux attach -t $sess"
+    echo "ALREADY-RUNNING $name  (running in: ${rdir:-?})  attach: $ATTACH_ENV tmux attach -t $sess"
     [ "$rdir" = "$dir" ] || echo "  note: requested $dir but rc-$name already runs in ${rdir:-?} — pass an explicit name to run a second session"
     return 0
   fi
@@ -69,7 +74,7 @@ spawn() {
   echo "SESSION $sid"
   [ -n "$prompt" ] && echo "  -> initial prompt queued (auto-submits once the session is ready)"
   echo "  -> now reachable in the Claude app (claude.ai/code + mobile)"
-  echo "  -> attach: tmux attach -t $sess   |   kill: rc-spawn.sh kill $name"
+  echo "  -> attach: $ATTACH_ENV tmux attach -t $sess   |   kill: rc-spawn.sh kill $name"
   echo "  note: first launch in a never-opened dir shows a one-time folder-trust prompt"
   echo "        inside the session (any queued prompt waits behind it) — attach once,"
   echo "        press Enter, detach (Ctrl-b d); the prompt then submits."
@@ -81,6 +86,7 @@ list() {
         | awk -F'\t' '$1 ~ /^rc-/ {printf "  %-22s %s\n", substr($1,4), $2}')"
   if [ -n "$out" ]; then
     echo "running remote-control sessions:"; printf '%s\n' "$out"
+    echo "  attach: $ATTACH_ENV tmux attach -t rc-<name>   |   ls: $ATTACH_ENV tmux ls"
   else
     echo "(no rc-* sessions running)"
   fi

--- a/remote-spawn/skills/remote-spawn/SKILL.md
+++ b/remote-spawn/skills/remote-spawn/SKILL.md
@@ -41,7 +41,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" kill <name>
 Notes to pass on when relevant:
 - The session lives until its claude exits (no auto-restart by design).
 - First launch in a directory Claude has never opened may show a one-time
-  folder-trust prompt **inside** the tmux session — `tmux attach -t rc-<name>`,
+  folder-trust prompt **inside** the tmux session — `TMUX_TMPDIR=~/.tmux-sockets tmux attach -t rc-<name>`,
   press Enter, then detach with `Ctrl-b d`. **A queued initial prompt waits
   behind this trust gate** and submits only after trust is confirmed.
 - tmux is used (not nohup/launchd) so sessions work under TCC-protected dirs


### PR DESCRIPTION
## Root cause

`remote-spawn/scripts/rc-spawn.sh` relocates the tmux socket near the top:

```sh
export TMUX_TMPDIR="${TMUX_TMPDIR:-$HOME/.tmux-sockets}"
```

So the script's own tmux calls work, but the attach/ls hints it **prints** to
the user omitted `TMUX_TMPDIR`. A user pasting them into their own interactive
shell (which does NOT inherit the relocated value) targets the **default**
socket and hits `no server running on /private/tmp/tmux-*/default`. The actual
session name is `rc-<name>` (the bare `<name>` is only the `claude --name`
shown in the app), which compounds the confusion.

## Fix

Introduce a reusable `ATTACH_ENV="TMUX_TMPDIR=$TMUX_TMPDIR"` prefix and prepend
it to every printed attach/ls hint, plus the SKILL.md folder-trust note, so the
hints paste-and-run as-is.

Before / after (the STARTED hint):

```
-  echo "  -> attach: tmux attach -t $sess   |   kill: rc-spawn.sh kill $name"
+  echo "  -> attach: $ATTACH_ENV tmux attach -t $sess   |   kill: rc-spawn.sh kill $name"
```

Covered hints: `ALREADY-RUNNING` attach, `STARTED` attach, and a new
`list` hint line (`attach … | ls …`). The `SKILL.md` folder-trust note's raw
`tmux attach -t rc-<name>` is likewise prefixed with
`TMUX_TMPDIR=~/.tmux-sockets`. The top SKILL.md code-block examples use
`rc-spawn.sh` subcommands (not raw tmux) and are unchanged.

## Note

Per the repo's bump-on-change rule (enforced by the `.githooks` pre-commit hook
and the version-bump CI gate), this change-set bumps
`remote-spawn/.claude-plugin/plugin.json` `1.1.0 → 1.1.1`.
