### PR TITLE
feat(card-mining): session-archive card-mining Span (sidecar + renderer)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -98,6 +98,11 @@
       "name": "hotspot-toggle",
       "source": "./hotspot-toggle",
       "description": "Mac Wi-Fi toggle between iPhone Personal Hotspot and known networks via Control Center automation"
+    },
+    {
+      "name": "srs",
+      "source": "./srs",
+      "description": "Personal spaced-repetition (SRS) card store + review"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -103,6 +103,11 @@
       "name": "srs",
       "source": "./srs",
       "description": "Personal SRS card generator — draft cards from your notes and push them into Anki via AnkiConnect"
+    },
+    {
+      "name": "card-mining",
+      "source": "./card-mining",
+      "description": "Mine Anki flashcards from your cross-project Claude session archive — a user-attended Span composing the epistemic protocols, a resumable run sidecar, and the srs Anki-push tool"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -102,7 +102,7 @@
     {
       "name": "srs",
       "source": "./srs",
-      "description": "Personal spaced-repetition (SRS) card store + review"
+      "description": "Personal SRS card generator — draft cards from your notes and push them into Anki via AnkiConnect"
     }
   ]
 }

--- a/card-mining/.claude-plugin/plugin.json
+++ b/card-mining/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "card-mining",
+  "description": "Mine Anki flashcards from your cross-project Claude session archive by composing the epistemic protocols (/ascend /inquire /induce /elicit), a resumable run sidecar, and the srs Anki-push tool",
+  "version": "0.1.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/card-mining/skills/card-mining/SKILL.md
+++ b/card-mining/skills/card-mining/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: card-mining
+description: |
+  This skill should be used when the user asks to "mine cards from my sessions",
+  "make Anki cards about <topic> from my history", "mine flashcards", "card-mine
+  <topic>", or wants to harvest spaced-repetition cards from their cross-project
+  Claude session archive about some topic or vague recall. It runs ONE
+  user-attended Span: recall the relevant sessions, gather evidence, abstract
+  patterns, let the user select, render selected items into cards, and push them
+  to Anki (TEST deck first). Composes the epistemic protocols and the srs push
+  tool — it does NOT reimplement them. Distinct from `srs` (which drafts cards
+  from material you point at directly); card-mining is the archive-mining Span.
+argument-hint: "<topic> [--dry-run] | resume <run-id> | harvest <run-id>"
+---
+
+# Card-Mining Span
+
+Mine flashcards from your **cross-project Claude session archive** by composing
+existing capability. This skill is an **orchestration recipe**, not an engine:
+the epistemic protocols do the thinking, a thin helper holds the run state, and
+the sibling `srs` plugin does the Anki push. Respond in the user's language.
+
+> **State lives outside this doc.** Two surfaces:
+> - **TaskList** — project each stage to a Task (`pending`/`in_progress`/`blocked`/`completed`) so progress is visible in ClaudePanel.
+> - **Run sidecar** — `~/.claude/srs/runs/<run-id>/run.json`, the resume ledger (per-stage checkpoint capsules + source_refs + resume handle). Written through the helper. TaskList *points* here; it is not the ledger.
+
+## Tools this Span composes
+
+| Role | What | How to reference |
+|------|------|------------------|
+| Sidecar + selection renderer (this plugin) | `card_mining.py` — `init` / `capsule` / `status` / `render` | `uv run ${CLAUDE_PLUGIN_ROOT}/skills/card-mining/scripts/card_mining.py` |
+| Anki push (sibling `srs` plugin) | `srs.py` — `add` / `push` | the `srs` plugin's `skills/srs/scripts/srs.py` (install it from this marketplace; it carries its own plugin root via `/srs:srs`) |
+| Protocols (installed skills) | `/ascend` `/inquire` `/induce` `/elicit` | invoked at run time — **never reimplement them here** |
+
+Set once per run for the commands below:
+
+```bash
+CM="uv run ${CLAUDE_PLUGIN_ROOT}/skills/card-mining/scripts/card_mining.py"
+SRS="uv run <path-to-srs-plugin>/skills/srs/scripts/srs.py"   # the sibling srs plugin
+```
+
+## Prerequisites
+
+- The protocol skills (`/ascend` `/inquire` `/induce` `/elicit`) installed.
+- The sibling **`srs`** plugin installed (push step), and for a live push, **Anki running with the AnkiConnect addon** (`open -a Anki`).
+- Session archive at `~/.claude/projects/<project-slug>/` (`hypomnesis/` summaries + `<session-uuid>.jsonl` raw), cross-project.
+
+## Authority and gate-out policy
+
+- This Span **resolves ORDINARY forks in place** — which evidence spans to read, induce refinements, card phrasing.
+- **Gate OUT to the user** (relay the fork, do not decide it) when a step: contradicts an explicit constraint here · changes scope or the stop condition · or creates new durable substrate (a new skill, a write to a non-TEST Anki deck).
+- **Selection (stage 5)** and any **live push (stage 7)** are *always* user gates, answered by the user directly.
+
+## Run lifecycle
+
+```bash
+# start a run (prints run-id on line 1, sidecar path on line 2)
+RUN=$($CM init "<topic>" | head -1)          # add --dry-run for selection-table-only
+$CM status "$RUN"                            # per-stage status + resume handle
+```
+
+After each stage, checkpoint to the sidecar **and** update the matching Task.
+A capsule is a small, source-backed JSON patch piped on stdin
+(`in`/`out`/`source_refs`/`status`), e.g.:
+
+```bash
+echo '{"out": {...stage output...}, "source_refs": ["projects/<slug>/<sess>.jsonl#L120-160"]}' \
+  | $CM capsule "$RUN" --stage 2 --status completed
+```
+
+## Stages
+
+Each stage: **goal · protocol invocation · budget · checkpoint · validation · gate-out.**
+
+1. **Recall** — `/ascend <topic>` → a session group. Budget: 1× ascend.
+   Checkpoint stage 1: `out` = recognized unit + per-deposit source/resume handles; `source_refs` ≥ 1.
+   Validate: ≥ 1 source handle. **Gate-out:** the recognized unit is ambiguous.
+2. **Gather** — `/inquire` over the session group → bounded evidence. Budget: bounded source spans only (read raw `~/.claude/projects/<slug>/<session>.jsonl` only for those spans; cross-project `rg` only as a fallback).
+   Checkpoint stage 2: `out` = evidence items, **each with `source_refs`**.
+   Validate: every item has source_refs. **Gate-out:** the `rg` fallback exceeds budget.
+3. **Abstract** — `/induce` → patterns. Budget: max 5 refine cycles.
+   Checkpoint stage 3: `out` = patterns + source_refs. Validate: each pattern traces to sources.
+4. **Sharpen** — `/elicit` **only if** the carding intent is axis-undetermined; else **skip**.
+   Checkpoint: `--status skipped` (or `completed` with the sharpened axis). Skipped stages do not block resume.
+5. **Select** — emit **ONE table**, classified from the induce output + source_refs (not prose):
+
+   | id | claim/pattern | source_refs | bucket | confidence | proposed | reason |
+   |----|---------------|-------------|--------|------------|----------|--------|
+
+   `bucket ∈ {memorize, continuous_cognition, layout_only}` — **only `memorize` becomes a card.**
+   Store the table as the stage-5 capsule, then **gate to the user** for the picked ids:
+   ```bash
+   echo '{"out": {"table": [ {"id":"c1","claim":"...","source_refs":["..."],"bucket":"memorize","confidence":"high","proposed":true,"reason":"..."}, ... ]}, "status":"completed"}' \
+     | $CM capsule "$RUN" --stage 5
+   ```
+   Validate: reject source-less candidates (the renderer enforces this too). **Gate-out:** user selection (always).
+6. **Render** — selected ids → card notes. Card front/back **drafting is your heuristic job** (one idea per card; the front prompts recall, the back gives the answer plus the "aha" link). The helper does the deterministic join: it keeps only picked **memorize** rows, rejects source-less ones, pulls `source_refs` from the table, and stamps a staleness tag (`mining-run::<run-id>`, `mined-as-of::<date>`). Pipe your drafted bodies in (keyed by row id), pipe the rendered card JSONL straight into `srs add`:
+   ```bash
+   $CM render "$RUN" --pick c1,c3 --deck TEST <<'BODIES' \
+     | while IFS= read -r card; do printf '%s' "$card" | $SRS add; done
+   {"c1": {"front": "...", "back": "...", "extra": "optional — appended to back", "tags": ["topic"]},
+    "c3": {"front": "...", "back": "..."}}
+   BODIES
+   ```
+   The rendered cards are also persisted as the stage-6 capsule (resume-safe). Then checkpoint stage 6 `--status completed`.
+7. **Push** — via the `srs` tool; **TEST deck first** (the renderer defaults `--deck TEST`).
+   ```bash
+   $SRS push --dry-run     # inspect the AnkiConnect payload, no contact
+   $SRS push               # land in the TEST deck
+   ```
+   **Gate-out:** a live push to a **real** (non-TEST) deck — get the user's go, then re-render with `--deck "<real deck>"` (or re-stage) before pushing. In a `--dry-run` run, stop after the selection table with no push.
+
+## Stop condition
+
+User-selected `memorize` cards pushed to Anki (TEST deck) + a short report. In dry-run mode: the selection table delivered, no push.
+
+## Harvest / Resume
+
+- **Harvest** `harvest <run-id>` — read the sidecar (`$CM status "$RUN"`) + the TaskList. Deliverable = the selection table + pushed-card count + the sidecar pointer.
+- **Resume** `resume <run-id>` — on kill, `$CM status "$RUN"` prints the resume handle (first non-completed stage). Re-enter there using that stage's **input capsule** from the sidecar; do not redo completed stages.
+
+## Constraints
+
+Personal, lightweight, **compose — do not reimplement**. New code → feature branch → PR (merge is user-held). **Dry-run before any live push.** Every card carries `source_refs`; source-less candidates never become cards.

--- a/card-mining/skills/card-mining/scripts/card_mining.py
+++ b/card-mining/skills/card-mining/scripts/card_mining.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+"""Card-mining Span sidecar + selection renderer (the deterministic glue).
+
+This is the *thin* supporting tool for the card-mining Span Runbook. It does NOT
+mine cards — the epistemic protocols (/ascend /inquire /induce /elicit) do that
+at run time, and card drafting (front/back) is the model's heuristic job. This
+script owns only the two deterministic concerns the recipe needs:
+
+  (a) Run sidecar  — a per-run checkpoint ledger at
+        ~/.claude/srs/runs/<run-id>/run.json
+      One entry per Span stage (status + in/out capsule + source_refs), so a
+      killed run can re-enter at the first non-completed stage (the resume
+      handle). `init` / `capsule` / `status`.
+
+  (b) Selection renderer — `render` turns user-picked rows of the stage-5
+      selection table into card JSON in the *srs* plugin's `add` shape, emitted
+      as JSONL on stdout. It does the deterministic join+validation:
+        - keep only rows the user picked AND bucketed `memorize`
+        - reject source-less candidates (provenance is mandatory)
+        - pull source_refs from the table (the provenance SSOT), not the body
+        - stamp a staleness tag so a card is traceable to its mining run/date
+      front/back come from the model on stdin; this just assembles & validates.
+
+Composition is by pipe, not import: `render ... | while read; do ... srs add`.
+The sibling `srs` plugin owns the actual Anki push.
+
+Overrides: SRS_DATA_DIR (store root; shared with the srs plugin, default
+~/.claude/srs). Runs live under <store>/runs/.
+
+Subcommands: init | capsule | status | render
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+# Stage skeleton mirrors the Span Runbook (card-mining-span.md). Stage 4
+# (Sharpen / elicit) is conditional — mark it `skipped` when not run.
+STAGES = [
+    (1, "Recall"),    # /ascend  <topic>      -> session group
+    (2, "Gather"),    # /inquire              -> bounded evidence + source_refs
+    (3, "Abstract"),  # /induce               -> patterns + source_refs
+    (4, "Sharpen"),   # /elicit  (optional)   -> carding-axis sharpened
+    (5, "Select"),    # selection table       -> user picks ids (user gate)
+    (6, "Render"),    # picked memorize rows  -> card notes
+    (7, "Push"),      # srs add/push          -> Anki TEST deck (user gate on live)
+]
+STAGE_STATUSES = ["pending", "in_progress", "completed", "blocked", "skipped"]
+# Treated as "done" when computing the resume handle.
+DONE_STATUSES = {"completed", "skipped"}
+DEFAULT_DECK = "TEST"  # recipe: TEST deck first; live push to a real deck is a user gate
+
+
+# --- store layout (shared root with the srs plugin) ----------------------
+
+def data_dir() -> Path:
+    return Path(os.environ.get("SRS_DATA_DIR", str(Path.home() / ".claude" / "srs")))
+
+
+def runs_dir() -> Path:
+    return data_dir() / "runs"
+
+
+def run_dir(run_id: str) -> Path:
+    return runs_dir() / run_id
+
+
+def run_path(run_id: str) -> Path:
+    return run_dir(run_id) / "run.json"
+
+
+def save_run(run: dict) -> None:
+    d = run_dir(run["run_id"])
+    d.mkdir(parents=True, exist_ok=True)
+    path = run_path(run["run_id"])
+    tmp = path.with_suffix(".json.tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(run, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+    os.replace(tmp, path)  # atomic on the same filesystem
+
+
+def load_run(run_id: str) -> dict:
+    path = run_path(run_id)
+    if not path.exists():
+        raise SystemExit(f"[ERROR] no such run: {run_id!r} (expected {path})")
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def find_stage(run: dict, n: int) -> dict:
+    for stage in run["stages"]:
+        if stage["n"] == n:
+            return stage
+    raise SystemExit(f"[ERROR] run {run['run_id']!r} has no stage {n}")
+
+
+def now_iso() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def slugify(text: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")
+    return s[:40] or "run"
+
+
+def read_stdin_json():
+    """Parse a JSON value piped on stdin; return None when nothing is piped.
+
+    Guarded by isatty() so an interactive invocation does not block waiting on
+    stdin.
+    """
+    if sys.stdin.isatty():
+        return None
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return None
+    return json.loads(raw)
+
+
+# --- subcommands ---------------------------------------------------------
+
+def cmd_init(args) -> int:
+    now = datetime.now()
+    run_id = now.strftime("%Y%m%d-%H%M%S") + "-" + slugify(args.topic)
+    if run_path(run_id).exists():
+        raise SystemExit(f"[ERROR] run {run_id!r} already exists")
+    stages = [
+        {"n": n, "name": name, "status": "pending",
+         "in": None, "out": None, "source_refs": [], "note": None}
+        for n, name in STAGES
+    ]
+    run = {
+        "run_id": run_id,
+        "topic": args.topic,
+        "created": now.isoformat(timespec="seconds"),
+        "dry_run": bool(args.dry_run),
+        "stages": stages,
+        "updated": now.isoformat(timespec="seconds"),
+    }
+    save_run(run)
+    # run_id on the first line so callers can capture it ($(... | head -1)).
+    print(run_id)
+    print(run_path(run_id))
+    return 0
+
+
+def cmd_capsule(args) -> int:
+    """Write/update one stage's checkpoint capsule.
+
+    A JSON object on stdin is a patch: its `in`/`out`/`note` keys replace the
+    stage's, `source_refs` (if present) replaces the list, `status` sets status
+    unless --status overrides. --status / --source-ref flags apply last.
+    """
+    run = load_run(args.run_id)
+    stage = find_stage(run, args.stage)
+
+    patch = read_stdin_json()
+    if patch is not None:
+        if not isinstance(patch, dict):
+            raise SystemExit("[ERROR] capsule: stdin must be a JSON object")
+        for key in ("in", "out", "note"):
+            if key in patch:
+                stage[key] = patch[key]
+        if "source_refs" in patch:
+            stage["source_refs"] = list(patch["source_refs"] or [])
+        if "status" in patch and not args.status:
+            if patch["status"] not in STAGE_STATUSES:
+                raise SystemExit(f"[ERROR] capsule: bad status {patch['status']!r}")
+            stage["status"] = patch["status"]
+
+    if args.status:
+        stage["status"] = args.status
+    if args.source_ref:
+        for ref in args.source_ref:
+            if ref not in stage["source_refs"]:
+                stage["source_refs"].append(ref)
+
+    run["updated"] = now_iso()
+    save_run(run)
+    print(f"stage {stage['n']} {stage['name']}: {stage['status']} "
+          f"(source_refs: {len(stage['source_refs'])})")
+    return 0
+
+
+def cmd_status(args) -> int:
+    run = load_run(args.run_id)
+    if args.json:
+        json.dump(run, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    print(f"run: {run['run_id']}  (topic: {run['topic']!r})")
+    print(f"created: {run['created']}   dry_run: {run['dry_run']}")
+    resume = None
+    for stage in run["stages"]:
+        refs = stage["source_refs"]
+        mark = f"  source_refs:{len(refs)}" if refs else ""
+        print(f"  {stage['n']} {stage['name']:<9} [{stage['status']}]{mark}")
+        if resume is None and stage["status"] not in DONE_STATUSES:
+            resume = stage
+    if resume is not None:
+        print(f"resume -> stage {resume['n']} {resume['name']} "
+              f"(re-enter with its input capsule)")
+    else:
+        print("resume -> all stages completed/skipped (harvest)")
+    print(f"sidecar: {run_path(run['run_id'])}")
+    return 0
+
+
+def cmd_render(args) -> int:
+    """Render user-picked memorize rows into card JSONL for `srs add`.
+
+    Selection table is read from the sidecar (stage-5 `out.table`, a list of
+    rows: id, claim, source_refs, bucket, confidence, proposed, reason). Card
+    bodies (front/back/extra?/tags?) come on stdin keyed by row id — those are
+    the model's stage-6 draft. Output is one JSON card per line on stdout (the
+    srs `add` shape); the stage-6 capsule is persisted with the same cards plus
+    the rejection log.
+    """
+    run = load_run(args.run_id)
+    sel = find_stage(run, args.table_stage)
+    out = sel.get("out") or {}
+    table = out.get("table")
+    if not table:
+        raise SystemExit(
+            f"[ERROR] stage {args.table_stage} has no selection table; "
+            f"capsule its out.table first")
+    rows = {str(r["id"]): r for r in table}
+
+    picks = [p.strip() for p in args.pick.split(",") if p.strip()]
+    if not picks:
+        raise SystemExit("[ERROR] render: --pick is empty")
+
+    bodies = read_stdin_json() or {}
+    if not isinstance(bodies, dict):
+        raise SystemExit("[ERROR] render: stdin card bodies must be a JSON object keyed by id")
+
+    as_of = args.as_of or date.today().isoformat()
+    cards: list = []
+    rejected: list = []
+
+    for pid in picks:
+        row = rows.get(pid)
+        if row is None:
+            rejected.append((pid, "not in selection table"))
+            continue
+        if row.get("bucket") != "memorize":
+            rejected.append((pid, f"bucket={row.get('bucket')!r} (only memorize -> cards)"))
+            continue
+        refs = list(row.get("source_refs") or [])
+        if not refs:
+            rejected.append((pid, "source-less candidate (rejected)"))
+            continue
+        body = bodies.get(pid) or {}
+        front = (body.get("front") or "").strip()
+        back = (body.get("back") or "").strip()
+        if not front or not back:
+            rejected.append((pid, "no front/back body provided on stdin"))
+            continue
+        if body.get("extra"):
+            back = back + "\n\n" + str(body["extra"]).strip()
+        # Staleness: a card mined from the session archive may drift from the
+        # current understanding — tag it with run + as-of so it stays traceable.
+        tags = list(body.get("tags") or [])
+        tags += [f"mining-run::{run['run_id']}", f"mined-as-of::{as_of}"]
+        cards.append({
+            "id": f"{run['run_id']}::{pid}",
+            "front": front,
+            "back": back,
+            "source_refs": refs,
+            "tags": tags,
+            "deck": args.deck,
+        })
+
+    # Persist the stage-6 capsule (resume-safe) and aggregate its source_refs.
+    rstage = find_stage(run, 6)
+    agg_refs: list = []
+    for card in cards:
+        for ref in card["source_refs"]:
+            if ref not in agg_refs:
+                agg_refs.append(ref)
+    rstage["out"] = {
+        "cards": cards,
+        "rejected": [{"id": i, "why": w} for i, w in rejected],
+        "as_of": as_of,
+        "deck": args.deck,
+        "picked": picks,
+    }
+    rstage["source_refs"] = agg_refs
+    if rstage["status"] == "pending":
+        rstage["status"] = "in_progress"
+    run["updated"] = now_iso()
+    save_run(run)
+
+    for card in cards:
+        sys.stdout.write(json.dumps(card, ensure_ascii=False) + "\n")
+    for pid, why in rejected:
+        print(f"  ! {pid}: {why}", file=sys.stderr)
+    print(f"rendered {len(cards)} card(s), {len(rejected)} rejected "
+          f"-> deck {args.deck!r} (as-of {as_of})", file=sys.stderr)
+    # Non-zero only when the user picked rows but none rendered — a real miss.
+    return 0 if cards or not picks else 1
+
+
+# --- entry point ---------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="card_mining", description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_init = sub.add_parser("init", help="create a run sidecar for a topic")
+    p_init.add_argument("topic", help="the topic / vague recall to mine cards about")
+    p_init.add_argument("--dry-run", action="store_true",
+                        help="mark this run dry-run (selection table only, no live push)")
+
+    p_cap = sub.add_parser("capsule", help="write/update a stage checkpoint capsule (JSON patch on stdin)")
+    p_cap.add_argument("run_id")
+    p_cap.add_argument("--stage", type=int, required=True, choices=range(1, 8), metavar="N")
+    p_cap.add_argument("--status", choices=STAGE_STATUSES)
+    p_cap.add_argument("--source-ref", action="append", dest="source_ref",
+                       help="append a provenance ref; repeat for multiple")
+
+    p_st = sub.add_parser("status", help="show per-stage status + resume handle")
+    p_st.add_argument("run_id")
+    p_st.add_argument("--json", action="store_true", help="dump the raw run ledger as JSON")
+
+    p_rn = sub.add_parser("render", help="render picked memorize rows -> card JSONL for `srs add`")
+    p_rn.add_argument("run_id")
+    p_rn.add_argument("--pick", required=True, help="comma-separated selection-table row ids")
+    p_rn.add_argument("--deck", default=DEFAULT_DECK,
+                      help=f"target Anki deck (default {DEFAULT_DECK!r})")
+    p_rn.add_argument("--as-of", dest="as_of", help="staleness date (default: today)")
+    p_rn.add_argument("--table-stage", dest="table_stage", type=int, default=5,
+                      help="stage whose out.table holds the selection table (default 5)")
+    return parser
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    return {
+        "init": cmd_init,
+        "capsule": cmd_capsule,
+        "status": cmd_status,
+        "render": cmd_render,
+    }[args.cmd](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/srs/.claude-plugin/plugin.json
+++ b/srs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "srs",
-  "description": "Personal spaced-repetition (SRS) card store + review",
+  "description": "Personal SRS card generator — draft cards from your notes and push them into Anki via AnkiConnect",
   "version": "1.0.0",
   "author": {
     "name": "Jongwon Choi",

--- a/srs/.claude-plugin/plugin.json
+++ b/srs/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "srs",
+  "description": "Personal spaced-repetition (SRS) card store + review",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/srs/skills/srs/SKILL.md
+++ b/srs/skills/srs/SKILL.md
@@ -1,21 +1,23 @@
 ---
 name: srs
 description: |
-  This skill should be used when the user asks to "review my cards", "do my
-  spaced repetition", "srs review", "what's due today", "add a flashcard",
-  "grade a card", or wants to study/recall saved notes on a spacing schedule.
-  A personal, single-user spaced-repetition (SRS) card store with an SM-2-style
-  scheduler — cards live in ~/.claude/srs/cards.json, reviewed interactively
-  over stdin. Also triggers for automated invocation via /loop 1d /srs:srs review.
-  Distinct from note-taking or summarization: this schedules recall, not capture.
-argument-hint: "[review|due|add|grade]"
+  This skill should be used when the user asks to "make flashcards", "turn these
+  notes into cards", "add this to Anki", "push cards to Anki", "make Anki cards
+  from X", or wants to capture something for spaced-repetition study. It drafts
+  Q/A cards from the user's material, stages them with provenance, and pushes
+  them into Anki via the AnkiConnect addon. Anki owns review, scheduling, and
+  visualization — this skill owns capture + provenance, not the review loop.
+  Also triggers for automated invocation via /loop 1d /srs:srs push.
+argument-hint: "[add|list|push]"
 ---
 
-# SRS — Personal Spaced Repetition
+# SRS — Card Generator + Anki Push
 
-A lightweight, single-user spaced-repetition tool. Cards are stored in
-`~/.claude/srs/cards.json`; the scheduler is an SM-2-style scheme (SM-2 is the
-classic SuperMemo spacing algorithm). Pure Python standard library, run via `uv`.
+A personal card *generator* for spaced repetition. It drafts flashcards from your
+Extended Mind (notes, decks, Claude sessions), stages them in
+`~/.claude/srs/cards.json` with provenance, and pushes them into **Anki** through
+the AnkiConnect addon. **Anki owns review, scheduling, and visualization** — this
+tool deliberately does not reimplement a review loop (Anki does it better).
 Respond in the user's language.
 
 The engine is one self-contained script — reference it as:
@@ -24,86 +26,77 @@ The engine is one self-contained script — reference it as:
 ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py
 ```
 
-Run every subcommand through `uv run` so the inline PEP 723 metadata resolves:
+Run every subcommand through `uv run`:
 
 ```
 uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py <subcommand> [args]
 ```
 
+## Prerequisite
+
+Pushing needs **Anki running with the [AnkiConnect](https://ankiweb.net/shared/info/2055492159) addon** (listens on `http://127.0.0.1:8765`). If Anki is closed, `push` fails with an actionable message — start Anki (`open -a Anki`) and retry. Override the endpoint with `ANKICONNECT_URL`; override the store dir with `SRS_DATA_DIR`.
+
 ## Subcommands
 
 | Input | Behavior |
 |-------|----------|
-| (empty) | Default to `review` — run the interactive loop over due cards |
-| `review` | Interactive review loop (the primary surface; see below) |
-| `due` | Print cards due today or earlier, as a JSON array |
-| `add` | Append one card — from `--id/--front/--back/--source-ref` flags, or a JSON object on stdin |
-| `grade <id> <again\|hard\|good\|easy>` | Apply a grade to one card and reschedule it |
+| `add` | Stage one card — from `--id/--front/--back/--source-ref/--tag/--deck` flags, or a JSON object on stdin (skips a duplicate `id`) |
+| `list` | List staged cards as JSON (`--unpushed` for only un-pushed) |
+| `push` | Push staged cards into Anki via AnkiConnect (`--all` re-pushes everything; `--dry-run` prints the payload without sending) |
 
-State directory override: set `SRS_DATA_DIR` to point the store somewhere other
-than `~/.claude/srs` (useful for testing without touching real cards).
+The store is a **staging ledger**: each card records `pushed` (date or null) and
+`anki_note_id`, so re-running `push` (including from `/loop`) only sends new cards
+— never double-creates.
 
-## Review loop (primary surface)
+## How Claude uses it (the generation step)
 
-`review` is interactive over stdin — no AI model sits in the per-card loop, so it
-is the lightest surface. It loads due cards, then for each one:
+Card *drafting* is Claude's job (it is heuristic, not deterministic, so it lives
+here, not in the script). When the user points at material to study:
 
-1. prints the `front` (the question),
-2. waits for you to recall, then on Enter prints the `back` (the answer) and any `source_refs`,
-3. reads a grade from stdin and reschedules the card.
-
-Grade keys accept the full word, its first letter, or a number, plus skip/quit:
-
-```
-1 / a / again    2 / h / hard    3 / g / good    4 / e / easy    s = skip    q = quit
-```
-
-Each grade is persisted immediately, so quitting mid-session keeps the progress so
-far. When nothing is due, the loop says so and exits.
-
-## Adding cards
-
-Two equivalent forms — pick whichever the caller has on hand:
+1. Read the source (a note, a deck slide, a passage, a session excerpt).
+2. Draft tight Q/A cards — one idea per card; the `front` prompts recall, the
+   `back` gives the answer plus the "aha" link (e.g. a root → meaning bridge).
+3. `add` each card, filling **`--source-ref`** with where it came from
+   (`note-123#p2`, `etymonline.com/word/salience`) — provenance that rides into
+   Anki as a `src::<ref>` tag, linking each card back to the Extended Mind.
+4. `push` to Anki. Report how many landed (and any duplicates Anki rejected).
 
 ```bash
-# flags
+# stage (flags)
 uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py add \
-  --id note-123#p2 --front "What does SM-2 schedule?" \
-  --back "The next review interval from ease × prior interval." \
-  --source-ref "note-123#p2"
+  --id "etymonline#salience" --front "salience — 어근과 '두드러짐'의 연결?" \
+  --back "라틴 salire '뛰다' + -ence → 튀어나옴 → 두드러짐 (punctum saliens)" \
+  --source-ref "etymonline.com/word/salience" --tag etymology --deck "Etymology"
 
-# JSON object on stdin
-echo '{"id":"deck.html#slide-3","front":"...","back":"...","source_refs":["deck.html#slide-3"]}' \
+# stage (JSON on stdin)
+echo '{"id":"deck.html#s3","front":"...","back":"...","source_refs":["deck.html#s3"]}' \
   | uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py add
+
+# inspect, then push to Anki
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py list --unpushed
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py push
 ```
 
-`source_refs` is provenance metadata (e.g. `"note-123#p2"`, `"deck.html#slide-3"`)
-— whatever creates a card fills it in; the engine just stores and surfaces it.
-A new card defaults to ease 2.5, reps 0, interval 0, lapses 0, and is due today
-(so it shows up in the next review). Re-adding an existing `id` is a no-op (skip).
+Cards land in the `--deck` deck (default **"Extended Mind"**) using Anki's
+**Basic** note type (Front/Back). `source_refs` and any `--tag` become Anki tags.
 
-## Scheduling (SM-2-style)
+## Reviewing
 
-On `grade`, `reps` is read **before** it is updated; the first-review guards give a
-fresh card an absolute interval so an initial `interval_days = 0` is never
-multiplied into zero:
-
-- **again** — interval → 1 day; ease − 0.2; lapses + 1; reps reset to 0 (a lapse restarts the ladder)
-- **hard** — first review → 1 day, else interval × 1.2; ease − 0.15; reps + 1
-- **good** — first → 1 day, second → 3 days, else interval × ease; reps + 1
-- **easy** — first → 3 days, else interval × (ease + 0.15) × 1.3; ease + 0.15; reps + 1
-
-After every grade: ease is clamped to a floor of 1.3, `last_reviewed` is set to
-today, and `due` becomes today + round(interval) days.
+Review happens **in Anki** — open Anki and study the deck (desktop, mobile,
+AnkiWeb, with full scheduling and stats). This tool intentionally has no `review`
+subcommand; pushing the card hands it to Anki's scheduler.
 
 ## Daily run
 
-Review once a day via the existing `/loop` skill, using the namespaced skill form:
+Flush any newly-staged cards into Anki once a day via the existing `/loop` skill:
 
 ```
-/loop 1d /srs:srs review
+/loop 1d /srs:srs push
 ```
 
-Plugin skills are namespaced as `{plugin-name}:{skill-name}`; the bare `/srs` form
-only resolves for a user-level skill installation. No separate scheduler code — the
-`/loop` skill carries the cadence.
+Plugin skills are namespaced as `{plugin-name}:{skill-name}`; the bare `/srs`
+form only resolves for a user-level skill installation. The `pushed` ledger makes
+this safe to repeat — already-pushed cards are skipped. (Anki must be running for
+the push to land; otherwise the loop reports the connection error and the cards
+stay staged for the next run.) No separate scheduler code — `/loop` carries the
+cadence, Anki carries the spacing.

--- a/srs/skills/srs/SKILL.md
+++ b/srs/skills/srs/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: srs
+description: |
+  This skill should be used when the user asks to "review my cards", "do my
+  spaced repetition", "srs review", "what's due today", "add a flashcard",
+  "grade a card", or wants to study/recall saved notes on a spacing schedule.
+  A personal, single-user spaced-repetition (SRS) card store with an SM-2-style
+  scheduler — cards live in ~/.claude/srs/cards.json, reviewed interactively
+  over stdin. Also triggers for automated invocation via /loop 1d /srs:srs review.
+  Distinct from note-taking or summarization: this schedules recall, not capture.
+argument-hint: "[review|due|add|grade]"
+---
+
+# SRS — Personal Spaced Repetition
+
+A lightweight, single-user spaced-repetition tool. Cards are stored in
+`~/.claude/srs/cards.json`; the scheduler is an SM-2-style scheme (SM-2 is the
+classic SuperMemo spacing algorithm). Pure Python standard library, run via `uv`.
+Respond in the user's language.
+
+The engine is one self-contained script — reference it as:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py
+```
+
+Run every subcommand through `uv run` so the inline PEP 723 metadata resolves:
+
+```
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py <subcommand> [args]
+```
+
+## Subcommands
+
+| Input | Behavior |
+|-------|----------|
+| (empty) | Default to `review` — run the interactive loop over due cards |
+| `review` | Interactive review loop (the primary surface; see below) |
+| `due` | Print cards due today or earlier, as a JSON array |
+| `add` | Append one card — from `--id/--front/--back/--source-ref` flags, or a JSON object on stdin |
+| `grade <id> <again\|hard\|good\|easy>` | Apply a grade to one card and reschedule it |
+
+State directory override: set `SRS_DATA_DIR` to point the store somewhere other
+than `~/.claude/srs` (useful for testing without touching real cards).
+
+## Review loop (primary surface)
+
+`review` is interactive over stdin — no AI model sits in the per-card loop, so it
+is the lightest surface. It loads due cards, then for each one:
+
+1. prints the `front` (the question),
+2. waits for you to recall, then on Enter prints the `back` (the answer) and any `source_refs`,
+3. reads a grade from stdin and reschedules the card.
+
+Grade keys accept the full word, its first letter, or a number, plus skip/quit:
+
+```
+1 / a / again    2 / h / hard    3 / g / good    4 / e / easy    s = skip    q = quit
+```
+
+Each grade is persisted immediately, so quitting mid-session keeps the progress so
+far. When nothing is due, the loop says so and exits.
+
+## Adding cards
+
+Two equivalent forms — pick whichever the caller has on hand:
+
+```bash
+# flags
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py add \
+  --id note-123#p2 --front "What does SM-2 schedule?" \
+  --back "The next review interval from ease × prior interval." \
+  --source-ref "note-123#p2"
+
+# JSON object on stdin
+echo '{"id":"deck.html#slide-3","front":"...","back":"...","source_refs":["deck.html#slide-3"]}' \
+  | uv run ${CLAUDE_PLUGIN_ROOT}/skills/srs/scripts/srs.py add
+```
+
+`source_refs` is provenance metadata (e.g. `"note-123#p2"`, `"deck.html#slide-3"`)
+— whatever creates a card fills it in; the engine just stores and surfaces it.
+A new card defaults to ease 2.5, reps 0, interval 0, lapses 0, and is due today
+(so it shows up in the next review). Re-adding an existing `id` is a no-op (skip).
+
+## Scheduling (SM-2-style)
+
+On `grade`, `reps` is read **before** it is updated; the first-review guards give a
+fresh card an absolute interval so an initial `interval_days = 0` is never
+multiplied into zero:
+
+- **again** — interval → 1 day; ease − 0.2; lapses + 1; reps reset to 0 (a lapse restarts the ladder)
+- **hard** — first review → 1 day, else interval × 1.2; ease − 0.15; reps + 1
+- **good** — first → 1 day, second → 3 days, else interval × ease; reps + 1
+- **easy** — first → 3 days, else interval × (ease + 0.15) × 1.3; ease + 0.15; reps + 1
+
+After every grade: ease is clamped to a floor of 1.3, `last_reviewed` is set to
+today, and `due` becomes today + round(interval) days.
+
+## Daily run
+
+Review once a day via the existing `/loop` skill, using the namespaced skill form:
+
+```
+/loop 1d /srs:srs review
+```
+
+Plugin skills are namespaced as `{plugin-name}:{skill-name}`; the bare `/srs` form
+only resolves for a user-level skill installation. No separate scheduler code — the
+`/loop` skill carries the cadence.

--- a/srs/skills/srs/scripts/srs.py
+++ b/srs/skills/srs/scripts/srs.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+"""Personal spaced-repetition (SRS) card store + SM-2-style grade/schedule engine.
+
+Standard library only. State lives in ~/.claude/srs/cards.json (override the
+directory with the SRS_DATA_DIR env var, e.g. for tests). A card is a dict:
+
+    id, front, back, source_refs (list[str]), due (YYYY-MM-DD),
+    interval_days (number), ease (number), reps (int), lapses (int),
+    last_reviewed (YYYY-MM-DD or null)
+
+Subcommands: due | grade <id> <again|hard|good|easy> | add | review
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+EASE_FLOOR = 1.3
+GRADES = ("again", "hard", "good", "easy")
+
+# New-card defaults. interval_days starts at 0; the `reps == 0` guards in
+# apply_grade give a first review an absolute interval so 0 is never multiplied.
+DEFAULTS = {
+    "source_refs": [],
+    "interval_days": 0,
+    "ease": 2.5,
+    "reps": 0,
+    "lapses": 0,
+    "last_reviewed": None,
+}
+
+
+# --- state file -----------------------------------------------------------
+
+def data_dir() -> Path:
+    return Path(os.environ.get("SRS_DATA_DIR", str(Path.home() / ".claude" / "srs")))
+
+
+def cards_path() -> Path:
+    return data_dir() / "cards.json"
+
+
+def load_cards() -> list:
+    path = cards_path()
+    if not path.exists():
+        return []
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save_cards(cards: list) -> None:
+    d = data_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    path = cards_path()
+    tmp = path.with_suffix(".json.tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(cards, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+    os.replace(tmp, path)  # atomic on the same filesystem
+
+
+def today_str() -> str:
+    return date.today().isoformat()
+
+
+def find_card(cards: list, card_id: str):
+    for card in cards:
+        if card.get("id") == card_id:
+            return card
+    return None
+
+
+# --- scheduling -----------------------------------------------------------
+
+def apply_grade(card: dict, grade: str) -> dict:
+    """Apply an SM-2-style update to `card` in place and return it.
+
+    `reps` is read BEFORE it is updated so the first-review guards work off the
+    pre-update repetition count.
+    """
+    reps = int(card.get("reps", DEFAULTS["reps"]))
+    ease = float(card.get("ease", DEFAULTS["ease"]))
+    interval = float(card.get("interval_days", DEFAULTS["interval_days"]))
+    lapses = int(card.get("lapses", DEFAULTS["lapses"]))
+
+    if grade == "again":
+        interval = 1
+        ease -= 0.2
+        lapses += 1
+        reps = 0  # a lapse restarts the ladder
+    elif grade == "hard":
+        interval = 1 if reps == 0 else interval * 1.2
+        ease -= 0.15
+        reps += 1
+    elif grade == "good":
+        if reps == 0:
+            interval = 1
+        elif reps == 1:
+            interval = 3
+        else:
+            interval = interval * ease
+        reps += 1
+    elif grade == "easy":
+        interval = 3 if reps == 0 else interval * (ease + 0.15) * 1.3
+        ease += 0.15
+        reps += 1
+    else:
+        raise ValueError(f"unknown grade {grade!r}; expected one of {GRADES}")
+
+    ease = max(ease, EASE_FLOOR)
+    today = date.today()
+    card["interval_days"] = interval
+    card["ease"] = ease
+    card["reps"] = reps
+    card["lapses"] = lapses
+    card["last_reviewed"] = today.isoformat()
+    card["due"] = (today + timedelta(days=round(interval))).isoformat()
+    return card
+
+
+# --- subcommands ----------------------------------------------------------
+
+def cmd_due(_args) -> int:
+    today = today_str()
+    cards = load_cards()
+    due = [c for c in cards if c.get("due", today) <= today]
+    due.sort(key=lambda c: (c.get("due", ""), str(c.get("id", ""))))
+    json.dump(due, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+def cmd_grade(args) -> int:
+    grade = args.grade.lower()
+    if grade not in GRADES:
+        print(f"[ERROR] grade must be one of {', '.join(GRADES)}", file=sys.stderr)
+        return 2
+    cards = load_cards()
+    card = find_card(cards, args.id)
+    if card is None:
+        print(f"[ERROR] no card with id {args.id!r}", file=sys.stderr)
+        return 1
+    apply_grade(card, grade)
+    save_cards(cards)
+    print(
+        f"{args.id}: {grade} -> due {card['due']} "
+        f"(interval {round(card['interval_days'])}d, ease {card['ease']:.2f}, "
+        f"reps {card['reps']}, lapses {card['lapses']})"
+    )
+    return 0
+
+
+def _new_card(fields: dict) -> dict:
+    card = dict(DEFAULTS)
+    card["source_refs"] = list(fields.get("source_refs", []) or [])
+    card["id"] = fields["id"]
+    card["front"] = fields.get("front", "")
+    card["back"] = fields.get("back", "")
+    # carry through any explicitly-provided scheduling fields, else default
+    for key in ("interval_days", "ease", "reps", "lapses", "last_reviewed"):
+        if key in fields and fields[key] is not None:
+            card[key] = fields[key]
+    # a fresh card is due today unless the caller pins a date
+    card["due"] = fields.get("due") or today_str()
+    return card
+
+
+def cmd_add(args) -> int:
+    if args.id is not None:
+        fields = {
+            "id": args.id,
+            "front": args.front or "",
+            "back": args.back or "",
+            "source_refs": args.source_ref or [],
+        }
+        if args.due:
+            fields["due"] = args.due
+    else:
+        # no --id flag: read a JSON object from stdin
+        raw = sys.stdin.read()
+        if not raw.strip():
+            print("[ERROR] add: provide --id ... or pipe a JSON object on stdin", file=sys.stderr)
+            return 2
+        fields = json.loads(raw)
+        if "id" not in fields:
+            print("[ERROR] add: stdin JSON object needs an 'id' field", file=sys.stderr)
+            return 2
+
+    cards = load_cards()
+    if find_card(cards, fields["id"]) is not None:
+        print(f"card {fields['id']!r} already exists, skipping", file=sys.stderr)
+        return 0
+    card = _new_card(fields)
+    cards.append(card)
+    save_cards(cards)
+    print(f"added {card['id']} (due {card['due']})")
+    return 0
+
+
+def _read_grade(prompt: str):
+    """Read a grade from stdin. Accepts full words, first letters, 1-4,
+    plus s(kip)/q(uit). Returns a grade string, 'skip', 'quit', or None on EOF.
+    """
+    aliases = {
+        "1": "again", "a": "again", "again": "again",
+        "2": "hard", "h": "hard", "hard": "hard",
+        "3": "good", "g": "good", "good": "good",
+        "4": "easy", "e": "easy", "easy": "easy",
+        "s": "skip", "skip": "skip",
+        "q": "quit", "quit": "quit",
+    }
+    while True:
+        try:
+            raw = input(prompt)
+        except EOFError:
+            return None
+        choice = aliases.get(raw.strip().lower())
+        if choice is not None:
+            return choice
+        print("  enter: 1/again  2/hard  3/good  4/easy  s/skip  q/quit")
+
+
+def cmd_review(_args) -> int:
+    today = today_str()
+    cards = load_cards()
+    due = [c for c in cards if c.get("due", today) <= today]
+    due.sort(key=lambda c: (c.get("due", ""), str(c.get("id", ""))))
+    if not due:
+        print("No cards due. ✨")
+        return 0
+
+    print(f"{len(due)} card(s) due.\n")
+    reviewed = 0
+    for idx, card in enumerate(due, 1):
+        print(f"[{idx}/{len(due)}] {card.get('id', '?')}")
+        print(f"  Q: {card.get('front', '')}")
+        try:
+            input("  (press Enter to reveal)")
+        except EOFError:
+            print("\n(input closed) stopping.")
+            break
+        print(f"  A: {card.get('back', '')}")
+        if card.get("source_refs"):
+            print(f"  refs: {', '.join(card['source_refs'])}")
+
+        grade = _read_grade("  grade [1/2/3/4 | a/h/g/e | s/q]: ")
+        if grade is None:
+            print("\n(input closed) stopping.")
+            break
+        if grade == "quit":
+            print("stopping.")
+            break
+        if grade == "skip":
+            print("  skipped.\n")
+            continue
+
+        apply_grade(card, grade)
+        save_cards(cards)  # persist after each grade so a mid-session quit keeps progress
+        reviewed += 1
+        print(
+            f"  -> {grade}: next due {card['due']} "
+            f"(interval {round(card['interval_days'])}d)\n"
+        )
+
+    print(f"\nReviewed {reviewed} card(s).")
+    return 0
+
+
+# --- entry point ----------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="srs", description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("due", help="print cards due today or earlier, as JSON")
+
+    p_grade = sub.add_parser("grade", help="apply a grade to a card and reschedule it")
+    p_grade.add_argument("id")
+    p_grade.add_argument("grade", help="again | hard | good | easy")
+
+    p_add = sub.add_parser("add", help="append a card (--id ... or JSON on stdin)")
+    p_add.add_argument("--id")
+    p_add.add_argument("--front")
+    p_add.add_argument("--back")
+    p_add.add_argument("--source-ref", action="append", dest="source_ref",
+                       help="provenance ref; repeat for multiple")
+    p_add.add_argument("--due", help="override the initial due date (YYYY-MM-DD)")
+
+    sub.add_parser("review", help="interactive review loop over due cards")
+    return parser
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    handlers = {
+        "due": cmd_due,
+        "grade": cmd_grade,
+        "add": cmd_add,
+        "review": cmd_review,
+    }
+    return handlers[args.cmd](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/srs/skills/srs/scripts/srs.py
+++ b/srs/skills/srs/scripts/srs.py
@@ -3,16 +3,25 @@
 # requires-python = ">=3.9"
 # dependencies = []
 # ///
-"""Personal spaced-repetition (SRS) card store + SM-2-style grade/schedule engine.
+"""Personal SRS card generator + Anki push (via AnkiConnect).
 
-Standard library only. State lives in ~/.claude/srs/cards.json (override the
-directory with the SRS_DATA_DIR env var, e.g. for tests). A card is a dict:
+Anki owns review, scheduling, and visualization; this tool owns capture and
+provenance. Flashcards drafted from your Extended Mind (notes, decks, Claude
+sessions) are staged in a ledger at ~/.claude/srs/cards.json, then pushed into
+Anki through the AnkiConnect addon (HTTP, localhost:8765). The ledger records
+what has been pushed so re-running (e.g. from /loop) never double-sends.
 
-    id, front, back, source_refs (list[str]), due (YYYY-MM-DD),
-    interval_days (number), ease (number), reps (int), lapses (int),
-    last_reviewed (YYYY-MM-DD or null)
+Overrides: SRS_DATA_DIR (store dir); ANKICONNECT_URL (default
+http://127.0.0.1:8765).
 
-Subcommands: due | grade <id> <again|hard|good|easy> | add | review
+A staged card:
+    id, front, back, source_refs (list[str]), tags (list[str]), deck (str),
+    added (YYYY-MM-DD), pushed (YYYY-MM-DD or null), anki_note_id (int or null)
+
+`source_refs` is provenance back into the Extended Mind (e.g. "note-123#p2",
+"deck.html#slide-3"); on push each becomes an Anki tag `src::<ref>`.
+
+Subcommands: add | list | push
 """
 from __future__ import annotations
 
@@ -20,25 +29,17 @@ import argparse
 import json
 import os
 import sys
-from datetime import date, timedelta
+import urllib.error
+import urllib.request
+from datetime import date
 from pathlib import Path
 
-EASE_FLOOR = 1.3
-GRADES = ("again", "hard", "good", "easy")
-
-# New-card defaults. interval_days starts at 0; the `reps == 0` guards in
-# apply_grade give a first review an absolute interval so 0 is never multiplied.
-DEFAULTS = {
-    "source_refs": [],
-    "interval_days": 0,
-    "ease": 2.5,
-    "reps": 0,
-    "lapses": 0,
-    "last_reviewed": None,
-}
+DEFAULT_DECK = "Extended Mind"
+DEFAULT_MODEL = "Basic"
+ANKICONNECT_URL = os.environ.get("ANKICONNECT_URL", "http://127.0.0.1:8765")
 
 
-# --- state file -----------------------------------------------------------
+# --- staging ledger ------------------------------------------------------
 
 def data_dir() -> Path:
     return Path(os.environ.get("SRS_DATA_DIR", str(Path.home() / ".claude" / "srs")))
@@ -78,99 +79,59 @@ def find_card(cards: list, card_id: str):
     return None
 
 
-# --- scheduling -----------------------------------------------------------
-
-def apply_grade(card: dict, grade: str) -> dict:
-    """Apply an SM-2-style update to `card` in place and return it.
-
-    `reps` is read BEFORE it is updated so the first-review guards work off the
-    pre-update repetition count.
-    """
-    reps = int(card.get("reps", DEFAULTS["reps"]))
-    ease = float(card.get("ease", DEFAULTS["ease"]))
-    interval = float(card.get("interval_days", DEFAULTS["interval_days"]))
-    lapses = int(card.get("lapses", DEFAULTS["lapses"]))
-
-    if grade == "again":
-        interval = 1
-        ease -= 0.2
-        lapses += 1
-        reps = 0  # a lapse restarts the ladder
-    elif grade == "hard":
-        interval = 1 if reps == 0 else interval * 1.2
-        ease -= 0.15
-        reps += 1
-    elif grade == "good":
-        if reps == 0:
-            interval = 1
-        elif reps == 1:
-            interval = 3
-        else:
-            interval = interval * ease
-        reps += 1
-    elif grade == "easy":
-        interval = 3 if reps == 0 else interval * (ease + 0.15) * 1.3
-        ease += 0.15
-        reps += 1
-    else:
-        raise ValueError(f"unknown grade {grade!r}; expected one of {GRADES}")
-
-    ease = max(ease, EASE_FLOOR)
-    today = date.today()
-    card["interval_days"] = interval
-    card["ease"] = ease
-    card["reps"] = reps
-    card["lapses"] = lapses
-    card["last_reviewed"] = today.isoformat()
-    card["due"] = (today + timedelta(days=round(interval))).isoformat()
-    return card
+def ref_to_tag(ref: str) -> str:
+    # Anki tags are space-separated, so a single tag cannot contain spaces.
+    return "src::" + "_".join(ref.split())
 
 
-# --- subcommands ----------------------------------------------------------
+# --- AnkiConnect (stdlib urllib; protocol-level, no Anki SDK) -------------
 
-def cmd_due(_args) -> int:
-    today = today_str()
-    cards = load_cards()
-    due = [c for c in cards if c.get("due", today) <= today]
-    due.sort(key=lambda c: (c.get("due", ""), str(c.get("id", ""))))
-    json.dump(due, sys.stdout, ensure_ascii=False, indent=2)
-    sys.stdout.write("\n")
-    return 0
-
-
-def cmd_grade(args) -> int:
-    grade = args.grade.lower()
-    if grade not in GRADES:
-        print(f"[ERROR] grade must be one of {', '.join(GRADES)}", file=sys.stderr)
-        return 2
-    cards = load_cards()
-    card = find_card(cards, args.id)
-    if card is None:
-        print(f"[ERROR] no card with id {args.id!r}", file=sys.stderr)
-        return 1
-    apply_grade(card, grade)
-    save_cards(cards)
-    print(
-        f"{args.id}: {grade} -> due {card['due']} "
-        f"(interval {round(card['interval_days'])}d, ease {card['ease']:.2f}, "
-        f"reps {card['reps']}, lapses {card['lapses']})"
+def anki_invoke(action: str, **params):
+    """POST one AnkiConnect action and return its result, or raise RuntimeError
+    on an AnkiConnect-level error / malformed response. Connection failures
+    surface as urllib.error.URLError for the caller to translate."""
+    body = json.dumps({"action": action, "version": 6, "params": params}).encode("utf-8")
+    req = urllib.request.Request(
+        ANKICONNECT_URL, data=body, headers={"Content-Type": "application/json"}
     )
-    return 0
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        try:
+            data = json.loads(resp.read().decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"non-JSON response from {ANKICONNECT_URL}: {exc}") from exc
+    if not isinstance(data, dict) or set(data.keys()) != {"result", "error"}:
+        raise RuntimeError(f"unexpected AnkiConnect response: {data!r}")
+    if data["error"] is not None:
+        raise RuntimeError(data["error"])
+    return data["result"]
 
+
+def card_to_note(card: dict) -> dict:
+    tags = list(card.get("tags", []) or [])
+    tags += [ref_to_tag(r) for r in (card.get("source_refs") or [])]
+    return {
+        "deckName": card.get("deck") or DEFAULT_DECK,
+        "modelName": DEFAULT_MODEL,
+        "fields": {"Front": card.get("front", ""), "Back": card.get("back", "")},
+        "tags": tags,
+        "options": {"allowDuplicate": False, "duplicateScope": "deck"},
+    }
+
+
+# --- subcommands ---------------------------------------------------------
 
 def _new_card(fields: dict) -> dict:
-    card = dict(DEFAULTS)
-    card["source_refs"] = list(fields.get("source_refs", []) or [])
-    card["id"] = fields["id"]
-    card["front"] = fields.get("front", "")
-    card["back"] = fields.get("back", "")
-    # carry through any explicitly-provided scheduling fields, else default
-    for key in ("interval_days", "ease", "reps", "lapses", "last_reviewed"):
-        if key in fields and fields[key] is not None:
-            card[key] = fields[key]
-    # a fresh card is due today unless the caller pins a date
-    card["due"] = fields.get("due") or today_str()
-    return card
+    return {
+        "id": fields["id"],
+        "front": fields.get("front", ""),
+        "back": fields.get("back", ""),
+        "source_refs": list(fields.get("source_refs") or []),
+        "tags": list(fields.get("tags") or []),
+        "deck": fields.get("deck") or DEFAULT_DECK,
+        "added": today_str(),
+        "pushed": None,
+        "anki_note_id": None,
+    }
 
 
 def cmd_add(args) -> int:
@@ -180,11 +141,11 @@ def cmd_add(args) -> int:
             "front": args.front or "",
             "back": args.back or "",
             "source_refs": args.source_ref or [],
+            "tags": args.tag or [],
         }
-        if args.due:
-            fields["due"] = args.due
+        if args.deck:
+            fields["deck"] = args.deck
     else:
-        # no --id flag: read a JSON object from stdin
         raw = sys.stdin.read()
         if not raw.strip():
             print("[ERROR] add: provide --id ... or pipe a JSON object on stdin", file=sys.stderr)
@@ -196,117 +157,104 @@ def cmd_add(args) -> int:
 
     cards = load_cards()
     if find_card(cards, fields["id"]) is not None:
-        print(f"card {fields['id']!r} already exists, skipping", file=sys.stderr)
+        print(f"card {fields['id']!r} already staged, skipping", file=sys.stderr)
         return 0
     card = _new_card(fields)
     cards.append(card)
     save_cards(cards)
-    print(f"added {card['id']} (due {card['due']})")
+    print(f"staged {card['id']} (deck '{card['deck']}', not yet pushed)")
     return 0
 
 
-def _read_grade(prompt: str):
-    """Read a grade from stdin. Accepts full words, first letters, 1-4,
-    plus s(kip)/q(uit). Returns a grade string, 'skip', 'quit', or None on EOF.
-    """
-    aliases = {
-        "1": "again", "a": "again", "again": "again",
-        "2": "hard", "h": "hard", "hard": "hard",
-        "3": "good", "g": "good", "good": "good",
-        "4": "easy", "e": "easy", "easy": "easy",
-        "s": "skip", "skip": "skip",
-        "q": "quit", "quit": "quit",
-    }
-    while True:
-        try:
-            raw = input(prompt)
-        except EOFError:
-            return None
-        choice = aliases.get(raw.strip().lower())
-        if choice is not None:
-            return choice
-        print("  enter: 1/again  2/hard  3/good  4/easy  s/skip  q/quit")
-
-
-def cmd_review(_args) -> int:
-    today = today_str()
+def cmd_list(args) -> int:
     cards = load_cards()
-    due = [c for c in cards if c.get("due", today) <= today]
-    due.sort(key=lambda c: (c.get("due", ""), str(c.get("id", ""))))
-    if not due:
-        print("No cards due. ✨")
+    if args.unpushed:
+        cards = [c for c in cards if not c.get("pushed")]
+    json.dump(cards, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+def cmd_push(args) -> int:
+    cards = load_cards()
+    pending = [c for c in cards if args.all or not c.get("pushed")]
+    if not pending:
+        print("Nothing to push. ✨")
         return 0
 
-    print(f"{len(due)} card(s) due.\n")
-    reviewed = 0
-    for idx, card in enumerate(due, 1):
-        print(f"[{idx}/{len(due)}] {card.get('id', '?')}")
-        print(f"  Q: {card.get('front', '')}")
-        try:
-            input("  (press Enter to reveal)")
-        except EOFError:
-            print("\n(input closed) stopping.")
-            break
-        print(f"  A: {card.get('back', '')}")
-        if card.get("source_refs"):
-            print(f"  refs: {', '.join(card['source_refs'])}")
+    notes = [card_to_note(c) for c in pending]
+    decks = sorted({n["deckName"] for n in notes})
 
-        grade = _read_grade("  grade [1/2/3/4 | a/h/g/e | s/q]: ")
-        if grade is None:
-            print("\n(input closed) stopping.")
-            break
-        if grade == "quit":
-            print("stopping.")
-            break
-        if grade == "skip":
-            print("  skipped.\n")
-            continue
+    if args.dry_run:
+        print(f"# dry-run: would push {len(pending)} card(s) to {ANKICONNECT_URL}")
+        print(f"# ensure decks exist: {decks}")
+        json.dump({"action": "addNotes", "notes": notes}, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 0
 
-        apply_grade(card, grade)
-        save_cards(cards)  # persist after each grade so a mid-session quit keeps progress
-        reviewed += 1
+    try:
+        for deck in decks:
+            anki_invoke("createDeck", deck=deck)  # idempotent
+        results = anki_invoke("addNotes", notes=notes)
+    except urllib.error.URLError as exc:
         print(
-            f"  -> {grade}: next due {card['due']} "
-            f"(interval {round(card['interval_days'])}d)\n"
+            f"[ERROR] cannot reach AnkiConnect at {ANKICONNECT_URL}: {exc.reason}\n"
+            f"        Is Anki running with the AnkiConnect addon installed? (open -a Anki)",
+            file=sys.stderr,
         )
+        return 1
+    except RuntimeError as exc:
+        print(f"[ERROR] AnkiConnect: {exc}", file=sys.stderr)
+        return 1
 
-    print(f"\nReviewed {reviewed} card(s).")
-    return 0
+    # addNotes returns a parallel list: a note id on success, null when Anki
+    # rejected the note (most commonly a duplicate within the deck).
+    pushed = failed = 0
+    for card, note_id in zip(pending, results):
+        if note_id is not None:
+            card["pushed"] = today_str()
+            card["anki_note_id"] = note_id
+            pushed += 1
+        else:
+            failed += 1
+            print(f"  ! {card['id']}: rejected by Anki (likely a duplicate)", file=sys.stderr)
+    save_cards(cards)
+
+    summary = f"pushed {pushed} card(s) to Anki"
+    if failed:
+        summary += f", {failed} rejected"
+    print(summary + f" (decks: {', '.join(decks)})")
+    return 0 if failed == 0 else 1
 
 
-# --- entry point ----------------------------------------------------------
+# --- entry point ---------------------------------------------------------
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="srs", description=__doc__)
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    sub.add_parser("due", help="print cards due today or earlier, as JSON")
-
-    p_grade = sub.add_parser("grade", help="apply a grade to a card and reschedule it")
-    p_grade.add_argument("id")
-    p_grade.add_argument("grade", help="again | hard | good | easy")
-
-    p_add = sub.add_parser("add", help="append a card (--id ... or JSON on stdin)")
+    p_add = sub.add_parser("add", help="stage a card (--id ... or JSON on stdin)")
     p_add.add_argument("--id")
     p_add.add_argument("--front")
     p_add.add_argument("--back")
     p_add.add_argument("--source-ref", action="append", dest="source_ref",
-                       help="provenance ref; repeat for multiple")
-    p_add.add_argument("--due", help="override the initial due date (YYYY-MM-DD)")
+                       help="provenance ref; repeat for multiple (→ Anki tag src::<ref>)")
+    p_add.add_argument("--tag", action="append", dest="tag", help="extra Anki tag; repeat")
+    p_add.add_argument("--deck", help=f"target Anki deck (default '{DEFAULT_DECK}')")
 
-    sub.add_parser("review", help="interactive review loop over due cards")
+    p_list = sub.add_parser("list", help="list staged cards as JSON")
+    p_list.add_argument("--unpushed", action="store_true", help="only cards not yet pushed")
+
+    p_push = sub.add_parser("push", help="push staged cards into Anki via AnkiConnect")
+    p_push.add_argument("--all", action="store_true", help="re-push every card, not just un-pushed")
+    p_push.add_argument("--dry-run", action="store_true",
+                        help="print the AnkiConnect payload without sending")
     return parser
 
 
 def main(argv=None) -> int:
     args = build_parser().parse_args(argv)
-    handlers = {
-        "due": cmd_due,
-        "grade": cmd_grade,
-        "add": cmd_add,
-        "review": cmd_review,
-    }
-    return handlers[args.cmd](args)
+    return {"add": cmd_add, "list": cmd_list, "push": cmd_push}[args.cmd](args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Realizes the **card-mining-span** Span Runbook as minimal runnable tooling — a cc-plugin plugin that mines Anki flashcards from the cross-project Claude session archive.

Per the codex guidance ("orchestration recipe + thin selection helper, not a monolith"), it **composes** existing capability rather than reimplementing it:

- **Recipe** (`SKILL.md`) — the 7-stage Span (Recall → Gather → Abstract → Sharpen → Select → Render → Push) wiring the epistemic protocols (`/ascend` `/inquire` `/induce` `/elicit`), sidecar checkpoints, and the sibling `srs` Anki-push tool. The protocols are invoked at run time, never reimplemented.
- **Thin helper** (`card_mining.py`, stdlib + PEP 723) — the deterministic glue only:
  - `init` / `capsule` / `status` — a per-run checkpoint ledger at `~/.claude/srs/runs/<run-id>/run.json` (per-stage in/out capsules + `source_refs` + resume handle). Killed runs re-enter at the first non-completed stage.
  - `render` — selection-table → card JSONL in the `srs add` shape. Keeps only user-picked **`memorize`** rows, **rejects source-less candidates**, joins `source_refs` from the table (provenance SSOT), stamps a staleness tag (`mining-run::`, `mined-as-of::`). Emits JSONL; composition with `srs` is **by pipe, not import**.

## Composition (verified end-to-end)

```
card_mining render <run> --pick c1 | while read card; do srs add; done
srs push --dry-run   # TEST deck payload; source_refs -> src:: tag, staleness tags carried
```

## Notes

- **TEST deck first** (renderer default `--deck TEST`); a live push to a real deck is a user gate.
- New plugin → satisfies the per-plugin version-bump gate via its initial version (`0.1.0`).
- Personal scope. **Do not merge** — merge is user-held after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
