### PR TITLE
feat(pdf-split,google): run fetch-type forks on sonnet

### DIFF
--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/skills/video-understanding/SKILL.md
+++ b/google/skills/video-understanding/SKILL.md
@@ -3,6 +3,7 @@ name: video-understanding
 description: |
   This skill should be used when the user asks to "analyze video", "summarize video", "extract video transcript", "understand video content", "video to text", "describe video", "ask questions about video", or "what happens in this video". Analyzes videos using Google Gemini API with local file upload or YouTube URL input.
 context: fork
+model: sonnet
 ---
 
 # Video Understanding with Gemini

--- a/pdf-split/.claude-plugin/plugin.json
+++ b/pdf-split/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pdf-split",
   "description": "PDF chapter splitting",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/pdf-split/skills/pdf-split/SKILL.md
+++ b/pdf-split/skills/pdf-split/SKILL.md
@@ -3,6 +3,7 @@ name: pdf-split
 description: |
   This skill should be used when the user asks to "split PDF by chapters", "divide book into chapters", "extract chapters from PDF", or "break PDF into sections". Splits PDF documents based on table of contents or text patterns using pypdf.
 context: fork
+model: sonnet
 ---
 
 # PDF Chapter Splitting


### PR DESCRIPTION
## What

Pin the forked execution of two fetch-type skills to **Sonnet**, following the same pattern merged for `cdp-attach` in #93.

| skill | change | version |
|---|---|---|
| **pdf-split** | `model: sonnet` added | 1.1.0 → 1.1.1 |
| **video-understanding** (google) | `model: sonnet` added | 1.4.0 → 1.4.1 |

Both skills already declare `context: fork`, so adding `model: sonnet` makes only the isolated fork run on Sonnet — the main session is untouched ([Skills docs](https://code.claude.com/docs/en/skills): `model` accepts `/model` values; with `context: fork` the fork runs on that model).

## Why

These are I/O-bound / mechanical skills that don't need the session's top-tier model:
- **pdf-split** — deterministic PDF splitting via pypdf against TOC/text patterns.
- **video-understanding** — a thin wrapper that uploads a file / YouTube URL to the Gemini API; the actual video analysis runs on Gemini's side, so the Claude-side work is I/O.

Cheaper forks, no quality loss on the reasoning that matters.

## Scope note

This is **List A** from a survey of the repo's fork-type skills — the clean, one-line-change set. A separate **List B** (media-download, excalidraw-host, cdp-bootstrap) is *not* included: those aren't `context: fork` today, and forking the process-spawning ones carries an open question (does a fork's teardown kill long-running child processes it started?) that needs verification first.
