### PR TITLE
fix(voice-dictation): bound whisper transcription to prevent runaway

### DIFF
--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/README.md
+++ b/voice-dictation/README.md
@@ -15,7 +15,7 @@ Push-to-talk voice dictation for Claude Code, powered by whisper.cpp.
 데몬 실행 전 다음 CLI가 PATH에 있어야 합니다:
 
 - `whisper-cli` (brew `whisper-cpp`) — 전사
-- `rec` (brew `sox`) — 녹음 (`-b 16 -e signed-integer -r 16000 -c 1` 고정 s16 출력; 녹음 길이는 파일 크기에서 직접 산출하므로 ffprobe 불필요)
+- `rec` (brew `sox`) — 녹음 (`-b 16 -e signed-integer -r 16000 -c 1` 컴팩트 s16 선호; 녹음 길이는 WAV `fmt ` 청크의 실제 포맷으로 파일 크기에서 산출하므로 ffprobe 불필요, 포맷 미반영에도 정확)
 - `uv` — 데몬 실행
 
 ## Permissions (macOS, one-time)

--- a/voice-dictation/README.md
+++ b/voice-dictation/README.md
@@ -15,8 +15,7 @@ Push-to-talk voice dictation for Claude Code, powered by whisper.cpp.
 데몬 실행 전 다음 CLI가 PATH에 있어야 합니다:
 
 - `whisper-cli` (brew `whisper-cpp`) — 전사
-- `rec` (brew `sox`) — 녹음
-- `ffprobe` (brew `ffmpeg`) — 녹음 길이 측정. **미설치 시 모든 녹음이 `무시: 0.00s`로 조용히 폐기**되니 주의
+- `rec` (brew `sox`) — 녹음 (`-b 16 -e signed-integer -r 16000 -c 1` 고정 s16 출력; 녹음 길이는 파일 크기에서 직접 산출하므로 ffprobe 불필요)
 - `uv` — 데몬 실행
 
 ## Permissions (macOS, one-time)

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -30,6 +30,14 @@ LANG = "auto"          # ko / en / auto
 PROMPT = "whisper, hotkey, active window, transcription, paste, 데몬, 핫키, 단축키, 음성 전사"
 TRIGGER = keyboard.Key.alt_r   # 오른쪽 Option
 MIN_SEC = 0.3          # 이보다 짧은 녹음은 오발화로 간주, 무시
+# rec 녹음 포맷 — _wav_duration 의 크기→길이 산출이 이 값에 의존하므로
+# 아래 rec 호출 인자와 반드시 일치해야 한다.
+SAMPLE_RATE = 16000
+CHANNELS = 1
+SAMPLE_BYTES = 2       # rec 기본 s16(16-bit signed) WAV
+WAV_HEADER_BYTES = 44  # 표준 WAV 헤더 크기
+WHISPER_MIN_TIMEOUT = 20.0    # 전사 타임아웃 하한(초)
+WHISPER_TIMEOUT_FACTOR = 4.0  # 실제 오디오 길이 대비 타임아웃 배수
 WAV = os.path.join(tempfile.gettempdir(), "voice_dictation.wav")
 LOCK = os.path.join(tempfile.gettempdir(), "voice_dictation.lock")
 
@@ -51,7 +59,7 @@ def _start_recording():
         pass
     # 16kHz mono. SIGINT 으로 종료해야 sox 가 WAV 헤더를 정상 finalize 함.
     _rec_proc = subprocess.Popen(
-        ["rec", "-q", "-r", "16000", "-c", "1", WAV],
+        ["rec", "-q", "-r", str(SAMPLE_RATE), "-c", str(CHANNELS), WAV],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
@@ -76,9 +84,10 @@ def _stop_and_transcribe():
         print(f"  (무시: {dur:.2f}s)", flush=True)
         return
 
-    print(f"  전사 중… ({dur:.1f}s)", flush=True)
+    timeout = max(WHISPER_MIN_TIMEOUT, dur * WHISPER_TIMEOUT_FACTOR)
+    print(f"  전사 중… ({dur:.1f}s, 타임아웃 {timeout:.0f}s)", flush=True)
     t0 = time.time()
-    text = _transcribe(WAV)
+    text = _transcribe(WAV, timeout)
     dt = time.time() - t0
     if not text:
         print("  (빈 결과)", flush=True)
@@ -88,22 +97,36 @@ def _stop_and_transcribe():
 
 
 def _wav_duration(path):
+    """녹음 길이(초)를 파일 크기에서 직접 산출 — 헤더 손상에 면역.
+
+    이전 구현은 ffprobe 로 WAV 헤더의 duration 을 읽었는데, rec(sox) 가
+    SIGINT 종료 시 헤더를 finalize 하지 못하면(간헐적) 헤더에 sentinel
+    거대값이 남아 실제 수 초짜리 녹음이 수 시간으로 잘못 읽혔다. 그 값이
+    MIN_SEC '너무 짧으면 무시' 가드를 통과해 whisper 가 폭주했다. 데몬은
+    고정 포맷(SAMPLE_RATE/CHANNELS/SAMPLE_BYTES)으로만 녹음하므로, 디스크에
+    실제로 쓰인 바이트 수가 길이의 신뢰 가능한 근거다.
+    """
     try:
-        out = subprocess.run(
-            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
-             "-of", "default=nw=1:nk=1", path],
-            capture_output=True, text=True,
-        ).stdout.strip()
-        return float(out)
-    except Exception:
+        size = os.path.getsize(path)
+    except OSError:
         return 0.0
+    data_bytes = max(0, size - WAV_HEADER_BYTES)
+    return data_bytes / (SAMPLE_RATE * CHANNELS * SAMPLE_BYTES)
 
 
-def _transcribe(path):
+def _transcribe(path, timeout):
     cmd = [WHISPER_CLI, "-m", MODEL, "-f", path, "-l", LANG, "-nt", "-np"]
     if PROMPT:
         cmd += ["--prompt", PROMPT]
-    out = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        out = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        # 손상 WAV 등으로 전사가 무한정 길어지는 폭주를 차단 — run() 은
+        # 타임아웃 시 자식 프로세스를 종료(kill)한다.
+        print(f"  (전사 타임아웃 {timeout:.0f}s 초과 — 중단)", flush=True)
+        return ""
     return " ".join(out.stdout.split()).strip()
 
 

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -19,6 +19,7 @@ import glob
 import os
 import queue
 import signal
+import struct
 import subprocess
 import tempfile
 import threading
@@ -33,13 +34,13 @@ LANG = "auto"          # ko / en / auto
 PROMPT = "whisper, hotkey, active window, transcription, paste, 데몬, 핫키, 단축키, 음성 전사"
 TRIGGER = keyboard.Key.alt_r   # 오른쪽 Option
 MIN_SEC = 0.3          # 이보다 짧은 녹음은 오발화로 간주, 무시
-# rec 녹음 포맷 — _wav_duration 의 크기→길이 산출이 이 값에 의존하므로
-# 아래 rec 호출에서 -b/-e 로 명시 고정한다(sox 기본값에 의존하지 않음: 기본은
-# 장치 정밀도를 따라 32-bit/EXTENSIBLE 가 나올 수 있어 크기→길이 산식이 깨진다).
+# rec 녹음 포맷 — whisper 친화적인 컴팩트 s16 PCM 으로 고정한다. _wav_duration
+# 은 더 이상 이 값에 의존하지 않고(WAV `fmt ` 청크에서 실제 포맷을 읽음) 포맷이
+# 드리프트해도 길이가 조용히 틀어지지 않으므로, 아래 -b/-e 고정은 정확성의
+# 근거가 아니라 파일 크기 절감용 best-effort 다(미반영돼도 길이는 정확).
 SAMPLE_RATE = 16000
 CHANNELS = 1
-SAMPLE_BYTES = 2       # rec -b 16 -e signed-integer 로 고정한 s16(16-bit signed)
-WAV_HEADER_BYTES = 44  # 고정 s16 PCM 의 정규 WAV 헤더 크기
+SAMPLE_BYTES = 2       # rec -b 16 -e signed-integer 선호 포맷 s16(16-bit signed)
 # 전사 타임아웃 하한 — whisper-cli 는 매 호출 fresh 프로세스라 모델 콜드 로드 +
 # Metal 셰이더 컴파일(첫 호출 수십 초 가능) 비용을 짧은 발화에서도 흡수해야 한다.
 WHISPER_MIN_TIMEOUT = 40.0
@@ -65,9 +66,9 @@ def _start_recording():
         os.remove(WAV)
     except FileNotFoundError:
         pass
-    # 16kHz mono s16. -b/-e 로 포맷을 고정해 _wav_duration 의 크기→길이 산식
-    # (SAMPLE_BYTES/WAV_HEADER_BYTES)이 항상 성립하게 한다. SIGINT 으로 종료해야
-    # sox 가 WAV 헤더를 정상 finalize 함.
+    # 16kHz mono s16. -b/-e 로 컴팩트 s16 을 선호 포맷으로 요청한다(정확성용은
+    # 아님 — _wav_duration 은 파일의 `fmt ` 청크에서 실제 포맷을 읽으므로 이 요청이
+    # 미반영돼도 길이는 정확). SIGINT 으로 종료해야 sox 가 WAV 헤더를 정상 finalize 함.
     _rec_proc = subprocess.Popen(
         ["rec", "-q", "-b", str(SAMPLE_BYTES * 8), "-e", "signed-integer",
          "-r", str(SAMPLE_RATE), "-c", str(CHANNELS), WAV],
@@ -92,7 +93,7 @@ def _stop_and_transcribe():
         _rec_proc = None
 
     # 오발화(짧은 brush)는 스냅샷·스레드를 만들기 전에 리스너 스레드에서 바로 거른다
-    # — 무의미한 워커가 쌓이지 않게. _wav_duration 은 getsize 뿐이라 즉시 반환된다.
+    # — 무의미한 워커가 쌓이지 않게. _wav_duration 은 헤더 청크만 읽어 즉시 반환된다.
     dur = _wav_duration(WAV)
     if dur < MIN_SEC:
         print(f"  (무시: {dur:.2f}s)", flush=True)
@@ -138,22 +139,82 @@ def _transcribe_worker():
                 pass
 
 
+def _read_wav_format(path):
+    """WAV `fmt ` 청크에서 (nSamplesPerSec, bytes_per_frame, header_len) 산출.
+
+    파싱 실패 시 None. `fmt ` 청크는 sox 가 녹음 *시작* 시점에 기록하므로,
+    SIGINT 중단이 파일 끝의 data 청크 size 필드를 손상시켜도 온전하다(과거
+    ffprobe 경로가 깨진 이유가 바로 그 끝부분 size/duration 필드를 믿었기
+    때문). 여기서는 손상될 수 있는 data 청크 size 는 읽지 않고, 데이터가
+    시작되는 오프셋(header_len)과 실제 포맷만 얻는다 — 길이는 호출부에서
+    파일 크기 기준으로 계산한다.
+
+    stdlib `wave` 대신 직접 파싱: `wave` 는 WAVE_FORMAT_EXTENSIBLE 헤더나
+    손상된 data size 에서 예외를 던질 수 있는 반면, 여기 필요한 필드(포맷,
+    data 오프셋)만 읽는 최소 파서는 그런 입력에도 견고하고 의존성도 없다.
+    """
+    try:
+        with open(path, "rb") as f:
+            riff = f.read(12)
+            if len(riff) < 12 or riff[0:4] != b"RIFF" or riff[8:12] != b"WAVE":
+                return None
+            sample_rate = n_channels = bits_per_sample = header_len = None
+            while True:
+                chunk_hdr = f.read(8)
+                if len(chunk_hdr) < 8:
+                    break
+                chunk_id, chunk_size = struct.unpack("<4sI", chunk_hdr)
+                if chunk_id == b"fmt ":
+                    fmt = f.read(chunk_size)
+                    if len(fmt) < 16:
+                        return None
+                    # 오프셋 2: nChannels(H), 4: nSamplesPerSec(I), 14: wBitsPerSample(H).
+                    # EXTENSIBLE(0xFFFE) 도 이 세 필드 위치는 동일하다.
+                    n_channels, sample_rate = struct.unpack("<HI", fmt[2:8])
+                    bits_per_sample = struct.unpack("<H", fmt[14:16])[0]
+                    if chunk_size & 1:   # 워드 정렬 패딩 바이트
+                        f.read(1)
+                elif chunk_id == b"data":
+                    # 오디오 바이트가 시작되는 오프셋. data 청크 size(손상 가능)는
+                    # 읽지 않고 여기서 멈춘다 — 손상된 size 로 전진하지 않게.
+                    header_len = f.tell()
+                    break
+                else:
+                    f.seek(chunk_size + (chunk_size & 1), 1)
+            if (sample_rate is None or n_channels is None
+                    or bits_per_sample is None or header_len is None):
+                return None
+            bytes_per_frame = (bits_per_sample // 8) * n_channels
+            if sample_rate <= 0 or bytes_per_frame <= 0:
+                return None
+            return sample_rate, bytes_per_frame, header_len
+    except OSError:
+        return None
+
+
 def _wav_duration(path):
-    """녹음 길이(초)를 파일 크기에서 직접 산출 — 헤더 손상에 면역.
+    """녹음 길이(초)를 파일 크기 + 실제 포맷에서 산출 — 헤더 손상에 면역.
 
     이전 구현은 ffprobe 로 WAV 헤더의 duration 을 읽었는데, rec(sox) 가
     SIGINT 종료 시 헤더를 finalize 하지 못하면(간헐적) 헤더에 sentinel
     거대값이 남아 실제 수 초짜리 녹음이 수 시간으로 잘못 읽혔다. 그 값이
-    MIN_SEC '너무 짧으면 무시' 가드를 통과해 whisper 가 폭주했다. 데몬은
-    고정 포맷(SAMPLE_RATE/CHANNELS/SAMPLE_BYTES)으로만 녹음하므로, 디스크에
-    실제로 쓰인 바이트 수가 길이의 신뢰 가능한 근거다.
+    MIN_SEC '너무 짧으면 무시' 가드를 통과해 whisper 가 폭주했다.
+
+    길이는 디스크에 실제로 쓰인 바이트 수에서 산출한다(손상되는 끝부분 size
+    필드가 아님). 바이트→길이 변환에 필요한 포맷(샘플레이트·프레임 바이트)과
+    헤더 길이는 시작 시점에 기록돼 온전한 `fmt ` 청크에서 읽으므로, rec 포맷
+    고정이 미반영돼도(예: 장치 기본 32-bit/EXTENSIBLE) 길이가 틀어지지 않는다.
     """
+    fmt = _read_wav_format(path)
+    if fmt is None:
+        return 0.0
+    sample_rate, bytes_per_frame, header_len = fmt
     try:
         size = os.path.getsize(path)
     except OSError:
         return 0.0
-    data_bytes = max(0, size - WAV_HEADER_BYTES)
-    return data_bytes / (SAMPLE_RATE * CHANNELS * SAMPLE_BYTES)
+    data_bytes = max(0, size - header_len)
+    return data_bytes / (sample_rate * bytes_per_frame)
 
 
 def _transcribe(path, timeout):

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -15,10 +15,13 @@
 중지: Ctrl+C
 """
 import fcntl
+import glob
 import os
+import queue
 import signal
 import subprocess
 import tempfile
+import threading
 import time
 
 from pynput import keyboard
@@ -31,12 +34,15 @@ PROMPT = "whisper, hotkey, active window, transcription, paste, 데몬, 핫키, 
 TRIGGER = keyboard.Key.alt_r   # 오른쪽 Option
 MIN_SEC = 0.3          # 이보다 짧은 녹음은 오발화로 간주, 무시
 # rec 녹음 포맷 — _wav_duration 의 크기→길이 산출이 이 값에 의존하므로
-# 아래 rec 호출 인자와 반드시 일치해야 한다.
+# 아래 rec 호출에서 -b/-e 로 명시 고정한다(sox 기본값에 의존하지 않음: 기본은
+# 장치 정밀도를 따라 32-bit/EXTENSIBLE 가 나올 수 있어 크기→길이 산식이 깨진다).
 SAMPLE_RATE = 16000
 CHANNELS = 1
-SAMPLE_BYTES = 2       # rec 기본 s16(16-bit signed) WAV
-WAV_HEADER_BYTES = 44  # 표준 WAV 헤더 크기
-WHISPER_MIN_TIMEOUT = 20.0    # 전사 타임아웃 하한(초)
+SAMPLE_BYTES = 2       # rec -b 16 -e signed-integer 로 고정한 s16(16-bit signed)
+WAV_HEADER_BYTES = 44  # 고정 s16 PCM 의 정규 WAV 헤더 크기
+# 전사 타임아웃 하한 — whisper-cli 는 매 호출 fresh 프로세스라 모델 콜드 로드 +
+# Metal 셰이더 컴파일(첫 호출 수십 초 가능) 비용을 짧은 발화에서도 흡수해야 한다.
+WHISPER_MIN_TIMEOUT = 40.0
 WHISPER_TIMEOUT_FACTOR = 4.0  # 실제 오디오 길이 대비 타임아웃 배수
 WAV = os.path.join(tempfile.gettempdir(), "voice_dictation.wav")
 LOCK = os.path.join(tempfile.gettempdir(), "voice_dictation.lock")
@@ -44,6 +50,8 @@ LOCK = os.path.join(tempfile.gettempdir(), "voice_dictation.lock")
 _rec_proc = None
 _recording = False
 _lock_fp = None        # 단일 인스턴스 락 fd — 프로세스 수명 동안 열어 둬 락 유지
+_transcribe_q = queue.Queue()  # (snapshot, dur) FIFO 큐 — 단일 consumer 워커가 순서대로 전사
+_wav_seq = 0           # WAV 스냅샷 고유 카운터(리스너 단일 스레드에서만 증가)
 
 
 def _start_recording():
@@ -57,9 +65,12 @@ def _start_recording():
         os.remove(WAV)
     except FileNotFoundError:
         pass
-    # 16kHz mono. SIGINT 으로 종료해야 sox 가 WAV 헤더를 정상 finalize 함.
+    # 16kHz mono s16. -b/-e 로 포맷을 고정해 _wav_duration 의 크기→길이 산식
+    # (SAMPLE_BYTES/WAV_HEADER_BYTES)이 항상 성립하게 한다. SIGINT 으로 종료해야
+    # sox 가 WAV 헤더를 정상 finalize 함.
     _rec_proc = subprocess.Popen(
-        ["rec", "-q", "-r", str(SAMPLE_RATE), "-c", str(CHANNELS), WAV],
+        ["rec", "-q", "-b", str(SAMPLE_BYTES * 8), "-e", "signed-integer",
+         "-r", str(SAMPLE_RATE), "-c", str(CHANNELS), WAV],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
@@ -67,7 +78,7 @@ def _start_recording():
 
 
 def _stop_and_transcribe():
-    global _rec_proc, _recording
+    global _rec_proc, _recording, _wav_seq
     if not _recording:
         return
     _recording = False
@@ -77,23 +88,54 @@ def _stop_and_transcribe():
             _rec_proc.wait(timeout=2)
         except subprocess.TimeoutExpired:
             _rec_proc.kill()
+            _rec_proc.wait()   # SIGKILL 후 reap — 미종료 writer 의 파일을 전사하지 않게
         _rec_proc = None
 
+    # 오발화(짧은 brush)는 스냅샷·스레드를 만들기 전에 리스너 스레드에서 바로 거른다
+    # — 무의미한 워커가 쌓이지 않게. _wav_duration 은 getsize 뿐이라 즉시 반환된다.
     dur = _wav_duration(WAV)
     if dur < MIN_SEC:
         print(f"  (무시: {dur:.2f}s)", flush=True)
         return
 
-    timeout = max(WHISPER_MIN_TIMEOUT, dur * WHISPER_TIMEOUT_FACTOR)
-    print(f"  전사 중… ({dur:.1f}s, 타임아웃 {timeout:.0f}s)", flush=True)
-    t0 = time.time()
-    text = _transcribe(WAV, timeout)
-    dt = time.time() - t0
-    if not text:
-        print("  (빈 결과)", flush=True)
+    # WAV 를 고유 스냅샷으로 옮긴 뒤 전사를 FIFO 큐에 넣는다. 두 가지를 동시에
+    # 해결한다: (1) pynput 리스너 콜백 스레드를 즉시 풀어, 전사(최대 timeout 초)
+    # 동안 다음 키 입력·녹음이 막히거나 macOS 이벤트 탭이 비활성화되지 않게 한다.
+    # (2) 다음 녹음이 같은 WAV 경로를 덮어써 전사 중인 파일을 훼손하는 race 를 막는다.
+    _wav_seq += 1
+    snapshot = f"{WAV}.{_wav_seq}"
+    try:
+        os.replace(WAV, snapshot)
+    except OSError:
+        # rec 가 파일을 못 만든 경우(장치 점유/권한 오류 등) — 조용히 종료
         return
-    print(f"  ⤷ ({dt:.1f}s) {text}", flush=True)
-    _inject(text)
+    _transcribe_q.put((snapshot, dur))
+
+
+def _transcribe_worker():
+    # 단일 consumer 워커(데몬). 큐에서 순서대로(FIFO) 꺼내 한 번에 하나씩 전사·주입
+    # 하므로 발화 순서가 보존되고, 워커 스레드는 프로세스 전체에 정확히 하나만 존재한다.
+    # 한 전사의 예외가 워커(=전체 파이프라인)를 죽이지 않도록 폭넓게 잡아 로깅만 한다.
+    while True:
+        path, dur = _transcribe_q.get()
+        try:
+            timeout = max(WHISPER_MIN_TIMEOUT, dur * WHISPER_TIMEOUT_FACTOR)
+            print(f"  전사 중… ({dur:.1f}s, 타임아웃 {timeout:.0f}s)", flush=True)
+            t0 = time.time()
+            text = _transcribe(path, timeout)
+            dt = time.time() - t0
+            if not text:
+                print("  (빈 결과)", flush=True)
+                continue
+            print(f"  ⤷ ({dt:.1f}s) {text}", flush=True)
+            _inject(text)
+        except Exception as exc:
+            print(f"  (전사 오류 — 건너뜀: {exc})", flush=True)
+        finally:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
 
 
 def _wav_duration(path):
@@ -172,11 +214,19 @@ def _acquire_singleton_lock():
 
 def main():
     _acquire_singleton_lock()
+    # 이전 비정상 종료(전사 중 프로세스 kill)로 남은 전사 스냅샷 정리. 단일 인스턴스
+    # 락 획득 후이므로 다른 인스턴스의 진행 중 스냅샷을 건드리지 않는다.
+    for stale in glob.glob(f"{WAV}.*"):
+        try:
+            os.remove(stale)
+        except OSError:
+            pass
     if not os.path.exists(MODEL):
         raise SystemExit(f"모델 없음: {MODEL}")
     print("voice-dictation 프로토타입 — 오른쪽 Option(⌥) 홀드로 받아쓰기. 중지: Ctrl+C")
     print(f"  모델: {os.path.basename(MODEL)} | 언어: {LANG}")
     print("  (첫 전사는 모델 콜드 로드로 다소 느릴 수 있음)")
+    threading.Thread(target=_transcribe_worker, daemon=True).start()
     with keyboard.Listener(on_press=_on_press, on_release=_on_release) as listener:
         listener.join()
 


### PR DESCRIPTION
## Problem

`rec`(sox) occasionally fails to finalize the WAV header when stopped via SIGINT. The resulting file has a corrupt header that declares a sentinel duration — observed: a 104K / ~3.3s recording declared as ~33554s (≈9.3h). `_wav_duration` read that value via `ffprobe`, it passed the `MIN_SEC < 0.3s` guard unchanged, and `whisper-cli` was then invoked synchronously with **no timeout** → unbounded CPU/RAM grind (4.6GB RSS, multi-minute fan spin).

## Root Cause

Two independent failures required to combine:
1. `rec` header corruption (intermittent, triggered by SIGINT timing)
2. No timeout on the `whisper-cli` subprocess

## Fix

**`_wav_duration`** — drop `ffprobe`; derive duration from actual bytes on disk.  
The daemon records in a fixed format (`16kHz / mono / s16`), so `(file_size − 44) / (16000 × 1 × 2)` is header-corruption-immune. New constants (`SAMPLE_RATE`, `CHANNELS`, `SAMPLE_BYTES`, `WAV_HEADER_BYTES`) are co-located with the `rec` call so they stay in sync.

**`_transcribe`** — add a `timeout` argument (`max(20s, dur × 4)`) passed to `subprocess.run`. On `TimeoutExpired`, `run()` kills the child and the daemon prints a warning and returns empty — no runaway.

## Version

`1.0.3` → `1.0.4`
