### PR TITLE
feat(remote-spawn)!: restore tmux-tracked spawn for network-drop recoverability

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -70,6 +70,11 @@
       "description": "Push-to-talk voice dictation daemon (whisper.cpp) transcribing speech into the active window"
     },
     {
+      "name": "remote-spawn",
+      "source": "./remote-spawn",
+      "description": "Spawn a backgrounded `claude --remote-control` session in any directory (tmux-tracked), reachable from the Claude app"
+    },
+    {
       "name": "excalidraw-host",
       "source": "./excalidraw-host",
       "description": "Self-host the official open-source Excalidraw whiteboard (clone + Vite dev server, no Docker)"

--- a/remote-spawn/.claude-plugin/plugin.json
+++ b/remote-spawn/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "remote-spawn",
+  "description": "Spawn a backgrounded `claude --remote-control` session in any directory (tmux-tracked), reachable from the Claude app",
+  "version": "3.0.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/remote-spawn/README.md
+++ b/remote-spawn/README.md
@@ -1,0 +1,34 @@
+# remote-spawn
+
+Spawn a backgrounded `claude --remote-control` session in **any directory**, tracked as a
+tmux session and reachable from the Claude app (claude.ai/code + mobile). No Telegram, no
+bridge — the running session *is* the aperture; voice input comes from the app's own
+dictation.
+
+```bash
+bash scripts/rc-spawn.sh spawn ~/projects/foo        # -> rc-foo, now in the app
+bash scripts/rc-spawn.sh spawn ~/projects/foo api    # custom name -> rc-api
+bash scripts/rc-spawn.sh list                        # running rc-* sessions + dirs
+bash scripts/rc-spawn.sh kill foo                     # SIGTERM + drop tmux session
+```
+
+One tmux session per name (`rc-<name>`), idempotent. The session lives until its claude
+exits (no auto-restart by design).
+
+On a fresh spawn the script generates the new session's id (a lowercased UUID, passed
+to claude as `--session-id`) and prints it as a `SESSION <uuid>` line right after
+`STARTED`. An initial prompt, when given, is passed after a `--` end-of-options separator
+(`claude --remote-control --name <name> --session-id <uuid> -- "<prompt>"`) so an
+arbitrary prompt can never be misparsed as a flag.
+
+## Why tmux + ps/SIGTERM
+- **tmux, not nohup/launchd** — `claude --remote-control` is an interactive TUI that wants
+  a PTY, and a tmux server launched from your terminal inherits its TCC grant, so sessions
+  work under TCC-protected dirs (`~/Downloads`, `~/Documents`, `~/Desktop`) where launchd
+  gets `Operation not permitted`.
+- **`ps` + SIGTERM on kill, not `pkill`** — on macOS `pkill -f` can't read claude's full
+  arg string and silently no-ops; `ps -o command` sees it. SIGTERM (not `-9`) lets
+  SessionEnd hooks (e.g. anamnesis memory) flush before exit.
+
+First launch in a never-opened directory may show a one-time folder-trust prompt inside the
+session — `tmux attach -t rc-<name>`, press Enter, detach with `Ctrl-b d`.

--- a/remote-spawn/scripts/rc-spawn.sh
+++ b/remote-spawn/scripts/rc-spawn.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Spawn / list / kill backgrounded `claude --remote-control` sessions — one per
+# directory, each tracked as a tmux session `rc-<name>` and reachable from the
+# Claude app (claude.ai/code + mobile). No Telegram, no bridge.
+#
+# Subcommands:
+#   spawn <dir> [name] [prompt]   start a remote-control session in <dir> (idempotent);
+#                                 [prompt], if given, is auto-submitted as the first
+#                                 message (passed positionally to claude). To pass a
+#                                 prompt you must also pass a name.
+#   list                 list running rc-* sessions and their dirs
+#   kill  <name>         SIGTERM the claude session, then drop its tmux session
+#
+# WHY tmux (not nohup/launchd): claude --remote-control runs an interactive TUI
+# that wants a PTY, and a tmux server launched from the user's terminal inherits
+# that terminal's TCC grant — so a session can live under TCC-protected dirs
+# (~/Downloads, ~/Documents, ~/Desktop) where launchd/nohup gets
+# "Operation not permitted". (Lesson carried over from the martin supervisor.)
+#
+# WHY ps+SIGTERM on kill (not pkill): on macOS pkill/pgrep can't read claude's
+# full arg string (KERN_PROCARGS), so `pkill -f "remote-control --name X"`
+# silently matches nothing. `ps -o command` does see it. SIGTERM (not -9) lets
+# SessionEnd hooks (e.g. anamnesis memory write) flush before exit.
+
+export TMUX_TMPDIR="${TMUX_TMPDIR:-$HOME/.tmux-sockets}"
+mkdir -p "$TMUX_TMPDIR"
+unset TMUX  # target the tmux daemon, not a nested client, if invoked from inside tmux
+
+# Copy-paste hint prefix. The user's interactive shell does NOT inherit the
+# relocated TMUX_TMPDIR above, so a bare `tmux attach`/`tmux ls` targets the
+# default socket and fails ("no server running"). Printed hints carry the socket.
+ATTACH_ENV="TMUX_TMPDIR=$TMUX_TMPDIR"
+
+# Reduce a path/name to a tmux- and shell-safe token: [A-Za-z0-9._-], no runs of '-'.
+sanitize() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-' | sed 's/--*/-/g; s/^-//; s/-$//'; }
+
+spawn() {
+  local dir="$1" name="$2" prompt="$3"
+  [ -n "$dir" ] || { echo "usage: rc-spawn.sh spawn <dir> [name] [prompt]" >&2; return 2; }
+  dir="$(cd "$dir" 2>/dev/null && pwd)" || { echo "ERROR: no such dir: $1" >&2; return 1; }
+  [ -n "$name" ] || name="$(basename "$dir")"
+  name="$(sanitize "$name")"
+  [ -n "$name" ] || { echo "ERROR: name resolves to empty (dir basename has no usable chars) — pass an explicit name" >&2; return 2; }
+  local sess="rc-$name"
+  if tmux has-session -t "$sess" 2>/dev/null; then
+    # report the dir the session is ACTUALLY running in (not the one just asked for),
+    # and flag a basename collision so it isn't a silent no-op.
+    local rdir; rdir="$(tmux display-message -p -t "$sess" '#{session_path}' 2>/dev/null)"
+    echo "ALREADY-RUNNING $name  (running in: ${rdir:-?})  attach: $ATTACH_ENV tmux attach -t $sess"
+    [ "$rdir" = "$dir" ] || echo "  note: requested $dir but rc-$name already runs in ${rdir:-?} — pass an explicit name to run a second session"
+    return 0
+  fi
+  # Fresh session id, minted only once we're actually spawning (below the
+  # idempotency guard, so the ALREADY-RUNNING path stays untouched). Claude Code
+  # validates --session-id as a UUID and stores the session file lowercase, but
+  # uuidgen emits uppercase — lowercase it; bail if it comes back empty.
+  local sid; sid="$(uuidgen | tr 'A-Z' 'a-z')"
+  [ -n "$sid" ] || { echo "ERROR: failed to generate a session id (is uuidgen available?)" >&2; return 1; }
+  # Build the claude command. name is sanitized to [A-Za-z0-9._-] so it needs no
+  # quoting; an optional prompt is arbitrary text, so single-quote it for the
+  # `sh -c` that tmux runs. Escape embedded ' as '\'' via bash expansion (no sed).
+  local cmd="claude --remote-control --name $name --session-id $sid"
+  if [ -n "$prompt" ]; then
+    # Escape each ' as '\'' in a standalone assignment (embedding the expansion
+    # inside the double-quoted cmd "...'${p//.../...}'..." mangles the backslashes).
+    # '--' ends option parsing so an arbitrary prompt can't be misread as a flag
+    # or as the `--remote-control [name]` optional positional.
+    local esc=${prompt//\'/\'\\\'\'}
+    cmd="$cmd -- '$esc'"
+  fi
+  # Detached tmux session running claude directly; when claude exits the session ends.
+  tmux new-session -d -s "$sess" -x 220 -y 55 -c "$dir" "$cmd"
+  echo "STARTED $name  (dir: $dir)"
+  echo "SESSION $sid"
+  [ -n "$prompt" ] && echo "  -> initial prompt queued (auto-submits once the session is ready)"
+  echo "  -> now reachable in the Claude app (claude.ai/code + mobile)"
+  echo "  -> attach: $ATTACH_ENV tmux attach -t $sess   |   kill: rc-spawn.sh kill $name"
+  echo "  note: first launch in a never-opened dir shows a one-time folder-trust prompt"
+  echo "        inside the session (any queued prompt waits behind it) — attach once,"
+  echo "        press Enter, detach (Ctrl-b d); the prompt then submits."
+}
+
+list() {
+  local out
+  out="$(tmux list-sessions -F '#{session_name}'$'\t''#{session_path}' 2>/dev/null \
+        | awk -F'\t' '$1 ~ /^rc-/ {printf "  %-22s %s\n", substr($1,4), $2}')"
+  if [ -n "$out" ]; then
+    echo "running remote-control sessions:"; printf '%s\n' "$out"
+    echo "  attach: $ATTACH_ENV tmux attach -t rc-<name>   |   ls: $ATTACH_ENV tmux ls"
+  else
+    echo "(no rc-* sessions running)"
+  fi
+}
+
+kill_one() {
+  local name; name="$(sanitize "$1")"
+  [ -n "$name" ] || { echo "usage: rc-spawn.sh kill <name>" >&2; return 2; }
+  local sess="rc-$name" pids pid found=0 i
+  # sanitize() allows '.', the only ERE metachar a name can carry — escape it so
+  # `kill my.proj` can't also match `--name myXproj` (a different session).
+  local rname="${name//./\\.}"
+  # SIGTERM every matching claude, not just the first: a collision or a half-finished
+  # earlier teardown can leave more than one process on the same name.
+  pids="$(ps -Ao pid=,command= | grep -E "remote-control --name ${rname}([[:space:]]|\$)" | grep -v grep | awk '{print $1}')"
+  for pid in $pids; do
+    kill "$pid" 2>/dev/null && { echo "SIGTERM -> claude pid $pid ($name)"; found=1; }
+  done
+  # claude exiting cleanly ends its own tmux session (see spawn), so wait for that
+  # instead of racing it — gives SessionEnd hooks (anamnesis) time to flush. Only
+  # hard-drop the session if it outlives the bounded wait (~15s).
+  if [ "$found" = 1 ]; then
+    for i in $(seq 1 30); do
+      tmux has-session -t "$sess" 2>/dev/null || break
+      sleep 0.5
+    done
+  fi
+  if tmux has-session -t "$sess" 2>/dev/null; then
+    tmux kill-session -t "$sess" 2>/dev/null && { echo "dropped tmux $sess"; found=1; }
+  fi
+  [ "$found" = 0 ] && echo "NOT-FOUND $name"
+  return 0
+}
+
+case "${1:-}" in
+  spawn) spawn "${2:-}" "${3:-}" "${4:-}";;
+  list)  list;;
+  kill)  kill_one "${2:-}";;
+  *) echo "usage: rc-spawn.sh {spawn <dir> [name] [prompt] | list | kill <name>}" >&2; exit 2;;
+esac

--- a/remote-spawn/skills/remote-spawn/SKILL.md
+++ b/remote-spawn/skills/remote-spawn/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: remote-spawn
+description: >
+  This skill should be used when the user asks to "spawn a remote-control session",
+  "open this repo/folder in the Claude app", "remote control here", "띄워줘",
+  "이 디렉터리에서 remote-control 켜줘", or to list/kill those sessions. It launches
+  `claude --remote-control` in a chosen directory as a backgrounded tmux session
+  (`rc-<name>`) reachable from claude.ai/code and the mobile app — no Telegram bridge.
+---
+
+# Remote-Control Spawner
+
+Spawn, list, and kill backgrounded `claude --remote-control` sessions — one per
+directory, each a tmux session `rc-<name>` reachable from the Claude app.
+
+Run the script and report the result concisely:
+
+```bash
+# Spawn in a directory (name defaults to the dir's basename)
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> [name]
+
+# Spawn WITH an initial prompt — auto-submitted as the session's first message.
+# To pass a prompt you must also pass a name (it is the 3rd positional arg). The
+# prompt is passed to claude after a `--` separator (claude --remote-control ... -- "<prompt>").
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> <name> "<prompt>"
+
+# List running sessions
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" list
+
+# Kill one by name
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" kill <name>
+```
+
+- `STARTED <name>` → a remote-control session is now live in `<dir>` and appears in
+  the Claude app. The accompanying `SESSION <uuid>` line is the new session's id
+  (a lowercased UUID, passed to claude as `--session-id`). Relay the attach/kill
+  hints from the output.
+- `ALREADY-RUNNING <name>` → idempotent; a session for that name already exists.
+- `NOT-FOUND <name>` → nothing matched on kill.
+
+Notes to pass on when relevant:
+- The session lives until its claude exits (no auto-restart by design).
+- First launch in a directory Claude has never opened may show a one-time
+  folder-trust prompt **inside** the tmux session — `TMUX_TMPDIR=~/.tmux-sockets tmux attach -t rc-<name>`,
+  press Enter, then detach with `Ctrl-b d`. **A queued initial prompt waits
+  behind this trust gate** and submits only after trust is confirmed.
+- tmux is used (not nohup/launchd) so sessions work under TCC-protected dirs
+  (`~/Downloads`, `~/Documents`, `~/Desktop`); kill uses `ps`+SIGTERM so SessionEnd
+  hooks (e.g. anamnesis memory) flush before exit.


### PR DESCRIPTION
## What

Restore the **tmux-tracked `remote-spawn` plugin** — revert the native-`--bg` migration
(`e4db48e`) and the plugin removal (`81fc82a`). Brings back `rc-spawn.sh` + skill + README +
`plugin.json` and its `marketplace.json` catalog entry, at the last tmux version (`e1948d4`).
`2.0.0` (native, reverted) → **`3.0.0`** (tmux-tracked).

## Why

The native `claude --bg --remote-control --worktree <name> -- "<task>"` recipe that replaced
this plugin requires an **interactive re-login when the network drops** — fatal for a
long-running worker (e.g. `/review-loop … until convergence`). The tmux approach does not:

- pre-generates a **known** `--session-id` → recoverable by id via `claude --resume <sid>`
- runs claude in a **tmux pane** → re-attachable while live (`tmux attach`)
- rides the **keychain OAuth token** → auto-refreshes when the network returns, no re-login

Durability is the **harness's** to guarantee (the session persists on disk, resumable by id).
This plugin's only job is to give that session a *known id* and a *re-attachable surface* —
exactly what the native recipe lost. The plugin's `no auto-restart by design` is intentional
and correct: recovery is resume-by-id, not respawn.

### On the `81fc82a` irreducibility rationale

The deletion argued the wrapper "fails the irreducibility test — a native one-liner."
But the native one-liner is **not equivalent**: it regresses network-drop recoverability
(the fatal re-login above). So the tmux glue is not a thin passthrough — it carries
**irreducible recovery value** (known session-id + re-attachable tmux surface + keychain
auth) the native recipe cannot reproduce. That value, not the list/kill convenience, is what
justifies the plugin form.

## Side effect — un-breaks a downstream skill

`hermeneutic-assistant`'s `.claude/skills/triage-ship-review/scripts/spawn-worker.sh` resolves
`rc-spawn.sh` from this plugin (`installed_plugins.json`); the deletion left it pointing at a
missing path. The restored script's `STARTED` / `ALREADY-RUNNING` + line-1-name parse contract
matches what `spawn-worker.sh` expects, so this restore fixes that skill's worker-spawn path.

## Verification

- `marketplace.json` and `plugin.json` valid JSON; `rc-spawn.sh` passes `bash -n`
- restored tree is byte-for-byte the reviewed `e1948d4` tmux version (only the version string
  and the re-added catalog entry differ)
- worktree-isolated off `origin/main`; no unrelated changes staged
