### PR TITLE
feat(cdp-attach): run fork context on sonnet

### DIFF
--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -8,6 +8,7 @@ description: |
   or mentions CDP. Attaches to a running CDP instance for browser automation.
 user_invocable: true
 context: fork
+model: sonnet
 argument-hint: "<operation> [args...]"
 ---
 


### PR DESCRIPTION
## What

Set the `cdp-attach` fork model to **Sonnet**.

- Add `model: sonnet` to the skill frontmatter. Per the [Skills docs](https://code.claude.com/docs/en/skills), `model` accepts the same values as `/model`; with `context: fork` already set, the forked subagent now runs on Sonnet instead of inheriting the session model.
- Bump `1.7.0` → `1.7.1` so the change propagates to the installed plugin cache.

## Why

Browser-automation fork work (screenshots, tab ops, CDP interaction) doesn't need the session's top-tier model — pinning the fork to Sonnet keeps it cheaper without touching the main session.
