### PR TITLE
voice-dictation: initial prompt에 영문·숫자 원표기 편향 추가

### DIFF
--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -34,10 +34,10 @@ LANG = "auto"          # ko / en / auto
 # whisper 의 initial prompt — '명령'이 아니라 '편향'(soft bias, 약 224 토큰 상한).
 # 특정 용어를 나열하면 그 단어가 실제 발화에 없어도 출력에 끼어드는(hallucination)
 # 위험이 있어, 어휘 예시는 비운다. 대신 프롬프트 자체를 한국어+영문 혼합 스크립트로
-# 둬, 특정 어휘를 가리키지 않고 code-switching(영어 단어는 영문 그대로)만 구조적으로
+# 둬, 특정 어휘를 가리키지 않고 code-switching(영어 단어는 영문, 숫자는 아라비아 표기)을 구조적으로
 # 편향한다. 언어 선택은 LANG=auto 가 발화별로 담당하고(한/영 어느 쪽으로 말하든),
 # 이 프롬프트는 표기 스타일만 기울인다. 문법 교정·재작성은 이 층위로 불가(LLM 몫).
-PROMPT = "한국어와 English가 섞인 받아쓰기."
+PROMPT = "한국어와 English가 섞인 받아쓰기. 영어 단어는 영문으로, 숫자는 아라비아 숫자로 적습니다."
 TRIGGER = keyboard.Key.alt_r   # 오른쪽 Option
 MIN_SEC = 0.3          # 이보다 짧은 녹음은 오발화로 간주, 무시
 # rec 녹음 포맷 — whisper 친화적인 컴팩트 s16 PCM 으로 고정한다. _wav_duration


### PR DESCRIPTION
## 변경
whisper `initial_prompt`(`dictation_daemon.py`)에 서술형 규칙 한 줄 추가:

`한국어와 English가 섞인 받아쓰기. 영어 단어는 영문으로, 숫자는 아라비아 숫자로 적습니다.`

(기존: `한국어와 English가 섞인 받아쓰기.`)

## 왜
한국어 받아쓰기에 섞이는 영어 단어·숫자를 한글 음차 대신 원표기(라틴/아라비아)로 기울이기 위함.

## 설계 결정
- **구조형(서술 규칙)만, 어휘 목록 없음** — 특정 용어를 나열하면 발화에 없어도 출력에 끼어드는(hallucination) 위험이 있어, daemon의 기존 anti-hallucination 방침 유지.
- **리터럴 숫자 토큰 제외** — gpt-5.5 자문: "123" 같은 리터럴도 누출될 수 있어 서술만 남김.
- **"기술 용어" 아닌 "영어 단어"** — 모델은 "기술 용어" 카테고리를 적용하지 않음; 실제 경계는 발음(모델이 영어로 들은 토큰)이라 주석 표현과 일치하는 "영어 단어"로 기술.

## 부수
- plugin version 1.0.9 → 1.0.10 (pre-commit 버전 범프 훅 요구).
- daemon 주석 한 줄을 변경 내용과 동기화(숫자 표기 편향 반영).
