### PR TITLE
fix(voice-dictation): flock 단일 인스턴스 가드로 중복 데몬 방지

### DIFF
--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -14,6 +14,7 @@
 
 중지: Ctrl+C
 """
+import fcntl
 import os
 import signal
 import subprocess
@@ -30,9 +31,11 @@ PROMPT = "whisper, hotkey, active window, transcription, paste, 데몬, 핫키, 
 TRIGGER = keyboard.Key.alt_r   # 오른쪽 Option
 MIN_SEC = 0.3          # 이보다 짧은 녹음은 오발화로 간주, 무시
 WAV = os.path.join(tempfile.gettempdir(), "voice_dictation.wav")
+LOCK = os.path.join(tempfile.gettempdir(), "voice_dictation.lock")
 
 _rec_proc = None
 _recording = False
+_lock_fp = None        # 단일 인스턴스 락 fd — 프로세스 수명 동안 열어 둬 락 유지
 
 
 def _start_recording():
@@ -129,7 +132,23 @@ def _on_release(key):
         _stop_and_transcribe()
 
 
+def _acquire_singleton_lock():
+    """단일 인스턴스 보장 — 이미 다른 데몬이 락을 쥐고 있으면 즉시 종료.
+
+    advisory flock 은 프로세스 종료/크래시 시 OS 가 자동 해제하므로 stale PID
+    파일 문제가 없다. 락 fd 를 전역에 보관해 프로세스 수명 동안 락을 유지하며,
+    런처·플러그인 버전·시그니처와 무관하게 중복 기동 자체를 차단한다.
+    """
+    global _lock_fp
+    _lock_fp = open(LOCK, "w")
+    try:
+        fcntl.flock(_lock_fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        raise SystemExit("이미 실행 중인 voice-dictation 데몬이 있습니다 — 중복 기동 취소.")
+
+
 def main():
+    _acquire_singleton_lock()
     if not os.path.exists(MODEL):
         raise SystemExit(f"모델 없음: {MODEL}")
     print("voice-dictation 프로토타입 — 오른쪽 Option(⌥) 홀드로 받아쓰기. 중지: Ctrl+C")


### PR DESCRIPTION
## 문제
voice-dictation 데몬이 2개 동시 실행 중이었음 (v1.0.0 고아 + v1.0.1 현재).
두 데몬이 같은 오른쪽 Option 핫키를 잡고 같은 `/tmp/voice_dictation.wav` 에
동시에 녹음 → 오디오 손상 → whisper 가 토큰 반복 환각 (`I I I you you…`).

## 근본 원인
- **데몬에 단일 인스턴스 가드 부재** → 중복 기동 무방비
- `toggle.sh` 가 버전이 박힌 절대경로(`…/1.0.0/…dictation_daemon.py`)로 kill 매칭
  → 1.0.0→1.0.1 업데이트 시 새 토글이 옛 데몬을 못 죽이고 고아로 잔존

## 해결
`dictation_daemon.py` 시작 시 `/tmp/voice_dictation.lock` 에 비차단
`flock(LOCK_EX|LOCK_NB)`. 이미 점유 시 즉시 종료.
- advisory lock → 프로세스 종료/크래시 시 OS 자동 해제 (stale PID 파일 문제 없음)
- 런처·플러그인 버전·시그니처와 무관하게 중복 기동 자체 차단
- 정상 토글 off→on 재시작은 영향 없음 (해제 후 재획득 검증 완료)

`plugin.json` 1.0.2 → 1.0.3 (bump-on-change).

## 검증
- `py_compile` 구문 정상
- flock 동시성 테스트: 2번째 인스턴스 거부(exit 42), 해제 후 재획득 성공
