### PR TITLE
fix(voice-dictation): retune whisper prompt for bilingual ko/en dictation

### DIFF
--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -31,7 +31,13 @@ from pynput import keyboard
 MODEL = os.path.expanduser("~/whisper-models/ggml-large-v3-turbo-q5_0.bin")
 WHISPER_CLI = "whisper-cli"
 LANG = "auto"          # ko / en / auto
-PROMPT = "whisper, hotkey, active window, transcription, paste, 데몬, 핫키, 단축키, 음성 전사"
+# whisper 의 initial prompt — '명령'이 아니라 '편향'(soft bias, 약 224 토큰 상한).
+# 특정 용어를 나열하면 그 단어가 실제 발화에 없어도 출력에 끼어드는(hallucination)
+# 위험이 있어, 어휘 예시는 비운다. 대신 프롬프트 자체를 한국어+영문 혼합 스크립트로
+# 둬, 특정 어휘를 가리키지 않고 code-switching(영어 단어는 영문 그대로)만 구조적으로
+# 편향한다. 언어 선택은 LANG=auto 가 발화별로 담당하고(한/영 어느 쪽으로 말하든),
+# 이 프롬프트는 표기 스타일만 기울인다. 문법 교정·재작성은 이 층위로 불가(LLM 몫).
+PROMPT = "한국어와 English가 섞인 받아쓰기."
 TRIGGER = keyboard.Key.alt_r   # 오른쪽 Option
 MIN_SEC = 0.3          # 이보다 짧은 녹음은 오발화로 간주, 무시
 # rec 녹음 포맷 — whisper 친화적인 컴팩트 s16 PCM 으로 고정한다. _wav_duration


### PR DESCRIPTION
## Summary

Retunes the whisper initial prompt in the voice-dictation daemon for mixed Korean/English (code-switching) dictation.

The previous prompt was a domain keyword list (`whisper, hotkey, active window, ...`). Two problems with that shape:

- **Hallucination risk** — listing specific terms can push those words into the output even when they were not spoken (a known whisper prompt failure mode).
- **Wrong layer for "keep English in English"** — the goal is biasing *script/style*, not pinning vocabulary.

This change replaces it with a minimal Korean+Latin mixed-script phrase: `한국어와 English가 섞인 받아쓰기.` The mixed script structurally biases code-switching (English words stay in Latin script) without pointing at any specific vocabulary. Language selection is untouched — `LANG = "auto"` still detects ko/en per utterance, so full-Korean and full-English dictation both work.

Note: the whisper prompt is a *soft bias* (≈224-token cap), not an instruction. Grammar correction / rewriting is out of scope for this layer (it would need an LLM post-processing step).

## Test plan

- [ ] Re-toggle the dictation daemon, then dictate a mixed Korean+English sentence and confirm English terms stay in Latin script (not transliterated to Hangul)
- [ ] Dictate a full-English utterance and confirm it transcribes as English
- [ ] Dictate a full-Korean utterance and confirm no spurious English terms are inserted
