### PR TITLE
feat(srs): personal SRS card generator + Anki push (AnkiConnect)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -98,6 +98,11 @@
       "name": "hotspot-toggle",
       "source": "./hotspot-toggle",
       "description": "Mac Wi-Fi toggle between iPhone Personal Hotspot and known networks via Control Center automation"
+    },
+    {
+      "name": "srs",
+      "source": "./srs",
+      "description": "Personal spaced-repetition (SRS) card store + review"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -102,7 +102,7 @@
     {
       "name": "srs",
       "source": "./srs",
-      "description": "Personal spaced-repetition (SRS) card store + review"
+      "description": "Personal SRS card generator — draft cards from your notes and push them into Anki via AnkiConnect"
     }
   ]
 }

--- a/srs/.claude-plugin/plugin.json
+++ b/srs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "srs",
-  "description": "Personal spaced-repetition (SRS) card store + review",
+  "description": "Personal SRS card generator — draft cards from your notes and push them into Anki via AnkiConnect",
   "version": "1.0.0",
   "author": {
     "name": "Jongwon Choi",

--- a/srs/.claude-plugin/plugin.json
+++ b/srs/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "srs",
+  "description": "Personal spaced-repetition (SRS) card store + review",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/srs/skills/srs/SKILL.md
+++ b/srs/skills/srs/SKILL.md
@@ -1,21 +1,23 @@
 ---
 name: srs
 description: |
-  This skill should be used when the user asks to "review my cards", "do my
-  spaced repetition", "srs review", "what's due today", "add a flashcard",
-  "grade a card", or wants to study/recall saved notes on a spacing schedule.
-  A personal, single-user spaced-repetition (SRS) card store with an SM-2-style
-  scheduler — cards live in ~/.claude/srs/cards.json, reviewed interactively
-  over stdin. Also triggers for automated invocation via /loop 1d /srs:srs review.
-  Distinct from note-taking or summarization: this schedules recall, not capture.
-argument-hint: "[review|due|add|grade]"
+  This skill should be used when the user asks to "make flashcards", "turn these
+  notes into cards", "add this to Anki", "push cards to Anki", "make Anki cards
+  from X", or wants to capture something for spaced-repetition study. It drafts
+  Q/A cards from the user's material, stages them with provenance, and pushes
+  them into Anki via the AnkiConnect addon. Anki owns review, scheduling, and
+  visualization — this skill owns capture + provenance, not the review loop.
+  Also triggers for automated invocation via /loop 1d /srs:srs push.
+argument-hint: "[add|list|push]"
 ---
 
-# SRS — Personal Spaced Repetition
+# SRS — Card Generator + Anki Push
 
-A lightweight, single-user spaced-repetition tool. Cards are stored in
-`~/.claude/srs/cards.json`; the scheduler is an SM-2-style scheme (SM-2 is the
-classic SuperMemo spacing algorithm). Pure Python standard library, run via `uv`.
+A personal card *generator* for spaced repetition. It drafts flashcards from your
+Extended Mind (notes, decks, Claude sessions), stages them in
+`~/.claude/srs/cards.json` with provenance, and pushes them into **Anki** through
+the AnkiConnect addon. **Anki owns review, scheduling, and visualization** — this
+tool deliberately does not reimplement a review loop (Anki does it better).
 Respond in the user's language.
 
 The engine is one self-contained script — reference it as:
@@ -24,86 +26,77 @@ The engine is one self-contained script — reference it as:
 ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py
 ```
 
-Run every subcommand through `uv run` so the inline PEP 723 metadata resolves:
+Run every subcommand through `uv run`:
 
 ```
 uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py <subcommand> [args]
 ```
 
+## Prerequisite
+
+Pushing needs **Anki running with the [AnkiConnect](https://ankiweb.net/shared/info/2055492159) addon** (listens on `http://127.0.0.1:8765`). If Anki is closed, `push` fails with an actionable message — start Anki (`open -a Anki`) and retry. Override the endpoint with `ANKICONNECT_URL`; override the store dir with `SRS_DATA_DIR`.
+
 ## Subcommands
 
 | Input | Behavior |
 |-------|----------|
-| (empty) | Default to `review` — run the interactive loop over due cards |
-| `review` | Interactive review loop (the primary surface; see below) |
-| `due` | Print cards due today or earlier, as a JSON array |
-| `add` | Append one card — from `--id/--front/--back/--source-ref` flags, or a JSON object on stdin |
-| `grade <id> <again\|hard\|good\|easy>` | Apply a grade to one card and reschedule it |
+| `add` | Stage one card — from `--id/--front/--back/--source-ref/--tag/--deck` flags, or a JSON object on stdin (skips a duplicate `id`) |
+| `list` | List staged cards as JSON (`--unpushed` for only un-pushed) |
+| `push` | Push staged cards into Anki via AnkiConnect (`--all` re-pushes everything; `--dry-run` prints the payload without sending) |
 
-State directory override: set `SRS_DATA_DIR` to point the store somewhere other
-than `~/.claude/srs` (useful for testing without touching real cards).
+The store is a **staging ledger**: each card records `pushed` (date or null) and
+`anki_note_id`, so re-running `push` (including from `/loop`) only sends new cards
+— never double-creates.
 
-## Review loop (primary surface)
+## How Claude uses it (the generation step)
 
-`review` is interactive over stdin — no AI model sits in the per-card loop, so it
-is the lightest surface. It loads due cards, then for each one:
+Card *drafting* is Claude's job (it is heuristic, not deterministic, so it lives
+here, not in the script). When the user points at material to study:
 
-1. prints the `front` (the question),
-2. waits for you to recall, then on Enter prints the `back` (the answer) and any `source_refs`,
-3. reads a grade from stdin and reschedules the card.
-
-Grade keys accept the full word, its first letter, or a number, plus skip/quit:
-
-```
-1 / a / again    2 / h / hard    3 / g / good    4 / e / easy    s = skip    q = quit
-```
-
-Each grade is persisted immediately, so quitting mid-session keeps the progress so
-far. When nothing is due, the loop says so and exits.
-
-## Adding cards
-
-Two equivalent forms — pick whichever the caller has on hand:
+1. Read the source (a note, a deck slide, a passage, a session excerpt).
+2. Draft tight Q/A cards — one idea per card; the `front` prompts recall, the
+   `back` gives the answer plus the "aha" link (e.g. a root → meaning bridge).
+3. `add` each card, filling **`--source-ref`** with where it came from
+   (`note-123#p2`, `etymonline.com/word/salience`) — provenance that rides into
+   Anki as a `src::<ref>` tag, linking each card back to the Extended Mind.
+4. `push` to Anki. Report how many landed (and any duplicates Anki rejected).
 
 ```bash
-# flags
+# stage (flags)
 uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py add \
-  --id note-123#p2 --front "What does SM-2 schedule?" \
-  --back "The next review interval from ease × prior interval." \
-  --source-ref "note-123#p2"
+  --id "etymonline#salience" --front "salience — 어근과 '두드러짐'의 연결?" \
+  --back "라틴 salire '뛰다' + -ence → 튀어나옴 → 두드러짐 (punctum saliens)" \
+  --source-ref "etymonline.com/word/salience" --tag etymology --deck "Etymology"
 
-# JSON object on stdin
-echo '{"id":"deck.html#slide-3","front":"...","back":"...","source_refs":["deck.html#slide-3"]}' \
+# stage (JSON on stdin)
+echo '{"id":"deck.html#s3","front":"...","back":"...","source_refs":["deck.html#s3"]}' \
   | uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py add
+
+# inspect, then push to Anki
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py list --unpushed
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py push
 ```
 
-`source_refs` is provenance metadata (e.g. `"note-123#p2"`, `"deck.html#slide-3"`)
-— whatever creates a card fills it in; the engine just stores and surfaces it.
-A new card defaults to ease 2.5, reps 0, interval 0, lapses 0, and is due today
-(so it shows up in the next review). Re-adding an existing `id` is a no-op (skip).
+Cards land in the `--deck` deck (default **"Extended Mind"**) using Anki's
+**Basic** note type (Front/Back). `source_refs` and any `--tag` become Anki tags.
 
-## Scheduling (SM-2-style)
+## Reviewing
 
-On `grade`, `reps` is read **before** it is updated; the first-review guards give a
-fresh card an absolute interval so an initial `interval_days = 0` is never
-multiplied into zero:
-
-- **again** — interval → 1 day; ease − 0.2; lapses + 1; reps reset to 0 (a lapse restarts the ladder)
-- **hard** — first review → 1 day, else interval × 1.2; ease − 0.15; reps + 1
-- **good** — first → 1 day, second → 3 days, else interval × ease; reps + 1
-- **easy** — first → 3 days, else interval × (ease + 0.15) × 1.3; ease + 0.15; reps + 1
-
-After every grade: ease is clamped to a floor of 1.3, `last_reviewed` is set to
-today, and `due` becomes today + round(interval) days.
+Review happens **in Anki** — open Anki and study the deck (desktop, mobile,
+AnkiWeb, with full scheduling and stats). This tool intentionally has no `review`
+subcommand; pushing the card hands it to Anki's scheduler.
 
 ## Daily run
 
-Review once a day via the existing `/loop` skill, using the namespaced skill form:
+Flush any newly-staged cards into Anki once a day via the existing `/loop` skill:
 
 ```
-/loop 1d /srs:srs review
+/loop 1d /srs:srs push
 ```
 
-Plugin skills are namespaced as `{plugin-name}:{skill-name}`; the bare `/srs` form
-only resolves for a user-level skill installation. No separate scheduler code — the
-`/loop` skill carries the cadence.
+Plugin skills are namespaced as `{plugin-name}:{skill-name}`; the bare `/srs`
+form only resolves for a user-level skill installation. The `pushed` ledger makes
+this safe to repeat — already-pushed cards are skipped. (Anki must be running for
+the push to land; otherwise the loop reports the connection error and the cards
+stay staged for the next run.) No separate scheduler code — `/loop` carries the
+cadence, Anki carries the spacing.

--- a/srs/skills/srs/SKILL.md
+++ b/srs/skills/srs/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: srs
+description: |
+  This skill should be used when the user asks to "review my cards", "do my
+  spaced repetition", "srs review", "what's due today", "add a flashcard",
+  "grade a card", or wants to study/recall saved notes on a spacing schedule.
+  A personal, single-user spaced-repetition (SRS) card store with an SM-2-style
+  scheduler — cards live in ~/.claude/srs/cards.json, reviewed interactively
+  over stdin. Also triggers for automated invocation via /loop 1d /srs:srs review.
+  Distinct from note-taking or summarization: this schedules recall, not capture.
+argument-hint: "[review|due|add|grade]"
+---
+
+# SRS — Personal Spaced Repetition
+
+A lightweight, single-user spaced-repetition tool. Cards are stored in
+`~/.claude/srs/cards.json`; the scheduler is an SM-2-style scheme (SM-2 is the
+classic SuperMemo spacing algorithm). Pure Python standard library, run via `uv`.
+Respond in the user's language.
+
+The engine is one self-contained script — reference it as:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py
+```
+
+Run every subcommand through `uv run` so the inline PEP 723 metadata resolves:
+
+```
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py <subcommand> [args]
+```
+
+## Subcommands
+
+| Input | Behavior |
+|-------|----------|
+| (empty) | Default to `review` — run the interactive loop over due cards |
+| `review` | Interactive review loop (the primary surface; see below) |
+| `due` | Print cards due today or earlier, as a JSON array |
+| `add` | Append one card — from `--id/--front/--back/--source-ref` flags, or a JSON object on stdin |
+| `grade <id> <again\|hard\|good\|easy>` | Apply a grade to one card and reschedule it |
+
+State directory override: set `SRS_DATA_DIR` to point the store somewhere other
+than `~/.claude/srs` (useful for testing without touching real cards).
+
+## Review loop (primary surface)
+
+`review` is interactive over stdin — no AI model sits in the per-card loop, so it
+is the lightest surface. It loads due cards, then for each one:
+
+1. prints the `front` (the question),
+2. waits for you to recall, then on Enter prints the `back` (the answer) and any `source_refs`,
+3. reads a grade from stdin and reschedules the card.
+
+Grade keys accept the full word, its first letter, or a number, plus skip/quit:
+
+```
+1 / a / again    2 / h / hard    3 / g / good    4 / e / easy    s = skip    q = quit
+```
+
+Each grade is persisted immediately, so quitting mid-session keeps the progress so
+far. When nothing is due, the loop says so and exits.
+
+## Adding cards
+
+Two equivalent forms — pick whichever the caller has on hand:
+
+```bash
+# flags
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py add \
+  --id note-123#p2 --front "What does SM-2 schedule?" \
+  --back "The next review interval from ease × prior interval." \
+  --source-ref "note-123#p2"
+
+# JSON object on stdin
+echo '{"id":"deck.html#slide-3","front":"...","back":"...","source_refs":["deck.html#slide-3"]}' \
+  | uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py add
+```
+
+`source_refs` is provenance metadata (e.g. `"note-123#p2"`, `"deck.html#slide-3"`)
+— whatever creates a card fills it in; the engine just stores and surfaces it.
+A new card defaults to ease 2.5, reps 0, interval 0, lapses 0, and is due today
+(so it shows up in the next review). Re-adding an existing `id` is a no-op (skip).
+
+## Scheduling (SM-2-style)
+
+On `grade`, `reps` is read **before** it is updated; the first-review guards give a
+fresh card an absolute interval so an initial `interval_days = 0` is never
+multiplied into zero:
+
+- **again** — interval → 1 day; ease − 0.2; lapses + 1; reps reset to 0 (a lapse restarts the ladder)
+- **hard** — first review → 1 day, else interval × 1.2; ease − 0.15; reps + 1
+- **good** — first → 1 day, second → 3 days, else interval × ease; reps + 1
+- **easy** — first → 3 days, else interval × (ease + 0.15) × 1.3; ease + 0.15; reps + 1
+
+After every grade: ease is clamped to a floor of 1.3, `last_reviewed` is set to
+today, and `due` becomes today + round(interval) days.
+
+## Daily run
+
+Review once a day via the existing `/loop` skill, using the namespaced skill form:
+
+```
+/loop 1d /srs:srs review
+```
+
+Plugin skills are namespaced as `{plugin-name}:{skill-name}`; the bare `/srs` form
+only resolves for a user-level skill installation. No separate scheduler code — the
+`/loop` skill carries the cadence.

--- a/srs/skills/srs/scripts/srs.py
+++ b/srs/skills/srs/scripts/srs.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+"""Personal spaced-repetition (SRS) card store + SM-2-style grade/schedule engine.
+
+Standard library only. State lives in ~/.claude/srs/cards.json (override the
+directory with the SRS_DATA_DIR env var, e.g. for tests). A card is a dict:
+
+    id, front, back, source_refs (list[str]), due (YYYY-MM-DD),
+    interval_days (number), ease (number), reps (int), lapses (int),
+    last_reviewed (YYYY-MM-DD or null)
+
+Subcommands: due | grade <id> <again|hard|good|easy> | add | review
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+EASE_FLOOR = 1.3
+GRADES = ("again", "hard", "good", "easy")
+
+# New-card defaults. interval_days starts at 0; the `reps == 0` guards in
+# apply_grade give a first review an absolute interval so 0 is never multiplied.
+DEFAULTS = {
+    "source_refs": [],
+    "interval_days": 0,
+    "ease": 2.5,
+    "reps": 0,
+    "lapses": 0,
+    "last_reviewed": None,
+}
+
+
+# --- state file -----------------------------------------------------------
+
+def data_dir() -> Path:
+    return Path(os.environ.get("SRS_DATA_DIR", str(Path.home() / ".claude" / "srs")))
+
+
+def cards_path() -> Path:
+    return data_dir() / "cards.json"
+
+
+def load_cards() -> list:
+    path = cards_path()
+    if not path.exists():
+        return []
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save_cards(cards: list) -> None:
+    d = data_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    path = cards_path()
+    tmp = path.with_suffix(".json.tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(cards, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+    os.replace(tmp, path)  # atomic on the same filesystem
+
+
+def today_str() -> str:
+    return date.today().isoformat()
+
+
+def find_card(cards: list, card_id: str):
+    for card in cards:
+        if card.get("id") == card_id:
+            return card
+    return None
+
+
+# --- scheduling -----------------------------------------------------------
+
+def apply_grade(card: dict, grade: str) -> dict:
+    """Apply an SM-2-style update to `card` in place and return it.
+
+    `reps` is read BEFORE it is updated so the first-review guards work off the
+    pre-update repetition count.
+    """
+    reps = int(card.get("reps", DEFAULTS["reps"]))
+    ease = float(card.get("ease", DEFAULTS["ease"]))
+    interval = float(card.get("interval_days", DEFAULTS["interval_days"]))
+    lapses = int(card.get("lapses", DEFAULTS["lapses"]))
+
+    if grade == "again":
+        interval = 1
+        ease -= 0.2
+        lapses += 1
+        reps = 0  # a lapse restarts the ladder
+    elif grade == "hard":
+        interval = 1 if reps == 0 else interval * 1.2
+        ease -= 0.15
+        reps += 1
+    elif grade == "good":
+        if reps == 0:
+            interval = 1
+        elif reps == 1:
+            interval = 3
+        else:
+            interval = interval * ease
+        reps += 1
+    elif grade == "easy":
+        interval = 3 if reps == 0 else interval * (ease + 0.15) * 1.3
+        ease += 0.15
+        reps += 1
+    else:
+        raise ValueError(f"unknown grade {grade!r}; expected one of {GRADES}")
+
+    ease = max(ease, EASE_FLOOR)
+    today = date.today()
+    card["interval_days"] = interval
+    card["ease"] = ease
+    card["reps"] = reps
+    card["lapses"] = lapses
+    card["last_reviewed"] = today.isoformat()
+    card["due"] = (today + timedelta(days=round(interval))).isoformat()
+    return card
+
+
+# --- subcommands ----------------------------------------------------------
+
+def cmd_due(_args) -> int:
+    today = today_str()
+    cards = load_cards()
+    due = [c for c in cards if c.get("due", today) <= today]
+    due.sort(key=lambda c: (c.get("due", ""), str(c.get("id", ""))))
+    json.dump(due, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+def cmd_grade(args) -> int:
+    grade = args.grade.lower()
+    if grade not in GRADES:
+        print(f"[ERROR] grade must be one of {', '.join(GRADES)}", file=sys.stderr)
+        return 2
+    cards = load_cards()
+    card = find_card(cards, args.id)
+    if card is None:
+        print(f"[ERROR] no card with id {args.id!r}", file=sys.stderr)
+        return 1
+    apply_grade(card, grade)
+    save_cards(cards)
+    print(
+        f"{args.id}: {grade} -> due {card['due']} "
+        f"(interval {round(card['interval_days'])}d, ease {card['ease']:.2f}, "
+        f"reps {card['reps']}, lapses {card['lapses']})"
+    )
+    return 0
+
+
+def _new_card(fields: dict) -> dict:
+    card = dict(DEFAULTS)
+    card["source_refs"] = list(fields.get("source_refs", []) or [])
+    card["id"] = fields["id"]
+    card["front"] = fields.get("front", "")
+    card["back"] = fields.get("back", "")
+    # carry through any explicitly-provided scheduling fields, else default
+    for key in ("interval_days", "ease", "reps", "lapses", "last_reviewed"):
+        if key in fields and fields[key] is not None:
+            card[key] = fields[key]
+    # a fresh card is due today unless the caller pins a date
+    card["due"] = fields.get("due") or today_str()
+    return card
+
+
+def cmd_add(args) -> int:
+    if args.id is not None:
+        fields = {
+            "id": args.id,
+            "front": args.front or "",
+            "back": args.back or "",
+            "source_refs": args.source_ref or [],
+        }
+        if args.due:
+            fields["due"] = args.due
+    else:
+        # no --id flag: read a JSON object from stdin
+        raw = sys.stdin.read()
+        if not raw.strip():
+            print("[ERROR] add: provide --id ... or pipe a JSON object on stdin", file=sys.stderr)
+            return 2
+        fields = json.loads(raw)
+        if "id" not in fields:
+            print("[ERROR] add: stdin JSON object needs an 'id' field", file=sys.stderr)
+            return 2
+
+    cards = load_cards()
+    if find_card(cards, fields["id"]) is not None:
+        print(f"card {fields['id']!r} already exists, skipping", file=sys.stderr)
+        return 0
+    card = _new_card(fields)
+    cards.append(card)
+    save_cards(cards)
+    print(f"added {card['id']} (due {card['due']})")
+    return 0
+
+
+def _read_grade(prompt: str):
+    """Read a grade from stdin. Accepts full words, first letters, 1-4,
+    plus s(kip)/q(uit). Returns a grade string, 'skip', 'quit', or None on EOF.
+    """
+    aliases = {
+        "1": "again", "a": "again", "again": "again",
+        "2": "hard", "h": "hard", "hard": "hard",
+        "3": "good", "g": "good", "good": "good",
+        "4": "easy", "e": "easy", "easy": "easy",
+        "s": "skip", "skip": "skip",
+        "q": "quit", "quit": "quit",
+    }
+    while True:
+        try:
+            raw = input(prompt)
+        except EOFError:
+            return None
+        choice = aliases.get(raw.strip().lower())
+        if choice is not None:
+            return choice
+        print("  enter: 1/again  2/hard  3/good  4/easy  s/skip  q/quit")
+
+
+def cmd_review(_args) -> int:
+    today = today_str()
+    cards = load_cards()
+    due = [c for c in cards if c.get("due", today) <= today]
+    due.sort(key=lambda c: (c.get("due", ""), str(c.get("id", ""))))
+    if not due:
+        print("No cards due. ✨")
+        return 0
+
+    print(f"{len(due)} card(s) due.\n")
+    reviewed = 0
+    for idx, card in enumerate(due, 1):
+        print(f"[{idx}/{len(due)}] {card.get('id', '?')}")
+        print(f"  Q: {card.get('front', '')}")
+        try:
+            input("  (press Enter to reveal)")
+        except EOFError:
+            print("\n(input closed) stopping.")
+            break
+        print(f"  A: {card.get('back', '')}")
+        if card.get("source_refs"):
+            print(f"  refs: {', '.join(card['source_refs'])}")
+
+        grade = _read_grade("  grade [1/2/3/4 | a/h/g/e | s/q]: ")
+        if grade is None:
+            print("\n(input closed) stopping.")
+            break
+        if grade == "quit":
+            print("stopping.")
+            break
+        if grade == "skip":
+            print("  skipped.\n")
+            continue
+
+        apply_grade(card, grade)
+        save_cards(cards)  # persist after each grade so a mid-session quit keeps progress
+        reviewed += 1
+        print(
+            f"  -> {grade}: next due {card['due']} "
+            f"(interval {round(card['interval_days'])}d)\n"
+        )
+
+    print(f"\nReviewed {reviewed} card(s).")
+    return 0
+
+
+# --- entry point ----------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="srs", description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("due", help="print cards due today or earlier, as JSON")
+
+    p_grade = sub.add_parser("grade", help="apply a grade to a card and reschedule it")
+    p_grade.add_argument("id")
+    p_grade.add_argument("grade", help="again | hard | good | easy")
+
+    p_add = sub.add_parser("add", help="append a card (--id ... or JSON on stdin)")
+    p_add.add_argument("--id")
+    p_add.add_argument("--front")
+    p_add.add_argument("--back")
+    p_add.add_argument("--source-ref", action="append", dest="source_ref",
+                       help="provenance ref; repeat for multiple")
+    p_add.add_argument("--due", help="override the initial due date (YYYY-MM-DD)")
+
+    sub.add_parser("review", help="interactive review loop over due cards")
+    return parser
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    handlers = {
+        "due": cmd_due,
+        "grade": cmd_grade,
+        "add": cmd_add,
+        "review": cmd_review,
+    }
+    return handlers[args.cmd](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/srs/skills/srs/scripts/srs.py
+++ b/srs/skills/srs/scripts/srs.py
@@ -3,16 +3,25 @@
 # requires-python = ">=3.9"
 # dependencies = []
 # ///
-"""Personal spaced-repetition (SRS) card store + SM-2-style grade/schedule engine.
+"""Personal SRS card generator + Anki push (via AnkiConnect).
 
-Standard library only. State lives in ~/.claude/srs/cards.json (override the
-directory with the SRS_DATA_DIR env var, e.g. for tests). A card is a dict:
+Anki owns review, scheduling, and visualization; this tool owns capture and
+provenance. Flashcards drafted from your Extended Mind (notes, decks, Claude
+sessions) are staged in a ledger at ~/.claude/srs/cards.json, then pushed into
+Anki through the AnkiConnect addon (HTTP, localhost:8765). The ledger records
+what has been pushed so re-running (e.g. from /loop) never double-sends.
 
-    id, front, back, source_refs (list[str]), due (YYYY-MM-DD),
-    interval_days (number), ease (number), reps (int), lapses (int),
-    last_reviewed (YYYY-MM-DD or null)
+Overrides: SRS_DATA_DIR (store dir); ANKICONNECT_URL (default
+http://127.0.0.1:8765).
 
-Subcommands: due | grade <id> <again|hard|good|easy> | add | review
+A staged card:
+    id, front, back, source_refs (list[str]), tags (list[str]), deck (str),
+    added (YYYY-MM-DD), pushed (YYYY-MM-DD or null), anki_note_id (int or null)
+
+`source_refs` is provenance back into the Extended Mind (e.g. "note-123#p2",
+"deck.html#slide-3"); on push each becomes an Anki tag `src::<ref>`.
+
+Subcommands: add | list | push
 """
 from __future__ import annotations
 
@@ -20,25 +29,17 @@ import argparse
 import json
 import os
 import sys
-from datetime import date, timedelta
+import urllib.error
+import urllib.request
+from datetime import date
 from pathlib import Path
 
-EASE_FLOOR = 1.3
-GRADES = ("again", "hard", "good", "easy")
-
-# New-card defaults. interval_days starts at 0; the `reps == 0` guards in
-# apply_grade give a first review an absolute interval so 0 is never multiplied.
-DEFAULTS = {
-    "source_refs": [],
-    "interval_days": 0,
-    "ease": 2.5,
-    "reps": 0,
-    "lapses": 0,
-    "last_reviewed": None,
-}
+DEFAULT_DECK = "Extended Mind"
+DEFAULT_MODEL = "Basic"
+ANKICONNECT_URL = os.environ.get("ANKICONNECT_URL", "http://127.0.0.1:8765")
 
 
-# --- state file -----------------------------------------------------------
+# --- staging ledger ------------------------------------------------------
 
 def data_dir() -> Path:
     return Path(os.environ.get("SRS_DATA_DIR", str(Path.home() / ".claude" / "srs")))
@@ -78,99 +79,59 @@ def find_card(cards: list, card_id: str):
     return None
 
 
-# --- scheduling -----------------------------------------------------------
-
-def apply_grade(card: dict, grade: str) -> dict:
-    """Apply an SM-2-style update to `card` in place and return it.
-
-    `reps` is read BEFORE it is updated so the first-review guards work off the
-    pre-update repetition count.
-    """
-    reps = int(card.get("reps", DEFAULTS["reps"]))
-    ease = float(card.get("ease", DEFAULTS["ease"]))
-    interval = float(card.get("interval_days", DEFAULTS["interval_days"]))
-    lapses = int(card.get("lapses", DEFAULTS["lapses"]))
-
-    if grade == "again":
-        interval = 1
-        ease -= 0.2
-        lapses += 1
-        reps = 0  # a lapse restarts the ladder
-    elif grade == "hard":
-        interval = 1 if reps == 0 else interval * 1.2
-        ease -= 0.15
-        reps += 1
-    elif grade == "good":
-        if reps == 0:
-            interval = 1
-        elif reps == 1:
-            interval = 3
-        else:
-            interval = interval * ease
-        reps += 1
-    elif grade == "easy":
-        interval = 3 if reps == 0 else interval * (ease + 0.15) * 1.3
-        ease += 0.15
-        reps += 1
-    else:
-        raise ValueError(f"unknown grade {grade!r}; expected one of {GRADES}")
-
-    ease = max(ease, EASE_FLOOR)
-    today = date.today()
-    card["interval_days"] = interval
-    card["ease"] = ease
-    card["reps"] = reps
-    card["lapses"] = lapses
-    card["last_reviewed"] = today.isoformat()
-    card["due"] = (today + timedelta(days=round(interval))).isoformat()
-    return card
+def ref_to_tag(ref: str) -> str:
+    # Anki tags are space-separated, so a single tag cannot contain spaces.
+    return "src::" + "_".join(ref.split())
 
 
-# --- subcommands ----------------------------------------------------------
+# --- AnkiConnect (stdlib urllib; protocol-level, no Anki SDK) -------------
 
-def cmd_due(_args) -> int:
-    today = today_str()
-    cards = load_cards()
-    due = [c for c in cards if c.get("due", today) <= today]
-    due.sort(key=lambda c: (c.get("due", ""), str(c.get("id", ""))))
-    json.dump(due, sys.stdout, ensure_ascii=False, indent=2)
-    sys.stdout.write("\n")
-    return 0
-
-
-def cmd_grade(args) -> int:
-    grade = args.grade.lower()
-    if grade not in GRADES:
-        print(f"[ERROR] grade must be one of {', '.join(GRADES)}", file=sys.stderr)
-        return 2
-    cards = load_cards()
-    card = find_card(cards, args.id)
-    if card is None:
-        print(f"[ERROR] no card with id {args.id!r}", file=sys.stderr)
-        return 1
-    apply_grade(card, grade)
-    save_cards(cards)
-    print(
-        f"{args.id}: {grade} -> due {card['due']} "
-        f"(interval {round(card['interval_days'])}d, ease {card['ease']:.2f}, "
-        f"reps {card['reps']}, lapses {card['lapses']})"
+def anki_invoke(action: str, **params):
+    """POST one AnkiConnect action and return its result, or raise RuntimeError
+    on an AnkiConnect-level error / malformed response. Connection failures
+    surface as urllib.error.URLError for the caller to translate."""
+    body = json.dumps({"action": action, "version": 6, "params": params}).encode("utf-8")
+    req = urllib.request.Request(
+        ANKICONNECT_URL, data=body, headers={"Content-Type": "application/json"}
     )
-    return 0
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        try:
+            data = json.loads(resp.read().decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"non-JSON response from {ANKICONNECT_URL}: {exc}") from exc
+    if not isinstance(data, dict) or set(data.keys()) != {"result", "error"}:
+        raise RuntimeError(f"unexpected AnkiConnect response: {data!r}")
+    if data["error"] is not None:
+        raise RuntimeError(data["error"])
+    return data["result"]
 
+
+def card_to_note(card: dict) -> dict:
+    tags = list(card.get("tags", []) or [])
+    tags += [ref_to_tag(r) for r in (card.get("source_refs") or [])]
+    return {
+        "deckName": card.get("deck") or DEFAULT_DECK,
+        "modelName": DEFAULT_MODEL,
+        "fields": {"Front": card.get("front", ""), "Back": card.get("back", "")},
+        "tags": tags,
+        "options": {"allowDuplicate": False, "duplicateScope": "deck"},
+    }
+
+
+# --- subcommands ---------------------------------------------------------
 
 def _new_card(fields: dict) -> dict:
-    card = dict(DEFAULTS)
-    card["source_refs"] = list(fields.get("source_refs", []) or [])
-    card["id"] = fields["id"]
-    card["front"] = fields.get("front", "")
-    card["back"] = fields.get("back", "")
-    # carry through any explicitly-provided scheduling fields, else default
-    for key in ("interval_days", "ease", "reps", "lapses", "last_reviewed"):
-        if key in fields and fields[key] is not None:
-            card[key] = fields[key]
-    # a fresh card is due today unless the caller pins a date
-    card["due"] = fields.get("due") or today_str()
-    return card
+    return {
+        "id": fields["id"],
+        "front": fields.get("front", ""),
+        "back": fields.get("back", ""),
+        "source_refs": list(fields.get("source_refs") or []),
+        "tags": list(fields.get("tags") or []),
+        "deck": fields.get("deck") or DEFAULT_DECK,
+        "added": today_str(),
+        "pushed": None,
+        "anki_note_id": None,
+    }
 
 
 def cmd_add(args) -> int:
@@ -180,11 +141,11 @@ def cmd_add(args) -> int:
             "front": args.front or "",
             "back": args.back or "",
             "source_refs": args.source_ref or [],
+            "tags": args.tag or [],
         }
-        if args.due:
-            fields["due"] = args.due
+        if args.deck:
+            fields["deck"] = args.deck
     else:
-        # no --id flag: read a JSON object from stdin
         raw = sys.stdin.read()
         if not raw.strip():
             print("[ERROR] add: provide --id ... or pipe a JSON object on stdin", file=sys.stderr)
@@ -196,117 +157,104 @@ def cmd_add(args) -> int:
 
     cards = load_cards()
     if find_card(cards, fields["id"]) is not None:
-        print(f"card {fields['id']!r} already exists, skipping", file=sys.stderr)
+        print(f"card {fields['id']!r} already staged, skipping", file=sys.stderr)
         return 0
     card = _new_card(fields)
     cards.append(card)
     save_cards(cards)
-    print(f"added {card['id']} (due {card['due']})")
+    print(f"staged {card['id']} (deck '{card['deck']}', not yet pushed)")
     return 0
 
 
-def _read_grade(prompt: str):
-    """Read a grade from stdin. Accepts full words, first letters, 1-4,
-    plus s(kip)/q(uit). Returns a grade string, 'skip', 'quit', or None on EOF.
-    """
-    aliases = {
-        "1": "again", "a": "again", "again": "again",
-        "2": "hard", "h": "hard", "hard": "hard",
-        "3": "good", "g": "good", "good": "good",
-        "4": "easy", "e": "easy", "easy": "easy",
-        "s": "skip", "skip": "skip",
-        "q": "quit", "quit": "quit",
-    }
-    while True:
-        try:
-            raw = input(prompt)
-        except EOFError:
-            return None
-        choice = aliases.get(raw.strip().lower())
-        if choice is not None:
-            return choice
-        print("  enter: 1/again  2/hard  3/good  4/easy  s/skip  q/quit")
-
-
-def cmd_review(_args) -> int:
-    today = today_str()
+def cmd_list(args) -> int:
     cards = load_cards()
-    due = [c for c in cards if c.get("due", today) <= today]
-    due.sort(key=lambda c: (c.get("due", ""), str(c.get("id", ""))))
-    if not due:
-        print("No cards due. ✨")
+    if args.unpushed:
+        cards = [c for c in cards if not c.get("pushed")]
+    json.dump(cards, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+def cmd_push(args) -> int:
+    cards = load_cards()
+    pending = [c for c in cards if args.all or not c.get("pushed")]
+    if not pending:
+        print("Nothing to push. ✨")
         return 0
 
-    print(f"{len(due)} card(s) due.\n")
-    reviewed = 0
-    for idx, card in enumerate(due, 1):
-        print(f"[{idx}/{len(due)}] {card.get('id', '?')}")
-        print(f"  Q: {card.get('front', '')}")
-        try:
-            input("  (press Enter to reveal)")
-        except EOFError:
-            print("\n(input closed) stopping.")
-            break
-        print(f"  A: {card.get('back', '')}")
-        if card.get("source_refs"):
-            print(f"  refs: {', '.join(card['source_refs'])}")
+    notes = [card_to_note(c) for c in pending]
+    decks = sorted({n["deckName"] for n in notes})
 
-        grade = _read_grade("  grade [1/2/3/4 | a/h/g/e | s/q]: ")
-        if grade is None:
-            print("\n(input closed) stopping.")
-            break
-        if grade == "quit":
-            print("stopping.")
-            break
-        if grade == "skip":
-            print("  skipped.\n")
-            continue
+    if args.dry_run:
+        print(f"# dry-run: would push {len(pending)} card(s) to {ANKICONNECT_URL}")
+        print(f"# ensure decks exist: {decks}")
+        json.dump({"action": "addNotes", "notes": notes}, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 0
 
-        apply_grade(card, grade)
-        save_cards(cards)  # persist after each grade so a mid-session quit keeps progress
-        reviewed += 1
+    try:
+        for deck in decks:
+            anki_invoke("createDeck", deck=deck)  # idempotent
+        results = anki_invoke("addNotes", notes=notes)
+    except urllib.error.URLError as exc:
         print(
-            f"  -> {grade}: next due {card['due']} "
-            f"(interval {round(card['interval_days'])}d)\n"
+            f"[ERROR] cannot reach AnkiConnect at {ANKICONNECT_URL}: {exc.reason}\n"
+            f"        Is Anki running with the AnkiConnect addon installed? (open -a Anki)",
+            file=sys.stderr,
         )
+        return 1
+    except RuntimeError as exc:
+        print(f"[ERROR] AnkiConnect: {exc}", file=sys.stderr)
+        return 1
 
-    print(f"\nReviewed {reviewed} card(s).")
-    return 0
+    # addNotes returns a parallel list: a note id on success, null when Anki
+    # rejected the note (most commonly a duplicate within the deck).
+    pushed = failed = 0
+    for card, note_id in zip(pending, results):
+        if note_id is not None:
+            card["pushed"] = today_str()
+            card["anki_note_id"] = note_id
+            pushed += 1
+        else:
+            failed += 1
+            print(f"  ! {card['id']}: rejected by Anki (likely a duplicate)", file=sys.stderr)
+    save_cards(cards)
+
+    summary = f"pushed {pushed} card(s) to Anki"
+    if failed:
+        summary += f", {failed} rejected"
+    print(summary + f" (decks: {', '.join(decks)})")
+    return 0 if failed == 0 else 1
 
 
-# --- entry point ----------------------------------------------------------
+# --- entry point ---------------------------------------------------------
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="srs", description=__doc__)
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    sub.add_parser("due", help="print cards due today or earlier, as JSON")
-
-    p_grade = sub.add_parser("grade", help="apply a grade to a card and reschedule it")
-    p_grade.add_argument("id")
-    p_grade.add_argument("grade", help="again | hard | good | easy")
-
-    p_add = sub.add_parser("add", help="append a card (--id ... or JSON on stdin)")
+    p_add = sub.add_parser("add", help="stage a card (--id ... or JSON on stdin)")
     p_add.add_argument("--id")
     p_add.add_argument("--front")
     p_add.add_argument("--back")
     p_add.add_argument("--source-ref", action="append", dest="source_ref",
-                       help="provenance ref; repeat for multiple")
-    p_add.add_argument("--due", help="override the initial due date (YYYY-MM-DD)")
+                       help="provenance ref; repeat for multiple (→ Anki tag src::<ref>)")
+    p_add.add_argument("--tag", action="append", dest="tag", help="extra Anki tag; repeat")
+    p_add.add_argument("--deck", help=f"target Anki deck (default '{DEFAULT_DECK}')")
 
-    sub.add_parser("review", help="interactive review loop over due cards")
+    p_list = sub.add_parser("list", help="list staged cards as JSON")
+    p_list.add_argument("--unpushed", action="store_true", help="only cards not yet pushed")
+
+    p_push = sub.add_parser("push", help="push staged cards into Anki via AnkiConnect")
+    p_push.add_argument("--all", action="store_true", help="re-push every card, not just un-pushed")
+    p_push.add_argument("--dry-run", action="store_true",
+                        help="print the AnkiConnect payload without sending")
     return parser
 
 
 def main(argv=None) -> int:
     args = build_parser().parse_args(argv)
-    handlers = {
-        "due": cmd_due,
-        "grade": cmd_grade,
-        "add": cmd_add,
-        "review": cmd_review,
-    }
-    return handlers[args.cmd](args)
+    return {"add": cmd_add, "list": cmd_list, "push": cmd_push}[args.cmd](args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

A personal **SRS card generator** as a new `srs` plugin. It drafts flashcards from the Extended Mind (notes, decks, Claude sessions) and **pushes them into Anki via AnkiConnect**. Anki owns review, scheduling, and visualization — this tool owns capture + provenance.

> **Design note:** this PR pivoted mid-review. An earlier commit built a self-contained SM-2 review loop, but a stdin reviewer is a worse Anki (no stats/mobile/sync). Per the repo Northstar (*present understanding > artifact continuity*), the review engine was metabolized away; only the Anki-can't-do part remains. History kept on the branch.

- **`srs.py`** (stdlib only, PEP 723 + `uv`) — staging ledger at `~/.claude/srs/cards.json` (`SRS_DATA_DIR` / `ANKICONNECT_URL` overrides):
  - `add` — stage a card from `--id/--front/--back/--source-ref/--tag/--deck` flags **or** a JSON object on stdin (skips a duplicate `id`)
  - `list` — staged cards as JSON (`--unpushed`)
  - `push` — `addNotes` via AnkiConnect over stdlib `urllib` (`--dry-run` prints the payload; `--all` re-pushes). Records `pushed`/`anki_note_id`, so re-running (incl. `/loop`) never double-sends.
- **Provenance**: `source_refs` ride into Anki as `src::<ref>` tags, linking each card back to its source.
- **`SKILL.md`** — Claude drafts cards from material → `add` → `push`; daily run is `/loop 1d /srs:srs push`. Review happens in Anki.
- Registered in `.claude-plugin/marketplace.json`.

AnkiConnect satisfies CLAUDE.md's 3 import tests: irreducible (live add to Anki's collection), environment-neutral (stdlib `urllib`, no Anki SDK), SSOT-respecting (the official addon API, no DB mirroring).

## Verification

Against an isolated `SRS_DATA_DIR` (`uv run srs/skills/srs/scripts/srs.py <cmd>`):

- `add` (flags + stdin JSON, Korean content, deck/tags/source-ref) → `list --unpushed` → duplicate-skip ✓
- `push --dry-run` emits the correct AnkiConnect `addNotes` payload (deck split, `source_refs`→`src::` tags); dry-run leaves `pushed` untouched ✓
- `push` with no AnkiConnect listening → clean actionable error + exit 1 (no traceback) ✓
- Backward-compatible: pre-pivot cards already in the real store map cleanly to notes ✓
- Version-bump check: CI range-mode (the gate) passes — `srs` is a new plugin satisfied by its initial `1.0.0`.

> Live push needs Anki running with the AnkiConnect addon; not exercised in CI. `--dry-run` + the connection-error path are covered above.

Personal scope — leaving open for review, not merging.
