### PR TITLE
feat(cdp-attach): add global single-access semaphore (flock) for CDP

### DIFF
--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/scripts/cdp_client.py
+++ b/cdp-attach/scripts/cdp_client.py
@@ -17,6 +17,7 @@ Import via sys.path manipulation in v1/v2/v3 scripts:
     from cdp_client import CDPClient
 """
 
+import contextlib
 import fcntl
 import json
 import os
@@ -547,3 +548,70 @@ class CDPClient:
             state.get("pids", {}).pop(process_type, None)
 
         self._locked_state_update(_update)
+
+
+@contextlib.contextmanager
+def cdp_lock(host=None, port=None):
+    """Global single-access semaphore for CDP browser access.
+
+    Serializes all CDP operations across concurrent sessions/subagents via an
+    exclusive flock on a per-(host,port) lock file in STATE_DIR. Kernel-enforced
+    and auto-released on process death (no stale-lock bookkeeping needed).
+
+    Blocks up to CDP_ATTACH_LOCK_TIMEOUT seconds (default 10) trying to acquire,
+    then fails fast with CDPError. Disabled entirely when CDP_ATTACH_NO_LOCK=1.
+    The flock is the mutual-exclusion mechanism; the JSON owner record written
+    into the lock file is informational (attribution / error messages) only.
+    """
+    if os.environ.get("CDP_ATTACH_NO_LOCK") == "1":
+        yield
+        return
+    h = host or os.environ.get("CDP_HOST", "127.0.0.1")
+    p = int(port or os.environ.get("CDP_PORT", "9222"))
+    os.makedirs(STATE_DIR, exist_ok=True)
+    lock_path = os.path.join(STATE_DIR, f"cdp-{h}-{p}.lock")
+    timeout = float(os.environ.get("CDP_ATTACH_LOCK_TIMEOUT", "10"))
+    # "a+" => create-if-absent, do NOT truncate a current holder's record
+    lock_f = open(lock_path, "a+")
+    deadline = time.time() + timeout
+    acquired = False
+    while time.time() < deadline:
+        try:
+            fcntl.flock(lock_f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            acquired = True
+            break
+        except (BlockingIOError, OSError):
+            time.sleep(0.1)
+    if not acquired:
+        # best-effort read of the current owner for a helpful message
+        holder = ""
+        try:
+            lock_f.seek(0)
+            holder = lock_f.read().strip()
+        except Exception:
+            pass
+        lock_f.close()
+        raise CDPError(
+            f"CDP busy: another session holds the lock on {h}:{p} after waiting "
+            f"{timeout:.0f}s. Holder: {holder or 'unknown'}. Retry shortly, raise "
+            f"CDP_ATTACH_LOCK_TIMEOUT, or set CDP_ATTACH_NO_LOCK=1 to bypass."
+        )
+    try:
+        try:
+            lock_f.seek(0)
+            lock_f.truncate()
+            lock_f.write(json.dumps({
+                "session_id": os.environ.get("CLAUDE_CODE_SESSION_ID"),
+                "pid": os.getpid(),
+                "acquired_at": time.time(),
+            }))
+            lock_f.flush()
+        except Exception:
+            pass  # owner record is best-effort; never block the caller
+        yield
+    finally:
+        try:
+            fcntl.flock(lock_f, fcntl.LOCK_UN)
+        except Exception:
+            pass
+        lock_f.close()

--- a/cdp-attach/scripts/v1_core.py
+++ b/cdp-attach/scripts/v1_core.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 # Import shared client from same directory
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from cdp_client import CDPClient, CDPError, ERRORS_FILE, STATE_DIR
+from cdp_client import CDPClient, CDPError, ERRORS_FILE, STATE_DIR, cdp_lock
 
 
 _TOP_LEVEL_CONST_LET_RE = re.compile(r'(?m)^(\s*)(const|let)\b')
@@ -960,10 +960,16 @@ def main():
     }
 
     try:
-        # Block headless browsers (except for diagnostic / local commands).
-        if args.command not in LOCAL_COMMANDS:
-            client.require_headed()
-        commands[args.command](client, args)
+        # doctor is exempt from the global lock: diagnostics must remain
+        # runnable during contention. All other commands serialize CDP access.
+        if args.command == "doctor":
+            commands[args.command](client, args)
+        else:
+            with cdp_lock(client.host, client.port):
+                # Block headless browsers (except for diagnostic / local commands).
+                if args.command not in LOCAL_COMMANDS:
+                    client.require_headed()
+                commands[args.command](client, args)
     except CDPError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/cdp-attach/scripts/v2_interact.py
+++ b/cdp-attach/scripts/v2_interact.py
@@ -17,7 +17,7 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from cdp_client import CDPClient, CDPConnectionError, CDPError
+from cdp_client import CDPClient, CDPConnectionError, CDPError, cdp_lock
 
 
 def _resolve_selector(client, selector):
@@ -884,8 +884,11 @@ def main():
     }
 
     try:
-        client.require_headed()  # Block headless browsers
-        commands[args.command](client, args)
+        # Serialize all CDP access machine-wide (per host:port) so concurrent
+        # sessions/subagents never drive the same browser simultaneously.
+        with cdp_lock(client.host, client.port):
+            client.require_headed()  # Block headless browsers
+            commands[args.command](client, args)
     except CDPError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/cdp-attach/scripts/v3_advanced.py
+++ b/cdp-attach/scripts/v3_advanced.py
@@ -18,7 +18,7 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from cdp_client import CDPClient, CDPConnectionError, CDPError
+from cdp_client import CDPClient, CDPConnectionError, CDPError, cdp_lock
 
 CACHE_DIR = os.path.expanduser("~/.cache/cdp-attach")
 NETWORK_EVENTS = os.path.join(CACHE_DIR, "network-events.jsonl")
@@ -1118,11 +1118,25 @@ def main():
         "dialog": cmd_dialog,
     }
 
+    # Daemon-spawning commands fork() a long-lived collector that holds the
+    # CDP session itself. They must NOT run under cdp_lock: the forked child
+    # would never release it (permanent deadlock), and flock is shared across
+    # fork. The daemon runs UNLOCKED by design (it only observes events). Their
+    # foreground parent does no synchronous browser I/O worth serializing.
+    DAEMON_COMMANDS = {"network_start", "console_start"}
+
     try:
-        # Block headless browsers (except local-only commands)
-        if args.command not in LOCAL_COMMANDS:
+        if args.command in DAEMON_COMMANDS:
+            # Block headless browsers (these are not local-only commands).
             client.require_headed()
-        commands[args.command](client, args)
+            commands[args.command](client, args)
+        else:
+            # Serialize all foreground CDP access machine-wide (per host:port).
+            with cdp_lock(client.host, client.port):
+                # Block headless browsers (except local-only commands)
+                if args.command not in LOCAL_COMMANDS:
+                    client.require_headed()
+                commands[args.command](client, args)
     except CDPError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary

Adds a global single-access semaphore (N=1 mutex) so multiple concurrent Claude
sessions/subagents can no longer drive the **same** Chrome via CDP at once. Without
it, interleaved operations from parallel sessions corrupt each other.

Mechanism: a kernel-enforced exclusive `flock` held around each command's entire
CDP body — not per-`send`. Serialized machine-wide, **per `(host, port)`**.

### Design

- **`cdp_lock(host, port)` context manager** (`cdp_attach/scripts/cdp_client.py`) —
  exclusive `flock` on a per-`(host,port)` lock file in `~/.cache/cdp-attach`
  (`cdp-<host>-<port>.lock`). Kernel-enforced, auto-released on process death — no
  stale-lock bookkeeping. Matches the existing `_locked_state_update` / `save_pid`
  flock idiom.
- **Owner record** — a JSON `{session_id, pid, acquired_at}` is written into the lock
  file for attribution / error messages only; the `flock` is the actual mutual-exclusion
  mechanism. `CLAUDE_CODE_SESSION_ID` feeds `session_id`.
- **Timeout + bypass env knobs** — blocks up to `CDP_ATTACH_LOCK_TIMEOUT` seconds
  (default 10) acquiring, then fails fast with a `CDPError` naming the current holder.
  `CDP_ATTACH_NO_LOCK=1` disables locking entirely.
- **Wiring (v1/v2/v3)** — each CDP-touching subcommand's whole body runs inside one
  `with cdp_lock(client.host, client.port):` (all internal `client.send(...)` under a
  single hold). Read-only commands (e.g. `list`) are locked too — strict single-access.
- **Exemptions**:
  - `doctor` (v1) stays **unlocked** — diagnostics must run during contention.
  - **Daemon collectors** `network_start` / `console_start` (v3) stay **unlocked**. They
    `os.fork()` a long-lived child that holds the CDP session; `flock` is shared across
    `fork`, so running them under the lock would (a) deadlock — the daemon never releases —
    and (b) risk the child's `finally` releasing the parent's lock. The daemon observes
    events only and runs unlocked by design. Their foreground parent does no synchronous
    browser I/O worth serializing, so `os.fork()` never executes inside a `with cdp_lock()`.

## Test plan

Smoke tests (no Chrome required), against `127.0.0.1:59999`:

- **Import / compile** — `import cdp_client` exposes `cdp_lock`; `py_compile` passes for
  `cdp_client.py`, `v1_core.py`, `v2_interact.py`, `v3_advanced.py`.
- **Mutual exclusion** — two processes each `with cdp_lock(...)` write a `[start,end]`
  interval to a shared file and sleep 0.5s (`CDP_ATTACH_LOCK_TIMEOUT=30`). Result: the two
  intervals do **not** overlap (serialized): p0 `[…152.59, …153.10]`, p1 `[…153.11, …153.62]`.
- **Bypass** — same with `CDP_ATTACH_NO_LOCK=1`: intervals fully overlap (lock disabled) and
  no exception raised.
- Test artifacts and the `~/.cache/cdp-attach/cdp-127.0.0.1-59999.lock` test file cleaned up.

Version bumped `1.6.1` → `1.7.0` (minor, new feature); pre-commit hook + CI version-bump
gate satisfied.
