### PR TITLE
feat(rc-spawn): direnv-aware worktree launch

### DIFF
--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "tmux-tracked `claude remote-control` toolkit: spawn one-off sessions (remote-spawn skill) or keep a self-restarting --spawn-worktree pool host alive per project (rc-pool skill), reachable from the Claude app",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "tmux-tracked `claude remote-control` toolkit: spawn one-off sessions (remote-spawn skill) or keep a self-restarting --spawn-worktree pool host alive per project (rc-pool skill), reachable from the Claude app",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "tmux-tracked `claude remote-control` toolkit: spawn one-off sessions (remote-spawn skill) or keep a self-restarting --spawn-worktree pool host alive per project (rc-pool skill), reachable from the Claude app",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/scripts/rc-spawn.sh
+++ b/remote-tmux/scripts/rc-spawn.sh
@@ -46,43 +46,26 @@ need() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' not found on PAT
 # inherit the target dir's direnv env — its .envrc creds. A detached tmux session
 # runs the launch through a non-interactive `sh -c`, which NEVER fires direnv's
 # shell hook, so an .envrc is silently ignored unless we wrap the launch in
-# `direnv exec <dir>` explicitly. A linked git worktree usually has NO .envrc of
-# its own: repos gitignore .envrc, so `git worktree add` never materializes it —
-# borrow the MAIN worktree's via a symlink (the same .gitignore keeps the link
-# uncommitted). Trust is PROPAGATED, never fabricated: we only `direnv allow` the
-# worktree copy when the main worktree's .envrc is ALREADY allowed by the user, so
-# direnv's review gate is never bypassed (an unreviewed .envrc is never
-# auto-trusted). Fail-open: unless the target's .envrc is present AND already
-# loads, print an EMPTY prefix — the original bare `claude` launch, unchanged.
-# Diagnostics go to stderr so only the prefix lands on stdout (this runs in a
-# command sub).
+# `direnv exec <dir>` explicitly. direnv walks UP from <dir> to the nearest .envrc,
+# so a worktree nested under its main repo (the `.claude/worktrees/<name>` layout)
+# finds the main repo's already-allowed .envrc for free — no symlink, no `direnv
+# allow`, nothing created or trusted, so direnv's review gate is never bypassed.
+# Wrap ONLY when an already-allowed .envrc actually loads (DIRENV_DIR gets set);
+# otherwise print an EMPTY prefix — the original bare `claude` launch, unchanged.
+# This is the true fail-open: a blocked/unallowed .envrc, or none in the tree,
+# falls back to bare rather than failing or pointlessly wrapping the launch. (A
+# worktree created OUTSIDE its main repo tree finds no .envrc by upward walk and
+# gets the bare launch.) Diagnostics go to stderr so only the prefix lands on
+# stdout (this runs in a command sub).
 direnv_launcher() {
   local dir="$1"
   command -v direnv >/dev/null 2>&1 || return 0
-  # Linked worktree missing its own .envrc: borrow the main worktree's — but ONLY
-  # by propagating trust the user already granted. `direnv exec <main> true`
-  # succeeds iff main's .envrc is already allowed; only then symlink it in and
-  # `direnv allow` the (identical, already-trusted) worktree copy. This keeps
-  # direnv's review gate intact — an unreviewed .envrc is never auto-trusted.
-  if [ ! -e "$dir/.envrc" ] && git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    local common main_wt
-    common="$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
-    main_wt="$(dirname "$common" 2>/dev/null)"   # <main>/.git -> <main>
-    if [ -n "$common" ] && [ "$main_wt" != "$dir" ] && [ -f "$main_wt/.envrc" ] \
-       && direnv exec "$main_wt" true >/dev/null 2>&1; then   # main already allowed?
-      if ln -s "$main_wt/.envrc" "$dir/.envrc" 2>/dev/null; then
-        echo "  linked .envrc <- $main_wt/.envrc (worktree had none)" >&2
-        direnv allow "$dir" >/dev/null 2>&1 || true  # propagate the already-trusted content
-      fi
-    fi
-  fi
-  # Wrap ONLY when the target's .envrc is present AND actually loads — already
-  # allowed (direct case) or just trust-propagated (worktree case). This behavioral
-  # gate never auto-trusts unreviewed content and is the true fail-open: a missing /
-  # blocked / unallowed .envrc -> empty prefix -> the original bare `claude` launch.
-  # (The probe loads an already-trusted, typically static .envrc once — negligible
-  # next to the launch's own load.)
-  [ -e "$dir/.envrc" ] && direnv exec "$dir" true >/dev/null 2>&1 || return 0
+  # `direnv exec <dir> <cmd>` loads the nearest .envrc found by walking up from
+  # <dir>; DIRENV_DIR is set in <cmd>'s env iff an ALLOWED .envrc actually loaded.
+  # A blocked/unallowed .envrc errors (non-zero) and none-in-tree leaves DIRENV_DIR
+  # empty — both fall through to the bare launch. We never `direnv allow` anything,
+  # so no unreviewed content is ever auto-trusted.
+  direnv exec "$dir" sh -c '[ -n "$DIRENV_DIR" ]' >/dev/null 2>&1 || return 0
   # Single-quote dir the same way spawn() quotes the prompt: POSIX-safe for the
   # `sh -c` tmux runs, and safe against spaces / word-splitting.
   local edir=${dir//\'/\'\\\'\'}
@@ -121,9 +104,9 @@ spawn() {
   # Build the claude command. name is sanitized to [A-Za-z0-9._-] so it needs no
   # quoting; an optional prompt is arbitrary text, so single-quote it for the
   # `sh -c` that tmux runs. Escape embedded ' as '\'' via bash expansion (no sed).
-  # direnv-aware launch prefix (empty when there's nothing to load — see
-  # direnv_launcher). For a linked worktree this also symlinks the main worktree's
-  # .envrc in first, so the wrap has something to load.
+  # direnv-aware launch prefix — empty unless an already-allowed .envrc loads for
+  # $dir (a nested worktree finds the main repo's via direnv's upward walk; see
+  # direnv_launcher).
   local dpfx; dpfx="$(direnv_launcher "$dir")"
   local cmd="${dpfx}claude --remote-control --name $name --session-id $sid"
   if [ -n "$prompt" ]; then

--- a/remote-tmux/scripts/rc-spawn.sh
+++ b/remote-tmux/scripts/rc-spawn.sh
@@ -42,6 +42,38 @@ sanitize() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-' | sed 's/--*/-/g; s/^-/
 # instead of letting a later command fail mid-flight (or, worse, printing success).
 need() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' not found on PATH (required by rc-spawn)" >&2; return 127; }; }
 
+# Compute a launch-command PREFIX (printed to stdout) that makes a spawned claude
+# inherit the target dir's direnv env — its .envrc creds. A detached tmux session
+# runs the launch through a non-interactive `sh -c`, which NEVER fires direnv's
+# shell hook, so an .envrc is silently ignored unless we wrap the launch in
+# `direnv exec <dir>` explicitly. A linked git worktree usually has NO .envrc of
+# its own: repos gitignore .envrc, so `git worktree add` never materializes it —
+# borrow the MAIN worktree's via a symlink (the same .gitignore keeps the link
+# uncommitted) and `direnv allow` it. Fail-open: any missing piece (direnv absent,
+# no reachable .envrc, allow fails) prints an EMPTY prefix, i.e. the original bare
+# `claude` launch — behavior unchanged for repos without an .envrc. Diagnostics go
+# to stderr so only the prefix lands on stdout (this runs in a command sub).
+direnv_launcher() {
+  local dir="$1"
+  command -v direnv >/dev/null 2>&1 || return 0
+  # Linked worktree missing its own .envrc: symlink the main worktree's one in.
+  if [ ! -e "$dir/.envrc" ] && git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    local common main_wt
+    common="$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+    main_wt="$(dirname "$common" 2>/dev/null)"   # <main>/.git -> <main>
+    if [ -n "$common" ] && [ "$main_wt" != "$dir" ] && [ -f "$main_wt/.envrc" ]; then
+      ln -s "$main_wt/.envrc" "$dir/.envrc" 2>/dev/null \
+        && echo "  linked .envrc <- $main_wt/.envrc (worktree had none)" >&2
+    fi
+  fi
+  [ -e "$dir/.envrc" ] || return 0             # nothing reachable -> bare launch
+  direnv allow "$dir" >/dev/null 2>&1 || true  # idempotent; exec refuses a blocked .envrc
+  # Single-quote dir the same way spawn() quotes the prompt: POSIX-safe for the
+  # `sh -c` tmux runs, and safe against spaces / word-splitting.
+  local edir=${dir//\'/\'\\\'\'}
+  printf "direnv exec '%s' " "$edir"
+}
+
 spawn() {
   local dir="$1" name="$2" prompt="$3"
   [ -n "$dir" ] || { echo "usage: rc-spawn.sh spawn <dir> [name] [prompt]" >&2; return 2; }
@@ -74,7 +106,11 @@ spawn() {
   # Build the claude command. name is sanitized to [A-Za-z0-9._-] so it needs no
   # quoting; an optional prompt is arbitrary text, so single-quote it for the
   # `sh -c` that tmux runs. Escape embedded ' as '\'' via bash expansion (no sed).
-  local cmd="claude --remote-control --name $name --session-id $sid"
+  # direnv-aware launch prefix (empty when there's nothing to load — see
+  # direnv_launcher). For a linked worktree this also symlinks the main worktree's
+  # .envrc in first, so the wrap has something to load.
+  local dpfx; dpfx="$(direnv_launcher "$dir")"
+  local cmd="${dpfx}claude --remote-control --name $name --session-id $sid"
   if [ -n "$prompt" ]; then
     # Escape each ' as '\'' in a standalone assignment (embedding the expansion
     # inside the double-quoted cmd "...'${p//.../...}'..." mangles the backslashes).

--- a/remote-tmux/scripts/rc-spawn.sh
+++ b/remote-tmux/scripts/rc-spawn.sh
@@ -49,25 +49,40 @@ need() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' not found on PAT
 # `direnv exec <dir>` explicitly. A linked git worktree usually has NO .envrc of
 # its own: repos gitignore .envrc, so `git worktree add` never materializes it —
 # borrow the MAIN worktree's via a symlink (the same .gitignore keeps the link
-# uncommitted) and `direnv allow` it. Fail-open: any missing piece (direnv absent,
-# no reachable .envrc, allow fails) prints an EMPTY prefix, i.e. the original bare
-# `claude` launch — behavior unchanged for repos without an .envrc. Diagnostics go
-# to stderr so only the prefix lands on stdout (this runs in a command sub).
+# uncommitted). Trust is PROPAGATED, never fabricated: we only `direnv allow` the
+# worktree copy when the main worktree's .envrc is ALREADY allowed by the user, so
+# direnv's review gate is never bypassed (an unreviewed .envrc is never
+# auto-trusted). Fail-open: unless the target's .envrc is present AND already
+# loads, print an EMPTY prefix — the original bare `claude` launch, unchanged.
+# Diagnostics go to stderr so only the prefix lands on stdout (this runs in a
+# command sub).
 direnv_launcher() {
   local dir="$1"
   command -v direnv >/dev/null 2>&1 || return 0
-  # Linked worktree missing its own .envrc: symlink the main worktree's one in.
+  # Linked worktree missing its own .envrc: borrow the main worktree's — but ONLY
+  # by propagating trust the user already granted. `direnv exec <main> true`
+  # succeeds iff main's .envrc is already allowed; only then symlink it in and
+  # `direnv allow` the (identical, already-trusted) worktree copy. This keeps
+  # direnv's review gate intact — an unreviewed .envrc is never auto-trusted.
   if [ ! -e "$dir/.envrc" ] && git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     local common main_wt
     common="$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
     main_wt="$(dirname "$common" 2>/dev/null)"   # <main>/.git -> <main>
-    if [ -n "$common" ] && [ "$main_wt" != "$dir" ] && [ -f "$main_wt/.envrc" ]; then
-      ln -s "$main_wt/.envrc" "$dir/.envrc" 2>/dev/null \
-        && echo "  linked .envrc <- $main_wt/.envrc (worktree had none)" >&2
+    if [ -n "$common" ] && [ "$main_wt" != "$dir" ] && [ -f "$main_wt/.envrc" ] \
+       && direnv exec "$main_wt" true >/dev/null 2>&1; then   # main already allowed?
+      if ln -s "$main_wt/.envrc" "$dir/.envrc" 2>/dev/null; then
+        echo "  linked .envrc <- $main_wt/.envrc (worktree had none)" >&2
+        direnv allow "$dir" >/dev/null 2>&1 || true  # propagate the already-trusted content
+      fi
     fi
   fi
-  [ -e "$dir/.envrc" ] || return 0             # nothing reachable -> bare launch
-  direnv allow "$dir" >/dev/null 2>&1 || true  # idempotent; exec refuses a blocked .envrc
+  # Wrap ONLY when the target's .envrc is present AND actually loads — already
+  # allowed (direct case) or just trust-propagated (worktree case). This behavioral
+  # gate never auto-trusts unreviewed content and is the true fail-open: a missing /
+  # blocked / unallowed .envrc -> empty prefix -> the original bare `claude` launch.
+  # (The probe loads an already-trusted, typically static .envrc once — negligible
+  # next to the launch's own load.)
+  [ -e "$dir/.envrc" ] && direnv exec "$dir" true >/dev/null 2>&1 || return 0
   # Single-quote dir the same way spawn() quotes the prompt: POSIX-safe for the
   # `sh -c` tmux runs, and safe against spaces / word-splitting.
   local edir=${dir//\'/\'\\\'\'}


### PR DESCRIPTION
## Problem

Spawning a worker into a **git worktree** via `rc-spawn.sh spawn` didn't pick up the repo's `.envrc` — the worker started without direnv-provided creds. Two causes stacked:

1. **Bare launch.** `spawn()` runs `claude` through tmux's non-interactive `sh -c`, which never fires direnv's shell hook, so the `.envrc` was silently never loaded.
2. **Worktree had no `.envrc`.** Repos gitignore `.envrc`, and `git worktree add` only materializes tracked files, so a fresh worktree started without one.

Intermittency ("sometimes doesn't reflect") matched this: a main-repo spawn could inherit already-exported env, but a worktree spawn hit both and failed.

## Fix

`spawn()` computes a launch prefix via `direnv_launcher()`, wrapping the launch in **`direnv exec <dir> claude …`** so the `.envrc` loads despite the non-interactive shell.

Because worktrees nest under their main repo (the `.claude/worktrees/<name>` convention), **direnv's natural upward `.envrc` lookup** finds the main repo's already-allowed `.envrc` from the worktree — no symlink, no `direnv allow`, nothing created or trusted, so direnv's review gate is never bypassed. The wrap fires **only** when an already-allowed `.envrc` actually loads (`DIRENV_DIR` is set); a blocked/unallowed `.envrc` or none-in-tree falls through to the original **bare launch, unchanged** (true fail-open).

Scope: `spawn()` only. `resume()` and `rc-pool.sh _run` are intentionally left for a follow-up.

## Review journey (codex, `/review-loop`, 3 rounds to approve)

- **R1** → an early symlink-based implementation `direnv allow`-ed any `.envrc` at the spawn target (**trust-bypass**, arbitrary code exec) and emitted the prefix even when `allow` failed (**fail-open regression**). Fixed by propagating existing trust only.
- **R2** → the symlink branch also fired for plain **subdirs** (mutating arbitrary spawn dirs) and had a check/allow **TOCTOU**. Verification revealed the symlink was unnecessary: nested worktrees resolve the main `.envrc` by direnv's upward walk. **Dropped the symlink+allow entirely** — resolving the trust-bypass, fail-open, subdir-mutation, and TOCTOU findings at once.
- **R3** → **approve, no findings.**

## Verification

Isolated temp-repo tests (direnv allow-store redirected to a throwaway `XDG_DATA_HOME`; no touch to real worktrees/allow-list):

- nested worktree + main allowed → wrap, **no file created** in the worktree ✓
- nested worktree + main **not** allowed → bare ✓
- plain subdir of main → wrap (loads main's naturally), **no file created** in the subdir ✓
- direct repo + `.envrc` allowed → wrap; **not** allowed → bare, **no auto-allow** ✓
- no `.envrc` anywhere → bare ✓
- invoked from a direnv-active parent shell → `direnv exec` clears the ambient `DIRENV_DIR`, so the guard doesn't false-positive ✓
- `bash -n` clean.

## After merge

- Reinstall/update the plugin so the versioned cache (`…/4.1.2/`) picks up the change.
- The user-global note "rc-spawn launches claude directly without a `direnv exec` wrapper, provide creds out of band" becomes obsolete once deployed.

## Follow-up (not in this PR)

- `resume()` and `rc-pool.sh _run` (`claude … --spawn worktree`) launch bare too — the same `direnv_launcher` wrap likely wanted; deferred by decision.
