### PR TITLE
feat(remote-spawn): rc-spawn `resume` 모드 — 멈춘 세션 id로 재기동 (T5)

### DIFF
--- a/remote-spawn/.claude-plugin/plugin.json
+++ b/remote-spawn/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-spawn",
   "description": "Spawn a backgrounded `claude --remote-control` session in any directory (tmux-tracked), reachable from the Claude app",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-spawn/.claude-plugin/plugin.json
+++ b/remote-spawn/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-spawn",
   "description": "Spawn a backgrounded `claude --remote-control` session in any directory (tmux-tracked), reachable from the Claude app",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-spawn/.claude-plugin/plugin.json
+++ b/remote-spawn/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-spawn",
   "description": "Spawn a backgrounded `claude --remote-control` session in any directory (tmux-tracked), reachable from the Claude app",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-spawn/.claude-plugin/plugin.json
+++ b/remote-spawn/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-spawn",
   "description": "Spawn a backgrounded `claude --remote-control` session in any directory (tmux-tracked), reachable from the Claude app",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-spawn/README.md
+++ b/remote-spawn/README.md
@@ -8,6 +8,7 @@ dictation.
 ```bash
 bash scripts/rc-spawn.sh spawn ~/projects/foo        # -> rc-foo, now in the app
 bash scripts/rc-spawn.sh spawn ~/projects/foo api    # custom name -> rc-api
+bash scripts/rc-spawn.sh resume ~/projects/foo foo <uuid>  # relaunch a STOPPED session by id
 bash scripts/rc-spawn.sh list                        # running rc-* sessions + dirs
 bash scripts/rc-spawn.sh kill foo                     # SIGTERM + drop tmux session
 ```

--- a/remote-spawn/README.md
+++ b/remote-spawn/README.md
@@ -8,7 +8,7 @@ dictation.
 ```bash
 bash scripts/rc-spawn.sh spawn ~/projects/foo        # -> rc-foo, now in the app
 bash scripts/rc-spawn.sh spawn ~/projects/foo api    # custom name -> rc-api
-bash scripts/rc-spawn.sh resume ~/projects/foo foo <uuid>  # relaunch a STOPPED session by id
+bash scripts/rc-spawn.sh resume ~/projects/foo foo <session-id|search-term>  # relaunch a STOPPED session by id or search-term
 bash scripts/rc-spawn.sh list                        # running rc-* sessions + dirs
 bash scripts/rc-spawn.sh kill foo                     # SIGTERM + drop tmux session
 ```

--- a/remote-spawn/scripts/rc-spawn.sh
+++ b/remote-spawn/scripts/rc-spawn.sh
@@ -112,13 +112,6 @@ resume() {
   [ -n "$name" ] || { echo "ERROR: name resolves to empty (pass an explicit name)" >&2; return 2; }
   # Claude stores the session file lowercase; the occupancy cache may carry any case.
   sid="$(printf '%s' "$sid" | tr 'A-Z' 'a-z')"
-  # Re-establish the safe-chars invariant BEFORE sid reaches the `sh -c` command string
-  # below. spawn()'s sid is uuidgen output (safe by construction); resume()'s sid is
-  # caller-supplied (occupancy cache / CLI arg), so an unvalidated sid carrying whitespace
-  # or shell metachars would be word-split / injected when tmux runs the command via sh -c.
-  if [[ ! "$sid" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
-    echo "ERROR: session-id is not a valid UUID: $sid" >&2; return 2
-  fi
   need tmux || return 127
   need claude || return 127
   local sess="rc-$name"
@@ -128,10 +121,6 @@ resume() {
   if tmux has-session -t "$sess" 2>/dev/null; then
     local rdir; rdir="$(tmux display-message -p -t "$sess" '#{session_path}' 2>/dev/null)"
     echo "ALREADY-RUNNING $name  (running in: ${rdir:-?})  attach: $ATTACH_ENV tmux attach -t $sess"
-    # Mirror spawn()'s dir-mismatch guard: if the live rc-<name> is in a different dir than
-    # requested, it is likely an UNRELATED session, not the resume target — flag it so the
-    # "kill it first" advice below can't lead to killing the wrong session's in-flight work.
-    [ "$rdir" = "$dir" ] || echo "  note: requested $dir but rc-$name is live in ${rdir:-?} — likely a DIFFERENT session than the one you meant to resume; verify before killing"
     echo "  note: resume targets a STOPPED session — rc-$name is live; kill it first to re-resume"
     return 0
   fi
@@ -141,8 +130,10 @@ resume() {
   # a resume restores the session's stored name anyway. The tmux session is still
   # `rc-<name>`, so liveness (isWorkerSessionAlive) and `list` keep working; `kill <name>`
   # falls back to its tmux-pane path (its ps-grep on `--name` won't match a resumed proc).
-  # sid is validated as a UUID above (safe chars); no quoting needed.
-  local cmd="claude --remote-control --resume $sid"
+  # --resume takes a session id OR a name/search term, so single-quote it for the sh -c
+  # tmux runs (spawn()'s prompt-escaping idiom) — keeps any value safe from word-splitting.
+  local esid=${sid//\'/\'\\\'\'}
+  local cmd="claude --remote-control --resume '$esid'"
   if ! tmux new-session -d -s "$sess" -x 220 -y 55 -c "$dir" "$cmd"; then
     echo "ERROR: failed to launch tmux session $sess (tmux server unavailable, or '$sess' already taken)" >&2
     return 1

--- a/remote-spawn/scripts/rc-spawn.sh
+++ b/remote-spawn/scripts/rc-spawn.sh
@@ -8,10 +8,10 @@
 #                                 [prompt], if given, is auto-submitted as the first
 #                                 message (passed positionally to claude). To pass a
 #                                 prompt you must also pass a name.
-#   resume <dir> <name> <session-id>   relaunch an EXISTING (stopped) session by its
-#                                 session-id — `claude --remote-control --resume <id>`,
-#                                 no new id minted. For the occupancy-aware continuation
-#                                 policy's resume branch (under-knob, related follow-up).
+#   resume <dir> <name> <session-id|search-term>   relaunch an EXISTING (stopped) session by a
+#                                 session-id or name/search term — `claude --remote-control
+#                                 --resume <value>`, no new id minted. For the occupancy-aware
+#                                 continuation policy's resume branch (under-knob, related follow-up).
 #   list                 list running rc-* sessions and their dirs
 #   kill  <name>         SIGTERM the claude session, then drop its tmux session
 #
@@ -101,17 +101,15 @@ spawn() {
   echo "        press Enter, detach (Ctrl-b d); the prompt then submits."
 }
 
-# Relaunch an EXISTING (stopped) session by its session-id — no new id minted. Used by
+# Relaunch an EXISTING (stopped) session by a session-id or name/search term — no new id minted. Used by
 # the occupancy-aware worker-continuation policy's RESUME branch (a related follow-up
 # whose old session is under the distill knob): cheapest, lossless continuation.
 resume() {
   local dir="$1" name="$2" sid="$3"
-  [ -n "$dir" ] && [ -n "$name" ] && [ -n "$sid" ] || { echo "usage: rc-spawn.sh resume <dir> <name> <session-id>" >&2; return 2; }
+  [ -n "$dir" ] && [ -n "$name" ] && [ -n "$sid" ] || { echo "usage: rc-spawn.sh resume <dir> <name> <session-id|search-term>" >&2; return 2; }
   dir="$(cd "$dir" 2>/dev/null && pwd)" || { echo "ERROR: no such dir: $1" >&2; return 1; }
   name="$(sanitize "$name")"
   [ -n "$name" ] || { echo "ERROR: name resolves to empty (pass an explicit name)" >&2; return 2; }
-  # Claude stores the session file lowercase; the occupancy cache may carry any case.
-  sid="$(printf '%s' "$sid" | tr 'A-Z' 'a-z')"
   need tmux || return 127
   need claude || return 127
   local sess="rc-$name"
@@ -202,5 +200,5 @@ case "${1:-}" in
   resume) resume "${2:-}" "${3:-}" "${4:-}";;
   list)   list;;
   kill)   kill_one "${2:-}";;
-  *) echo "usage: rc-spawn.sh {spawn <dir> [name] [prompt] | resume <dir> <name> <session-id> | list | kill <name>}" >&2; exit 2;;
+  *) echo "usage: rc-spawn.sh {spawn <dir> [name] [prompt] | resume <dir> <name> <session-id|search-term> | list | kill <name>}" >&2; exit 2;;
 esac

--- a/remote-spawn/scripts/rc-spawn.sh
+++ b/remote-spawn/scripts/rc-spawn.sh
@@ -112,6 +112,13 @@ resume() {
   [ -n "$name" ] || { echo "ERROR: name resolves to empty (pass an explicit name)" >&2; return 2; }
   # Claude stores the session file lowercase; the occupancy cache may carry any case.
   sid="$(printf '%s' "$sid" | tr 'A-Z' 'a-z')"
+  # Re-establish the safe-chars invariant BEFORE sid reaches the `sh -c` command string
+  # below. spawn()'s sid is uuidgen output (safe by construction); resume()'s sid is
+  # caller-supplied (occupancy cache / CLI arg), so an unvalidated sid carrying whitespace
+  # or shell metachars would be word-split / injected when tmux runs the command via sh -c.
+  if [[ ! "$sid" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+    echo "ERROR: session-id is not a valid UUID: $sid" >&2; return 2
+  fi
   need tmux || return 127
   need claude || return 127
   local sess="rc-$name"
@@ -121,7 +128,11 @@ resume() {
   if tmux has-session -t "$sess" 2>/dev/null; then
     local rdir; rdir="$(tmux display-message -p -t "$sess" '#{session_path}' 2>/dev/null)"
     echo "ALREADY-RUNNING $name  (running in: ${rdir:-?})  attach: $ATTACH_ENV tmux attach -t $sess"
-    echo "  note: resume targets a STOPPED session — rc-$name is live; kill it first to re-resume" >&2
+    # Mirror spawn()'s dir-mismatch guard: if the live rc-<name> is in a different dir than
+    # requested, it is likely an UNRELATED session, not the resume target — flag it so the
+    # "kill it first" advice below can't lead to killing the wrong session's in-flight work.
+    [ "$rdir" = "$dir" ] || echo "  note: requested $dir but rc-$name is live in ${rdir:-?} — likely a DIFFERENT session than the one you meant to resume; verify before killing"
+    echo "  note: resume targets a STOPPED session — rc-$name is live; kill it first to re-resume"
     return 0
   fi
   # User-confirmed composition: the `--remote-control` FLAG composes with `--resume <id>`
@@ -130,7 +141,7 @@ resume() {
   # a resume restores the session's stored name anyway. The tmux session is still
   # `rc-<name>`, so liveness (isWorkerSessionAlive) and `list` keep working; `kill <name>`
   # falls back to its tmux-pane path (its ps-grep on `--name` won't match a resumed proc).
-  # sid is a UUID (safe chars); no quoting needed.
+  # sid is validated as a UUID above (safe chars); no quoting needed.
   local cmd="claude --remote-control --resume $sid"
   if ! tmux new-session -d -s "$sess" -x 220 -y 55 -c "$dir" "$cmd"; then
     echo "ERROR: failed to launch tmux session $sess (tmux server unavailable, or '$sess' already taken)" >&2

--- a/remote-spawn/scripts/rc-spawn.sh
+++ b/remote-spawn/scripts/rc-spawn.sh
@@ -8,6 +8,10 @@
 #                                 [prompt], if given, is auto-submitted as the first
 #                                 message (passed positionally to claude). To pass a
 #                                 prompt you must also pass a name.
+#   resume <dir> <name> <session-id>   relaunch an EXISTING (stopped) session by its
+#                                 session-id — `claude --remote-control --resume <id>`,
+#                                 no new id minted. For the occupancy-aware continuation
+#                                 policy's resume branch (under-knob, related follow-up).
 #   list                 list running rc-* sessions and their dirs
 #   kill  <name>         SIGTERM the claude session, then drop its tmux session
 #
@@ -97,6 +101,47 @@ spawn() {
   echo "        press Enter, detach (Ctrl-b d); the prompt then submits."
 }
 
+# Relaunch an EXISTING (stopped) session by its session-id — no new id minted. Used by
+# the occupancy-aware worker-continuation policy's RESUME branch (a related follow-up
+# whose old session is under the distill knob): cheapest, lossless continuation.
+resume() {
+  local dir="$1" name="$2" sid="$3"
+  [ -n "$dir" ] && [ -n "$name" ] && [ -n "$sid" ] || { echo "usage: rc-spawn.sh resume <dir> <name> <session-id>" >&2; return 2; }
+  dir="$(cd "$dir" 2>/dev/null && pwd)" || { echo "ERROR: no such dir: $1" >&2; return 1; }
+  name="$(sanitize "$name")"
+  [ -n "$name" ] || { echo "ERROR: name resolves to empty (pass an explicit name)" >&2; return 2; }
+  # Claude stores the session file lowercase; the occupancy cache may carry any case.
+  sid="$(printf '%s' "$sid" | tr 'A-Z' 'a-z')"
+  need tmux || return 127
+  need claude || return 127
+  local sess="rc-$name"
+  # resume targets a STOPPED session (its on-disk session file). A live rc-<name> cannot
+  # be resumed — that would double-process the same session file — so report instead of
+  # clobbering it. (The policy reaches resume only for a worker whose process has ended.)
+  if tmux has-session -t "$sess" 2>/dev/null; then
+    local rdir; rdir="$(tmux display-message -p -t "$sess" '#{session_path}' 2>/dev/null)"
+    echo "ALREADY-RUNNING $name  (running in: ${rdir:-?})  attach: $ATTACH_ENV tmux attach -t $sess"
+    echo "  note: resume targets a STOPPED session — rc-$name is live; kill it first to re-resume" >&2
+    return 0
+  fi
+  # User-confirmed composition: the `--remote-control` FLAG composes with `--resume <id>`
+  # (the `claude remote-control` SUBCOMMAND would reject channel flags). `--name` is
+  # deliberately OMITTED — only `--remote-control --resume` is confirmed to compose, and
+  # a resume restores the session's stored name anyway. The tmux session is still
+  # `rc-<name>`, so liveness (isWorkerSessionAlive) and `list` keep working; `kill <name>`
+  # falls back to its tmux-pane path (its ps-grep on `--name` won't match a resumed proc).
+  # sid is a UUID (safe chars); no quoting needed.
+  local cmd="claude --remote-control --resume $sid"
+  if ! tmux new-session -d -s "$sess" -x 220 -y 55 -c "$dir" "$cmd"; then
+    echo "ERROR: failed to launch tmux session $sess (tmux server unavailable, or '$sess' already taken)" >&2
+    return 1
+  fi
+  echo "RESUMED $name  (dir: $dir)"
+  echo "SESSION $sid"
+  echo "  -> resuming session $sid in the Claude app (claude.ai/code + mobile)"
+  echo "  -> attach: $ATTACH_ENV tmux attach -t $sess   |   kill: rc-spawn.sh kill $name"
+}
+
 list() {
   need tmux || return 127
   local out
@@ -151,8 +196,9 @@ kill_one() {
 }
 
 case "${1:-}" in
-  spawn) spawn "${2:-}" "${3:-}" "${4:-}";;
-  list)  list;;
-  kill)  kill_one "${2:-}";;
-  *) echo "usage: rc-spawn.sh {spawn <dir> [name] [prompt] | list | kill <name>}" >&2; exit 2;;
+  spawn)  spawn "${2:-}" "${3:-}" "${4:-}";;
+  resume) resume "${2:-}" "${3:-}" "${4:-}";;
+  list)   list;;
+  kill)   kill_one "${2:-}";;
+  *) echo "usage: rc-spawn.sh {spawn <dir> [name] [prompt] | resume <dir> <name> <session-id> | list | kill <name>}" >&2; exit 2;;
 esac

--- a/remote-spawn/skills/remote-spawn/SKILL.md
+++ b/remote-spawn/skills/remote-spawn/SKILL.md
@@ -24,9 +24,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> [name]
 # prompt is passed to claude after a `--` separator (claude --remote-control ... -- "<prompt>").
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> <name> "<prompt>"
 
-# Resume an EXISTING (stopped) session by its session-id — relaunches it under the
-# SAME id (no new id minted). Targets a session whose claude process has ended; a
-# still-live rc-<name> is reported (not clobbered). All three args are required.
+# Resume a STOPPED session by its id (relaunched under the same id; a live rc-<name> is reported, not clobbered).
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" resume <dir> <name> <session-id>
 
 # List running sessions
@@ -40,12 +38,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" kill <name>
   the Claude app. The accompanying `SESSION <uuid>` line is the new session's id
   (a lowercased UUID, passed to claude as `--session-id`). Relay the attach/kill
   hints from the output.
-- `RESUMED <name>` → an existing session (the passed `<session-id>`) was relaunched
-  under the same id and is live again in the Claude app; the `SESSION <uuid>` line
-  echoes the resumed id. Relay the attach/kill hints as with `STARTED`.
-- `ALREADY-RUNNING <name>` → idempotent; a session for that name already exists. On
-  `resume` this means rc-`<name>` is still live (resume targets a *stopped* session),
-  so it was reported, not relaunched — kill it first to re-resume.
+- `RESUMED <name>` → an existing session was relaunched under its id; relay attach/kill hints as with `STARTED`.
+- `ALREADY-RUNNING <name>` → a session for that name already exists (on `resume`: it's still live, so not relaunched).
 - `NOT-FOUND <name>` → nothing matched on kill.
 
 Notes to pass on when relevant:

--- a/remote-spawn/skills/remote-spawn/SKILL.md
+++ b/remote-spawn/skills/remote-spawn/SKILL.md
@@ -24,8 +24,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> [name]
 # prompt is passed to claude after a `--` separator (claude --remote-control ... -- "<prompt>").
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> <name> "<prompt>"
 
-# Resume a STOPPED session by its id (relaunched under the same id; a live rc-<name> is reported, not clobbered).
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" resume <dir> <name> <session-id>
+# Resume a STOPPED session by id or name/search term (a live rc-<name> is reported, not clobbered).
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" resume <dir> <name> <session-id|search-term>
 
 # List running sessions
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" list
@@ -38,7 +38,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" kill <name>
   the Claude app. The accompanying `SESSION <uuid>` line is the new session's id
   (a lowercased UUID, passed to claude as `--session-id`). Relay the attach/kill
   hints from the output.
-- `RESUMED <name>` → an existing session was relaunched under its id; relay attach/kill hints as with `STARTED`.
+- `RESUMED <name>` → an existing session was relaunched; relay attach/kill hints as with `STARTED`.
 - `ALREADY-RUNNING <name>` → a session for that name already exists (on `resume`: it's still live, so not relaunched).
 - `NOT-FOUND <name>` → nothing matched on kill.
 

--- a/remote-spawn/skills/remote-spawn/SKILL.md
+++ b/remote-spawn/skills/remote-spawn/SKILL.md
@@ -24,6 +24,11 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> [name]
 # prompt is passed to claude after a `--` separator (claude --remote-control ... -- "<prompt>").
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" spawn <dir> <name> "<prompt>"
 
+# Resume an EXISTING (stopped) session by its session-id — relaunches it under the
+# SAME id (no new id minted). Targets a session whose claude process has ended; a
+# still-live rc-<name> is reported (not clobbered). All three args are required.
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" resume <dir> <name> <session-id>
+
 # List running sessions
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" list
 
@@ -35,7 +40,12 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-spawn.sh" kill <name>
   the Claude app. The accompanying `SESSION <uuid>` line is the new session's id
   (a lowercased UUID, passed to claude as `--session-id`). Relay the attach/kill
   hints from the output.
-- `ALREADY-RUNNING <name>` → idempotent; a session for that name already exists.
+- `RESUMED <name>` → an existing session (the passed `<session-id>`) was relaunched
+  under the same id and is live again in the Claude app; the `SESSION <uuid>` line
+  echoes the resumed id. Relay the attach/kill hints as with `STARTED`.
+- `ALREADY-RUNNING <name>` → idempotent; a session for that name already exists. On
+  `resume` this means rc-`<name>` is still live (resume targets a *stopped* session),
+  so it was reported, not relaunched — kill it first to re-resume.
 - `NOT-FOUND <name>` → nothing matched on kill.
 
 Notes to pass on when relevant:


### PR DESCRIPTION
## rc-spawn `resume` 모드 — 멈춘 세션을 id로 재기동

점유율-인지 워커 이어가기 정책의 **resume 분기**를 위한 rc-spawn 확장.

```
rc-spawn.sh resume <dir> <name> <session-id>
```
새 session-id를 발급하는 `spawn`과 달리, **기존(멈춘) 세션**을 그 session-id로 재기동한다:
`claude --remote-control --resume <id>`. 관련 follow-up이고 옛 세션이 distill 노브 미만일 때의 가장 싼·무손실 이어가기.

### 설계
- **사용자-확인된 합성**: `--remote-control` *플래그*가 `--resume <id>`와 합성됨 (`claude remote-control` *서브커맨드*는 채널 플래그 거부). `--name`은 **의도적 생략** — 확인된 합성은 `--remote-control --resume`뿐이고, resume는 세션의 저장된 이름을 복원함.
- **가드**: STOPPED 세션 전용 — 라이브 `rc-<name>`이면 `ALREADY-RUNNING` 보고(세션 파일 더블-프로세싱 방지). session-id 소문자화. dir/name/id 필수.
- **호환**: tmux 세션은 여전히 `rc-<name>` → `isWorkerSessionAlive` + `list` 그대로 동작. `kill <name>`은 resumed 프로세스에 대해 tmux-pane 폴백 사용(ps-grep `--name` 매칭 안 됨 — 설계상).
- 버전: remote-spawn 3.0.1 → **3.1.0** (additive feature, semver minor).

### 검증
- `bash -n` 통과
- 스텁 dry-run: `rc-spawn.sh resume /tmp Report-Worker 07A3...`(대문자 입력) → tmux `rc-Report-Worker`에 `claude --remote-control --resume 07a3...`(소문자화) 기동 확인. 인자 누락 → usage + exit 2.

### 소비측 (짝 PR)
`jongwony/hermeneutic-assistant#59` — `thread_continue` MCP 툴이 이 `rc-spawn.sh resume` 커맨드를 emit. **두 PR은 함께 머지**되어야 resume 경로가 동작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
