### PR TITLE
feat(voice-dictation): fix whisper prompting + bleed guards + VAD

### DIFF
--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.0.16",
+  "version": "1.1.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/README.md
+++ b/voice-dictation/README.md
@@ -28,19 +28,8 @@ Push-to-talk voice dictation for Claude Code, powered by whisper.cpp.
 
 ## Model
 
-전사 모델 파일이 다음 경로에 있어야 합니다:
+모델 파일이 다음 경로에 있어야 합니다:
 
 ```
 ~/whisper-models/ggml-large-v3-turbo-q5_0.bin
-```
-
-### VAD 모델 (선택, 권장)
-
-무음/잡음을 whisper 입력 *전에* 게이팅해 prompt-bleed·환각을 줄입니다 (디코더 임계는 사후
-방어, VAD는 사전·구조적 방어). 있으면 자동 사용, 없으면 자동 생략(데몬은 그대로 동작).
-같은 디렉터리에 받으세요:
-
-```
-curl -L -o ~/whisper-models/ggml-silero-v5.1.2.bin \
-  https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v5.1.2.bin
 ```

--- a/voice-dictation/README.md
+++ b/voice-dictation/README.md
@@ -28,8 +28,19 @@ Push-to-talk voice dictation for Claude Code, powered by whisper.cpp.
 
 ## Model
 
-모델 파일이 다음 경로에 있어야 합니다:
+전사 모델 파일이 다음 경로에 있어야 합니다:
 
 ```
 ~/whisper-models/ggml-large-v3-turbo-q5_0.bin
+```
+
+### VAD 모델 (선택, 권장)
+
+무음/잡음을 whisper 입력 *전에* 게이팅해 prompt-bleed·환각을 줄입니다 (디코더 임계는 사후
+방어, VAD는 사전·구조적 방어). 있으면 자동 사용, 없으면 자동 생략(데몬은 그대로 동작).
+같은 디렉터리에 받으세요:
+
+```
+curl -L -o ~/whisper-models/ggml-silero-v5.1.2.bin \
+  https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v5.1.2.bin
 ```

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -31,13 +31,12 @@ from pynput import keyboard
 MODEL = os.path.expanduser("~/whisper-models/ggml-large-v3-turbo-q5_0.bin")
 WHISPER_CLI = "whisper-cli"
 LANG = "auto"          # ko / en / auto
-# whisper 의 initial prompt — '명령'이 아니라 '편향'(soft bias, 약 224 토큰 상한).
-# 특정 용어를 나열하면 그 단어가 실제 발화에 없어도 출력에 끼어드는(hallucination)
-# 위험이 있어, 어휘 예시는 비운다. 대신 프롬프트 자체를 한국어+영문 혼합 스크립트로
-# 둬, 특정 어휘를 가리키지 않고 code-switching(영어 단어는 영문, 숫자는 아라비아 표기)을 구조적으로
-# 편향한다. 언어 선택은 LANG=auto 가 발화별로 담당하고(한/영 어느 쪽으로 말하든),
-# 이 프롬프트는 표기 스타일만 기울인다. 문법 교정·재작성은 이 층위로 불가(LLM 몫).
-PROMPT = "한국어와 English가 섞인 받아쓰기. 영어 단어는 영문으로, 숫자는 아라비아 숫자로 적습니다."
+# initial prompt 는 비운다. 내용 있는 프롬프트(어휘·표기 지시)는 무음/불명료 입력에서
+# 그 내용이 그대로 출력에 새는 prompt-bleed 환각의 발생원이었고('영어 단어는 …',
+# '아라비아 숫자 …' 가 빈 발화에 그대로 찍힘), 한국어 위주 프롬프트가 오히려 영어 단어를
+# 한글 음차 쪽으로 편향시킬 소지도 있었다. 표기 스타일(영문 표기·아라비아 숫자)은
+# whisper 네이티브 code-switching 에 맡기고, 필요하면 누출 가드와 함께 다시 도입한다.
+PROMPT = ""            # 빈 프롬프트 = --prompt 미전달 (_transcribe 의 `if PROMPT:` 가드)
 TRIGGER = keyboard.Key.alt_r   # 오른쪽 Option
 MIN_SEC = 0.3          # 이보다 짧은 녹음은 오발화로 간주, 무시
 # rec 녹음 포맷 — whisper 친화적인 컴팩트 s16 PCM 으로 고정한다. _wav_duration

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -31,12 +31,13 @@ from pynput import keyboard
 MODEL = os.path.expanduser("~/whisper-models/ggml-large-v3-turbo-q5_0.bin")
 WHISPER_CLI = "whisper-cli"
 LANG = "auto"          # ko / en / auto
-# initial prompt 는 비운다. 내용 있는 프롬프트(어휘·표기 지시)는 무음/불명료 입력에서
-# 그 내용이 그대로 출력에 새는 prompt-bleed 환각의 발생원이었고('영어 단어는 …',
-# '아라비아 숫자 …' 가 빈 발화에 그대로 찍힘), 한국어 위주 프롬프트가 오히려 영어 단어를
-# 한글 음차 쪽으로 편향시킬 소지도 있었다. 표기 스타일(영문 표기·아라비아 숫자)은
-# whisper 네이티브 code-switching 에 맡기고, 필요하면 누출 가드와 함께 다시 도입한다.
-PROMPT = ""            # 빈 프롬프트 = --prompt 미전달 (_transcribe 의 `if PROMPT:` 가드)
+# initial prompt 는 동적으로 구성한다(정적 명령문 X). whisper 의 --prompt 는 '지시'가 아니라
+# '직전 문맥'이라 모델은 프롬프트의 스타일을 이어쓴다(OpenAI). 사용자 본인의 최근 전사를
+# 프롬프트로 넣으면 = 실제 어휘·표기 스타일(영문 표기·아라비아 숫자)이 그대로 편향되고
+# 어휘에 자동 적응한다. 무음/불명료 입력의 bleed 는 디코더 임계(아래 _transcribe)로 막는다.
+RECENT_LOG = os.path.expanduser("~/.cache/voice-dictation/recent.txt")  # 영속 롤링 로그
+RECENT_N = 8           # 프롬프트에 넣을 최근 전사 개수 (whisper.cpp 가 224토큰 초과분 자동 절단)
+RECENT_KEEP = 50       # 로그 파일 보존 상한(줄)
 TRIGGER = keyboard.Key.alt_r   # 오른쪽 Option
 MIN_SEC = 0.3          # 이보다 짧은 녹음은 오발화로 간주, 무시
 # rec 녹음 포맷 — whisper 친화적인 컴팩트 s16 PCM 으로 고정한다. _wav_duration
@@ -139,6 +140,7 @@ def _transcribe_worker():
                 continue
             print(f"  ⤷ ({dt:.1f}s) {text}", flush=True)
             _inject(text)
+            _log_transcript(text)   # 동적 프롬프트용 롤링 로그에 기록
         except Exception as exc:
             print(f"  (전사 오류 — 건너뜀: {exc})", flush=True)
         finally:
@@ -226,10 +228,43 @@ def _wav_duration(path):
     return data_bytes / (sample_rate * bytes_per_frame)
 
 
+def _recent_prompt():
+    """동적 initial prompt: 최근 전사 RECENT_N 개를 직전-문맥으로 제공해 사용자 본인의
+    어휘·표기 스타일(영문 표기·아라비아 숫자)을 편향한다. 로그 없으면 빈 문자열."""
+    try:
+        with open(RECENT_LOG, encoding="utf-8") as fh:
+            lines = [ln.strip() for ln in fh if ln.strip()]
+    except OSError:
+        return ""
+    return " ".join(lines[-RECENT_N:])
+
+
+def _log_transcript(text):
+    """주입된 좋은 전사를 롤링 로그에 append 하고 최근 RECENT_KEEP 줄로 자른다.
+    다음 발화의 _recent_prompt 가 이를 직전-문맥으로 쓴다(자기적응 루프)."""
+    try:
+        os.makedirs(os.path.dirname(RECENT_LOG), exist_ok=True)
+        lines = []
+        if os.path.exists(RECENT_LOG):
+            with open(RECENT_LOG, encoding="utf-8") as fh:
+                lines = [ln.rstrip("\n") for ln in fh if ln.strip()]
+        lines.append(text)
+        with open(RECENT_LOG, "w", encoding="utf-8") as fh:
+            fh.write("\n".join(lines[-RECENT_KEEP:]) + "\n")
+    except OSError:
+        pass
+
+
 def _transcribe(path, timeout):
-    cmd = [WHISPER_CLI, "-m", MODEL, "-f", path, "-l", LANG, "-nt", "-np"]
-    if PROMPT:
-        cmd += ["--prompt", PROMPT]
+    # bleed 가드: -sns(비음성 토큰 억제) + -nth 0.4(무음 임계 0.6→0.4 강화). entropy(-et 2.40)·
+    # logprob(-lpt -1.00)·temperature fallback 은 기본값으로 이미 on(-nf 미전달). 프롬프트는
+    # _recent_prompt 로 매번 동적 구성. (단발 push-to-talk 라 직전-윈도우 문맥 조건화는 무관 —
+    # 이 whisper-cli 빌드엔 --no-context 플래그도 없음.)
+    cmd = [WHISPER_CLI, "-m", MODEL, "-f", path, "-l", LANG, "-nt", "-np",
+           "-sns", "-nth", "0.4"]
+    prompt = _recent_prompt()
+    if prompt:
+        cmd += ["--prompt", prompt]
     try:
         out = subprocess.run(
             cmd, capture_output=True, text=True, timeout=timeout,

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -38,6 +38,10 @@ LANG = "auto"          # ko / en / auto
 RECENT_LOG = os.path.expanduser("~/.cache/voice-dictation/recent.txt")  # 영속 롤링 로그
 RECENT_N = 8           # 프롬프트에 넣을 최근 전사 개수 (whisper.cpp 가 224토큰 초과분 자동 절단)
 RECENT_KEEP = 50       # 로그 파일 보존 상한(줄)
+# cold start(로그 빈 상태) 폴백 — 첫 발화를 올바른 스타일(영문 표기·아라비아 숫자)로 부트스트랩.
+# 명령문이 아니라 '원하는 출력 스타일의 샘플 문장'이라 whisper 가 그 스타일을 이어쓴다.
+# 실제 전사가 쌓이면 자연히 밀려난다(런1만 영향). 자주 쓰는 영어 용어로 다듬어도 됨.
+SEED_PROMPT = "오늘 standup에서 API 배포 일정을 review했고 version 2를 release했습니다."
 TRIGGER = keyboard.Key.alt_r   # 오른쪽 Option
 MIN_SEC = 0.3          # 이보다 짧은 녹음은 오발화로 간주, 무시
 # rec 녹음 포맷 — whisper 친화적인 컴팩트 s16 PCM 으로 고정한다. _wav_duration
@@ -230,13 +234,14 @@ def _wav_duration(path):
 
 def _recent_prompt():
     """동적 initial prompt: 최근 전사 RECENT_N 개를 직전-문맥으로 제공해 사용자 본인의
-    어휘·표기 스타일(영문 표기·아라비아 숫자)을 편향한다. 로그 없으면 빈 문자열."""
+    어휘·표기 스타일(영문 표기·아라비아 숫자)을 편향한다. 로그가 비면(cold start)
+    SEED_PROMPT 로 첫 발화를 올바른 스타일로 부트스트랩한다(이후 실제 전사가 밀어냄)."""
     try:
         with open(RECENT_LOG, encoding="utf-8") as fh:
             lines = [ln.strip() for ln in fh if ln.strip()]
     except OSError:
-        return ""
-    return " ".join(lines[-RECENT_N:])
+        lines = []
+    return " ".join(lines[-RECENT_N:]) if lines else SEED_PROMPT
 
 
 def _log_transcript(text):

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -29,6 +29,9 @@ from pynput import keyboard
 
 # ── 설정 (벤치마크로 검증된 기본값) ──
 MODEL = os.path.expanduser("~/whisper-models/ggml-large-v3-turbo-q5_0.bin")
+# Silero VAD 모델 — 있으면 _transcribe 가 --vad 로 무음/잡음을 whisper 입력 전에 게이팅한다
+# (없으면 자동 생략). 받기: huggingface ggml-org/whisper-vad → ggml-silero-v5.1.2.bin
+VAD_MODEL = os.path.expanduser("~/whisper-models/ggml-silero-v5.1.2.bin")
 WHISPER_CLI = "whisper-cli"
 LANG = "auto"          # ko / en / auto
 # initial prompt — 명령문이 아니라 '원하는 출력 스타일의 샘플 문장'. whisper 의 --prompt 는
@@ -232,6 +235,10 @@ def _transcribe(path, timeout):
     # (단발 push-to-talk 라 직전-윈도우 문맥 조건화는 무관 — 이 빌드엔 --no-context 도 없음.)
     cmd = [WHISPER_CLI, "-m", MODEL, "-f", path, "-l", LANG, "-nt", "-np",
            "-sns", "-nth", "0.4"]
+    # VAD: 무음/잡음을 whisper 앞단에서 게이팅 — bleed 의 사전·구조적 방어(임계는 사후 방어).
+    # 모델이 있을 때만 켠다(없으면 자동 생략). -vp 100 은 onset 클리핑 방지 여유.
+    if os.path.exists(VAD_MODEL):
+        cmd += ["--vad", "--vad-model", VAD_MODEL, "-vp", "100"]
     if PROMPT:
         cmd += ["--prompt", PROMPT]
     try:

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -29,9 +29,6 @@ from pynput import keyboard
 
 # ── 설정 (벤치마크로 검증된 기본값) ──
 MODEL = os.path.expanduser("~/whisper-models/ggml-large-v3-turbo-q5_0.bin")
-# Silero VAD 모델 — 있으면 _transcribe 가 --vad 로 무음/잡음을 whisper 입력 전에 게이팅한다
-# (없으면 자동 생략). 받기: huggingface ggml-org/whisper-vad → ggml-silero-v5.1.2.bin
-VAD_MODEL = os.path.expanduser("~/whisper-models/ggml-silero-v5.1.2.bin")
 WHISPER_CLI = "whisper-cli"
 LANG = "auto"          # ko / en / auto
 # initial prompt — 명령문이 아니라 '원하는 출력 스타일의 샘플 문장'. whisper 의 --prompt 는
@@ -235,10 +232,6 @@ def _transcribe(path, timeout):
     # (단발 push-to-talk 라 직전-윈도우 문맥 조건화는 무관 — 이 빌드엔 --no-context 도 없음.)
     cmd = [WHISPER_CLI, "-m", MODEL, "-f", path, "-l", LANG, "-nt", "-np",
            "-sns", "-nth", "0.4"]
-    # VAD: 무음/잡음을 whisper 앞단에서 게이팅 — bleed 의 사전·구조적 방어(임계는 사후 방어).
-    # 모델이 있을 때만 켠다(없으면 자동 생략). -vp 100 은 onset 클리핑 방지 여유.
-    if os.path.exists(VAD_MODEL):
-        cmd += ["--vad", "--vad-model", VAD_MODEL, "-vp", "100"]
     if PROMPT:
         cmd += ["--prompt", PROMPT]
     try:

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -36,7 +36,7 @@ LANG = "auto"          # ko / en / auto
 # 섞이고 영어는 Latin·숫자는 아라비아로 적힌 짧은 샘플 하나로 code-switching 표기를 편향한다.
 # (정적이라 단순; 무음/불명료 입력의 bleed 는 디코더 임계(아래 _transcribe)로 막는다.
 #  자주 쓰는 영어 용어로 다듬어도 됨.)
-PROMPT = "오늘 standup에서 API 배포 일정을 review했고 version 2를 release했습니다."
+PROMPT = "오늘 회의에서 project 일정을 확인했고 3시에 다시 meeting을 했습니다."
 TRIGGER = keyboard.Key.alt_r   # 오른쪽 Option
 MIN_SEC = 0.3          # 이보다 짧은 녹음은 오발화로 간주, 무시
 # rec 녹음 포맷 — whisper 친화적인 컴팩트 s16 PCM 으로 고정한다. _wav_duration

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -31,17 +31,12 @@ from pynput import keyboard
 MODEL = os.path.expanduser("~/whisper-models/ggml-large-v3-turbo-q5_0.bin")
 WHISPER_CLI = "whisper-cli"
 LANG = "auto"          # ko / en / auto
-# initial prompt 는 동적으로 구성한다(정적 명령문 X). whisper 의 --prompt 는 '지시'가 아니라
-# '직전 문맥'이라 모델은 프롬프트의 스타일을 이어쓴다(OpenAI). 사용자 본인의 최근 전사를
-# 프롬프트로 넣으면 = 실제 어휘·표기 스타일(영문 표기·아라비아 숫자)이 그대로 편향되고
-# 어휘에 자동 적응한다. 무음/불명료 입력의 bleed 는 디코더 임계(아래 _transcribe)로 막는다.
-RECENT_LOG = os.path.expanduser("~/.cache/voice-dictation/recent.txt")  # 영속 롤링 로그
-RECENT_N = 8           # 프롬프트에 넣을 최근 전사 개수 (whisper.cpp 가 224토큰 초과분 자동 절단)
-RECENT_KEEP = 50       # 로그 파일 보존 상한(줄)
-# cold start(로그 빈 상태) 폴백 — 첫 발화를 올바른 스타일(영문 표기·아라비아 숫자)로 부트스트랩.
-# 명령문이 아니라 '원하는 출력 스타일의 샘플 문장'이라 whisper 가 그 스타일을 이어쓴다.
-# 실제 전사가 쌓이면 자연히 밀려난다(런1만 영향). 자주 쓰는 영어 용어로 다듬어도 됨.
-SEED_PROMPT = "오늘 standup에서 API 배포 일정을 review했고 version 2를 release했습니다."
+# initial prompt — 명령문이 아니라 '원하는 출력 스타일의 샘플 문장'. whisper 의 --prompt 는
+# '지시'가 아니라 '직전 문맥'이라 모델은 프롬프트의 스타일을 이어쓴다(OpenAI). 한국어+영어가
+# 섞이고 영어는 Latin·숫자는 아라비아로 적힌 짧은 샘플 하나로 code-switching 표기를 편향한다.
+# (정적이라 단순; 무음/불명료 입력의 bleed 는 디코더 임계(아래 _transcribe)로 막는다.
+#  자주 쓰는 영어 용어로 다듬어도 됨.)
+PROMPT = "오늘 standup에서 API 배포 일정을 review했고 version 2를 release했습니다."
 TRIGGER = keyboard.Key.alt_r   # 오른쪽 Option
 MIN_SEC = 0.3          # 이보다 짧은 녹음은 오발화로 간주, 무시
 # rec 녹음 포맷 — whisper 친화적인 컴팩트 s16 PCM 으로 고정한다. _wav_duration
@@ -144,7 +139,6 @@ def _transcribe_worker():
                 continue
             print(f"  ⤷ ({dt:.1f}s) {text}", flush=True)
             _inject(text)
-            _log_transcript(text)   # 동적 프롬프트용 롤링 로그에 기록
         except Exception as exc:
             print(f"  (전사 오류 — 건너뜀: {exc})", flush=True)
         finally:
@@ -232,44 +226,14 @@ def _wav_duration(path):
     return data_bytes / (sample_rate * bytes_per_frame)
 
 
-def _recent_prompt():
-    """동적 initial prompt: 최근 전사 RECENT_N 개를 직전-문맥으로 제공해 사용자 본인의
-    어휘·표기 스타일(영문 표기·아라비아 숫자)을 편향한다. 로그가 비면(cold start)
-    SEED_PROMPT 로 첫 발화를 올바른 스타일로 부트스트랩한다(이후 실제 전사가 밀어냄)."""
-    try:
-        with open(RECENT_LOG, encoding="utf-8") as fh:
-            lines = [ln.strip() for ln in fh if ln.strip()]
-    except OSError:
-        lines = []
-    return " ".join(lines[-RECENT_N:]) if lines else SEED_PROMPT
-
-
-def _log_transcript(text):
-    """주입된 좋은 전사를 롤링 로그에 append 하고 최근 RECENT_KEEP 줄로 자른다.
-    다음 발화의 _recent_prompt 가 이를 직전-문맥으로 쓴다(자기적응 루프)."""
-    try:
-        os.makedirs(os.path.dirname(RECENT_LOG), exist_ok=True)
-        lines = []
-        if os.path.exists(RECENT_LOG):
-            with open(RECENT_LOG, encoding="utf-8") as fh:
-                lines = [ln.rstrip("\n") for ln in fh if ln.strip()]
-        lines.append(text)
-        with open(RECENT_LOG, "w", encoding="utf-8") as fh:
-            fh.write("\n".join(lines[-RECENT_KEEP:]) + "\n")
-    except OSError:
-        pass
-
-
 def _transcribe(path, timeout):
     # bleed 가드: -sns(비음성 토큰 억제) + -nth 0.4(무음 임계 0.6→0.4 강화). entropy(-et 2.40)·
-    # logprob(-lpt -1.00)·temperature fallback 은 기본값으로 이미 on(-nf 미전달). 프롬프트는
-    # _recent_prompt 로 매번 동적 구성. (단발 push-to-talk 라 직전-윈도우 문맥 조건화는 무관 —
-    # 이 whisper-cli 빌드엔 --no-context 플래그도 없음.)
+    # logprob(-lpt -1.00)·temperature fallback 은 기본값으로 이미 on(-nf 미전달).
+    # (단발 push-to-talk 라 직전-윈도우 문맥 조건화는 무관 — 이 빌드엔 --no-context 도 없음.)
     cmd = [WHISPER_CLI, "-m", MODEL, "-f", path, "-l", LANG, "-nt", "-np",
            "-sns", "-nth", "0.4"]
-    prompt = _recent_prompt()
-    if prompt:
-        cmd += ["--prompt", prompt]
+    if PROMPT:
+        cmd += ["--prompt", PROMPT]
     try:
         out = subprocess.run(
             cmd, capture_output=True, text=True, timeout=timeout,


### PR DESCRIPTION
Fix the dictation daemon's whisper prompting and hallucination handling, in three layers.

## 1. Prompt — style-sample, not instruction
whisper's `--prompt` is *prior context* — it continues the prompt's **style**, not instructions (OpenAI guide). The original Korean imperative (`영어 단어는 영문으로…`) was a misuse: not obeyed, and echoed verbatim on silence (prompt-bleed). Replaced with a short, domain-neutral KO+EN **style sample** demonstrating English-in-Latin + Arabic numerals:
`PROMPT = "오늘 회의에서 project 일정을 확인했고 3시에 다시 meeting을 했습니다."`

## 2. Decoder bleed guards (post-hoc)
`-sns` (suppress non-speech tokens) + `-nth 0.4` (no-speech threshold 0.6→0.4). Entropy/logprob/temperature-fallback on by default. Supersedes the post-hoc text filter from the closed #91.

## 3. VAD — pre-whisper audio gating (structural)
Per a Codex review, gating silence/noise *before* whisper is higher-leverage than prompt tweaking — if garbage never reaches the decoder there's nothing to echo. Wired whisper.cpp Silero VAD (`--vad --vad-model <path> -vp 100`), enabled only when the model file exists (graceful auto-skip otherwise, so machines without it still work). README documents the optional ~0.9 MB model download.

## Code-switching note
Hangul-transliterating embedded English is an architectural whisper limit (single 50K vocab). The style sample mitigates it (biases Latin), not a full cure.

## Verification
- `py_compile` clean.
- End-to-end `whisper-cli` with the full flag set (incl. `--vad`) transcribes a real capture correctly; a VAD padding sweep confirmed no onset loss vs the no-VAD baseline.
- Caught & removed an invalid `-nc` flag this whisper-cli build rejects.

## History
Supersedes #91 (closed). Explored empty → dynamic-rolling → seed, then settled on a static style sample; prompt de-skewed and VAD added per the Codex review. Net vs `main`: PROMPT + 2 guard flags + guarded VAD + README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
