### PR TITLE
feat(unfold): Linear loop moment-router skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,6 +88,11 @@
       "name": "manim",
       "source": "./manim",
       "description": "Render short headless Manim animations (math / parametric / 3D / equations) to browser-embeddable mp4/webm/gif with a ready-to-paste embed snippet"
+    },
+    {
+      "name": "unfold",
+      "source": "./unfold",
+      "description": "Linear loop moment router — unfold the whole picture, next unblocked actions, runbook invariants, decision log, and roadmap from Linear; write only structure and decisions, never state"
     }
   ]
 }

--- a/unfold/.claude-plugin/plugin.json
+++ b/unfold/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "unfold",
   "description": "Linear loop moment router — unfold the whole picture, next unblocked actions, runbook invariants, decision log, and roadmap from Linear; write only structure and decisions, never state",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/unfold/.claude-plugin/plugin.json
+++ b/unfold/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "unfold",
+  "description": "Linear loop moment router — unfold the whole picture, next unblocked actions, runbook invariants, decision log, and roadmap from Linear; write only structure and decisions, never state",
+  "version": "0.1.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/unfold/.claude-plugin/plugin.json
+++ b/unfold/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "unfold",
   "description": "Linear loop moment router — unfold the whole picture, next unblocked actions, runbook invariants, decision log, and roadmap from Linear; write only structure and decisions, never state",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/unfold/.claude-plugin/plugin.json
+++ b/unfold/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "unfold",
   "description": "Linear loop moment router — unfold the whole picture, next unblocked actions, runbook invariants, decision log, and roadmap from Linear; write only structure and decisions, never state",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/unfold/.claude-plugin/plugin.json
+++ b/unfold/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "unfold",
   "description": "Linear loop moment router — unfold the whole picture, next unblocked actions, runbook invariants, decision log, and roadmap from Linear; write only structure and decisions, never state",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/unfold/skills/unfold/SKILL.md
+++ b/unfold/skills/unfold/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: unfold
+description: |
+  This skill should be used when the user asks to "unfold" the current work
+  picture or hits one of six recurring moments in multi-PR / multi-project
+  work tracked in Linear: "전체 그림" / "지금 상태 펼쳐줘" / "whole picture"
+  (span-open orient), "다음 뭐 하지" / "뭐가 unblocked" / "next action"
+  (next), "배포 순서" / "머지 전 확인" / "deploy order" (deploy), "이 길로
+  가는 이유 기록" / "결정 남겨줘" / "log this decision" (decide), "세션 정리"
+  / "구조 변경 반영" / "wrap up the span" (close), "로드맵" / "게이트 어디까지
+  왔지" / "roadmap" (roadmap). Reads auto-derived state from Linear via MCP;
+  writes ONLY structure and decisions (never status). Invoked as
+  /unfold [moment] [project].
+version: 0.1.0
+---
+
+# Unfold — Linear Loop Moment Router
+
+Route a recurring cognitive moment to the right Linear read or minimal write.
+The substrate premise: the whole picture (workstreams, dependency DAG, gates,
+runbook) lives in Linear as structure; state (issue status, milestone %,
+blocked-relations) is auto-derived by Linear and the GitHub integration.
+Unfold READS that picture on demand instead of reconstructing it from memory,
+and confines WRITES to the two moments where a human hand belongs: decisions
+and structure deltas.
+
+## Core rule — pace layering
+
+- **Read freely**: issue status, milestone progress %, blocked/unblocked sets
+  are system-maintained. Pull them; never cache-and-trust stale copies.
+- **Write only structure and decisions**: new workstream issues, `blockedBy`
+  edges, runbook documents, one-line decision comments.
+- **Never hand-write state**: do not set issue status, milestone completion,
+  or live-system facts (deploy/image existence) in Linear. Status flows from
+  PR events; live facts are read from their source (CI, registry, ArgoCD)
+  at need. Hand-mirrored state drifts, and stale state read back as "the
+  whole picture" pollutes downstream judgment.
+
+## Invocation
+
+`/unfold [moment] [project]` — both arguments optional.
+
+| Moment | Aliases (EN / KO) | Kind |
+|---|---|---|
+| `open` | span-open, orient, 전체 그림, 지금 상태 | read |
+| `next` | unblocked, next-action, 다음 뭐, 다음 액션 | read |
+| `deploy` | pre-deploy, merge-check, 배포 순서, 머지 전 | read |
+| `decide` | decision, path, 결정, 왜 이 순서 | **write** (one comment) |
+| `close` | span-close, wrap-up, 세션 정리, 구조 반영 | **write** (structure delta) |
+| `roadmap` | gates, timeline, 로드맵, 경로 선택 | read |
+
+- No moment argument: infer from the utterance; when nothing matches,
+  default to `open` (the most common moment).
+- Korean voice input is expected — match aliases semantically, not literally.
+
+## Project resolution
+
+Resolve the target Linear project in this order; never hardcode project IDs:
+
+1. Explicit `[project]` argument (name, ID, or slug).
+2. Infer from the working repo: take the git repo directory name (and, if
+   present, the current worktree/branch's issue identifier like `FD-123`) and
+   query Linear (`list_projects` with a name query, or `get_issue` on the
+   identifier and read its project).
+3. Ambiguous or no match: list the user's in-progress lead projects and ask
+   once. Reuse the resolved project for the rest of the session.
+
+## Tool loading
+
+Linear MCP tools are deferred in most sessions. Before the first call, load
+schemas via ToolSearch, e.g.
+`select:mcp__claude_ai_Linear__list_issues,mcp__claude_ai_Linear__get_issue,mcp__claude_ai_Linear__list_milestones,mcp__claude_ai_Linear__get_project,mcp__claude_ai_Linear__list_documents,mcp__claude_ai_Linear__get_document,mcp__claude_ai_Linear__save_comment,mcp__claude_ai_Linear__save_issue,mcp__claude_ai_Linear__save_document`
+(load only what the moment needs; exact server prefix may differ — discover
+with a keyword search on "linear" first when unsure).
+
+## Moment routing (summary)
+
+Detailed per-moment procedures, the unblocked-derivation algorithm, and write
+templates live in `references/moments.md` — consult it when executing a
+moment. Summary:
+
+| Moment | Reads | Writes | Emit |
+|---|---|---|---|
+| `open` | project, milestones (%), open issues + relations, documents | — | current gate + % · unblocked next actions · runbook pointer |
+| `next` | open issues + relations | — | unblocked list only, ranked |
+| `deploy` | runbook document | — | ordering invariants section only |
+| `decide` | the target issue | `save_comment` | one-line decision log (draft → confirm → write) |
+| `close` | this session's work | `save_issue` / `save_document` | structure-delta checklist → minimal writes |
+| `roadmap` | initiative, member projects, milestones | optional `save_comment` | gate timeline + open path decisions |
+
+## Output discipline
+
+- Keep the readout compact: the moment's decision-relevant slice only —
+  current gate, its %, and the unblocked set are almost always the payload.
+  Do not dump full issue lists or document bodies.
+- Every write moment shows a draft first and writes only on user confirmation
+  (a decision comment and a structure delta are outward, team-visible acts).
+- When a read reveals stale structure (an edge or runbook contradicting
+  reality), surface it as a proposed structure fix — do not silently rewrite.
+
+## Additional Resources
+
+- **`references/moments.md`** — per-moment procedures: MCP call sequences,
+  the unblocked-derivation algorithm, decision-comment and structure-delta
+  templates, roadmap aggregation.

--- a/unfold/skills/unfold/SKILL.md
+++ b/unfold/skills/unfold/SKILL.md
@@ -11,7 +11,7 @@ description: |
   왔지" / "roadmap" (roadmap). Reads auto-derived state from Linear via MCP;
   writes ONLY structure and decisions (never status). Invoked as
   /unfold [moment] [project].
-version: 0.1.1
+version: 0.1.2
 ---
 
 # Unfold — Linear Loop Moment Router
@@ -73,7 +73,7 @@ Resolve the target Linear project in this order; never hardcode project IDs:
 
 Linear MCP tools are deferred in most sessions. Before the first call, load
 schemas via ToolSearch, e.g.
-`select:mcp__claude_ai_Linear__list_issues,mcp__claude_ai_Linear__get_issue,mcp__claude_ai_Linear__list_milestones,mcp__claude_ai_Linear__get_project,mcp__claude_ai_Linear__list_documents,mcp__claude_ai_Linear__get_document,mcp__claude_ai_Linear__save_comment,mcp__claude_ai_Linear__save_issue,mcp__claude_ai_Linear__save_document`
+`select:mcp__claude_ai_Linear__list_issues,mcp__claude_ai_Linear__get_issue,mcp__claude_ai_Linear__list_milestones,mcp__claude_ai_Linear__get_project,mcp__claude_ai_Linear__list_documents,mcp__claude_ai_Linear__get_document,mcp__claude_ai_Linear__save_comment,mcp__claude_ai_Linear__save_issue,mcp__claude_ai_Linear__save_document,mcp__claude_ai_Linear__get_initiative,mcp__claude_ai_Linear__list_initiatives`
 (load only what the moment needs; exact server prefix may differ — discover
 with a keyword search on "linear" first when unsure).
 

--- a/unfold/skills/unfold/SKILL.md
+++ b/unfold/skills/unfold/SKILL.md
@@ -11,7 +11,7 @@ description: |
   왔지" / "roadmap" (roadmap). Reads auto-derived state from Linear via MCP;
   writes ONLY structure and decisions (never status). Invoked as
   /unfold [moment] [project].
-version: 0.1.0
+version: 0.1.1
 ---
 
 # Unfold — Linear Loop Moment Router
@@ -34,7 +34,11 @@ and structure deltas.
   or live-system facts (deploy/image existence) in Linear. Status flows from
   PR events; live facts are read from their source (CI, registry, ArgoCD)
   at need. Hand-mirrored state drifts, and stale state read back as "the
-  whole picture" pollutes downstream judgment.
+  whole picture" pollutes downstream judgment. Sole exception: the initial
+  state of a backfilled issue — one created for work finished before the
+  issue existed — is set once at creation, because no PR event will ever
+  fire for it; this is a one-time creation fact, not ongoing mirroring,
+  and automation owns the state from then on.
 
 ## Invocation
 
@@ -86,7 +90,7 @@ moment. Summary:
 | `deploy` | runbook document | — | ordering invariants section only |
 | `decide` | the target issue | `save_comment` | one-line decision log (draft → confirm → write) |
 | `close` | this session's work | `save_issue` / `save_document` | structure-delta checklist → minimal writes |
-| `roadmap` | initiative, member projects, milestones | optional `save_comment` | gate timeline + open path decisions |
+| `roadmap` | initiative, member projects, milestones | — (path decisions route to `decide`) | gate timeline + open path decisions |
 
 ## Output discipline
 

--- a/unfold/skills/unfold/SKILL.md
+++ b/unfold/skills/unfold/SKILL.md
@@ -11,7 +11,6 @@ description: |
   왔지" / "roadmap" (roadmap). Reads auto-derived state from Linear via MCP;
   writes ONLY structure and decisions (never status). Invoked as
   /unfold [moment] [project].
-version: 0.1.2
 ---
 
 # Unfold — Linear Loop Moment Router
@@ -73,7 +72,7 @@ Resolve the target Linear project in this order; never hardcode project IDs:
 
 Linear MCP tools are deferred in most sessions. Before the first call, load
 schemas via ToolSearch, e.g.
-`select:mcp__claude_ai_Linear__list_issues,mcp__claude_ai_Linear__get_issue,mcp__claude_ai_Linear__list_milestones,mcp__claude_ai_Linear__get_project,mcp__claude_ai_Linear__list_documents,mcp__claude_ai_Linear__get_document,mcp__claude_ai_Linear__save_comment,mcp__claude_ai_Linear__save_issue,mcp__claude_ai_Linear__save_document,mcp__claude_ai_Linear__get_initiative,mcp__claude_ai_Linear__list_initiatives`
+`select:mcp__claude_ai_Linear__list_issues,mcp__claude_ai_Linear__get_issue,mcp__claude_ai_Linear__list_projects,mcp__claude_ai_Linear__list_milestones,mcp__claude_ai_Linear__get_project,mcp__claude_ai_Linear__list_documents,mcp__claude_ai_Linear__get_document,mcp__claude_ai_Linear__list_comments,mcp__claude_ai_Linear__save_comment,mcp__claude_ai_Linear__save_issue,mcp__claude_ai_Linear__save_document,mcp__claude_ai_Linear__get_initiative,mcp__claude_ai_Linear__list_initiatives`
 (load only what the moment needs; exact server prefix may differ — discover
 with a keyword search on "linear" first when unsure).
 
@@ -90,7 +89,7 @@ moment. Summary:
 | `deploy` | runbook document | — | ordering invariants section only |
 | `decide` | the target issue | `save_comment` | one-line decision log (draft → confirm → write) |
 | `close` | this session's work | `save_issue` / `save_document` | structure-delta checklist → minimal writes |
-| `roadmap` | initiative, member projects, milestones | — (path decisions route to `decide`) | gate timeline + open path decisions |
+| `roadmap` | initiative, member projects, milestones, decision comments | — (path decisions route to `decide`) | gate timeline + open path decisions |
 
 ## Output discipline
 

--- a/unfold/skills/unfold/references/moments.md
+++ b/unfold/skills/unfold/references/moments.md
@@ -69,7 +69,10 @@ Checklist the session against the structure in Linear; write only deltas:
 
 1. **New workstream emerged?** → `save_issue` (team, project, milestone,
    `blockedBy`/`blocks` edges, PR links as `links`). State: let automation
-   own it — set only the initial state when backfilling already-done work.
+   own it. Backfill exception (mirrors the SKILL.md core rule): an issue
+   created for work finished before it existed gets its state set once at
+   creation — no PR event will ever fire for it; a one-time creation fact,
+   not ongoing state mirroring.
 2. **Dependency changed?** → `save_issue` on the existing issue with
    `blockedBy`/`removeBlockedBy` etc.
 3. **Runbook stale?** (order/invariant changed this session) →

--- a/unfold/skills/unfold/references/moments.md
+++ b/unfold/skills/unfold/references/moments.md
@@ -91,10 +91,14 @@ Show the delta list as a draft; write each item on confirmation.
 1. `get_initiative` / `list_initiatives` for the umbrella; `list_projects`
    or the initiative's member projects.
 2. Per project: `list_milestones` — gate ladder with %.
-3. Emit the gate timeline: which gate each project sits at, which gates are
+3. Decision layer: `list_comments` with `projectId` per member project —
+   the project-anchored decision threads `decide` writes — plus open issues
+   in a hold/paused-type state (`list_issues` scoped to the project). These
+   are the executable sources for pending path decisions and HOLD items.
+4. Emit the gate timeline: which gate each project sits at, which gates are
    blocked on which (project dependencies are end-to-start only), and the
-   open path decisions (pending decision comments, HOLD items).
-4. A path decision made here → route to `decide` (comment on the issue or a
+   open path decisions from step 3 (pending decision comments, HOLD items).
+5. A path decision made here → route to `decide` (comment on the issue or a
    project-level comment via `save_comment` with `projectId`).
 
 ## Caveats learned in the field

--- a/unfold/skills/unfold/references/moments.md
+++ b/unfold/skills/unfold/references/moments.md
@@ -1,0 +1,106 @@
+# Unfold — Per-Moment Procedures
+
+Detailed execution for each moment. All reads treat Linear as the source of
+truth for structure and auto-derived state; live-system facts (image in a
+registry, deploy applied) are never read from Linear — go to their source.
+
+## Shared: unblocked derivation
+
+Linear auto-demotes a `blockedBy` relation to `related` when the blocking
+issue completes, so "currently blocked" is live. There is no server-side
+"unblocked" filter — derive client-side:
+
+1. `list_issues` scoped to the project, excluding completed/canceled states.
+2. For candidates, `get_issue` with `includeRelations: true`.
+3. `unblocked(i)` ≡ `relations.blockedBy` is empty ∧ status type is not
+   completed/canceled.
+4. Rank: In Progress first, then Todo within the earliest un-done milestone
+   (gate order = milestone sortOrder), then priority.
+
+Keep calls bounded: derive relations only for issues in the earliest one or
+two open gates, not the whole project.
+
+## open — span-open orient
+
+Purpose: start the session from the externalized whole, not from memory.
+
+1. `get_project` — name, target date, initiative.
+2. `list_milestones` — gates in sortOrder with auto progress %. The current
+   gate = earliest milestone with progress < 100.
+3. Unblocked derivation (above) within the current gate.
+4. `list_documents` — surface the runbook document title + link (do not load
+   its body unless asked).
+
+Emit: one compact block — project · current gate (+%) · unblocked next
+actions (issue key + title) · runbook pointer. Three to six lines.
+
+## next — next action
+
+Subset of `open` when orientation is already established: run the unblocked
+derivation only and emit the ranked unblocked list. If empty, say which
+blocker is holding the front (the blocking issue and its status) — that IS
+the next action's location.
+
+## deploy — pre-merge/deploy ordering check
+
+1. `list_documents` → `get_document` on the runbook.
+2. Extract and emit ONLY the ordering-invariants section (the runbook's
+   sequence rules: what must precede what; parallel-safe sets).
+3. Do not emit status; the question at this moment is "is the order I'm
+   about to act in legal", not "where are we".
+
+## decide — decision log (write, one comment)
+
+The only recurring hand-write. Template (one line, plus optional basis):
+
+> 결정: <chosen path>. 이유: <one-line why>. 배제: <rejected alternative — why not>.
+
+1. Identify the issue the decision belongs to (the workstream issue whose
+   path was chosen). Ambiguous → ask which issue anchors the decision.
+2. Draft the comment from the template; show the draft.
+3. On confirmation, `save_comment` with `issueId`.
+
+A decision that changes the dependency topology is not just a comment — it is
+also a `close`-style structure delta (edge change). Do both.
+
+## close — span-close structure delta (write)
+
+Checklist the session against the structure in Linear; write only deltas:
+
+1. **New workstream emerged?** → `save_issue` (team, project, milestone,
+   `blockedBy`/`blocks` edges, PR links as `links`). State: let automation
+   own it — set only the initial state when backfilling already-done work.
+2. **Dependency changed?** → `save_issue` on the existing issue with
+   `blockedBy`/`removeBlockedBy` etc.
+3. **Runbook stale?** (order/invariant changed this session) →
+   `save_document` update — structure and order only, never current status.
+4. **Distilled handoff produced?** (a cold, self-contained runbook for a
+   fresh session) → `save_document` as a project document.
+5. Everything else (progress, status, percentages) — explicitly NOT written.
+
+Show the delta list as a draft; write each item on confirmation.
+
+## roadmap — path selection over gates
+
+1. `get_initiative` / `list_initiatives` for the umbrella; `list_projects`
+   or the initiative's member projects.
+2. Per project: `list_milestones` — gate ladder with %.
+3. Emit the gate timeline: which gate each project sits at, which gates are
+   blocked on which (project dependencies are end-to-start only), and the
+   open path decisions (pending decision comments, HOLD items).
+4. A path decision made here → route to `decide` (comment on the issue or a
+   project-level comment via `save_comment` with `projectId`).
+
+## Caveats learned in the field
+
+- Milestones have no explicit sortOrder parameter on write; creation order
+  fixes display order. Plan gate creation order accordingly.
+- Milestone/Initiative entities are absent from Linear webhooks — any local
+  cache of gate % must be pull-based (refresh at session start / on demand).
+- Project health (On track / At risk) is permanently manual in Linear — do
+  not treat it as auto-derived state, and do not hand-write it as part of
+  this skill's moments.
+- The GitHub integration transitions issue status only when the team's Git
+  automations mapping is configured (Team Settings → Workflow) and the PR
+  references the issue (identifier in branch name, or magic word in the PR
+  description). When automation seems dead, check those two wires first.

--- a/unfold/skills/unfold/references/moments.md
+++ b/unfold/skills/unfold/references/moments.md
@@ -70,6 +70,12 @@ also a `close`-style structure delta (edge change). Do both.
 
 Checklist the session against the structure in Linear; write only deltas:
 
+0. **Read current structure first** — `list_issues` scoped to the project
+   (non-archived; `includeRelations` on candidates) and `list_documents`.
+   A delta exists only against this read: an issue, edge, or runbook line
+   already present in Linear is not a delta, and re-writing it creates
+   duplicates or clobbers edits made outside this session.
+
 1. **New workstream emerged?** → `save_issue` (team, project, milestone,
    `blockedBy`/`blocks` edges, PR links as `links`). State: let automation
    own it. Backfill exception (mirrors the SKILL.md core rule): an issue
@@ -91,13 +97,19 @@ Show the delta list as a draft; write each item on confirmation.
 1. `get_initiative` / `list_initiatives` for the umbrella; `list_projects`
    or the initiative's member projects.
 2. Per project: `list_milestones` — gate ladder with %.
-3. Decision layer: `list_comments` with `projectId` per member project —
-   the project-anchored decision threads `decide` writes — plus open issues
-   in a hold/paused-type state (`list_issues` scoped to the project). These
-   are the executable sources for pending path decisions and HOLD items.
+3. Decision layer: `list_comments` with `projectId` per member project
+   (the project-anchored decision threads `decide` writes) plus
+   `list_issues` scoped to the project for hold/paused-type states.
+   Distinguish by thread state: a thread whose latest message is a
+   `결정:` record is a RESOLVED decision — emit as context, not as open;
+   a thread ending in an open question, and any hold-state issue, is an
+   OPEN path decision. Issue-anchored decisions belong to their
+   workstream's `open`/`next` view — roadmap deliberately reads only the
+   project layer.
 4. Emit the gate timeline: which gate each project sits at, which gates are
-   blocked on which (project dependencies are end-to-start only), and the
-   open path decisions from step 3 (pending decision comments, HOLD items).
+   blocked on which (project dependencies are end-to-start only), the open
+   path decisions from step 3, and the latest resolved decisions as
+   context.
 5. A path decision made here → route to `decide` (comment on the issue or a
    project-level comment via `save_comment` with `projectId`).
 

--- a/unfold/skills/unfold/references/moments.md
+++ b/unfold/skills/unfold/references/moments.md
@@ -55,10 +55,13 @@ The only recurring hand-write. Template (one line, plus optional basis):
 
 > 결정: <chosen path>. 이유: <one-line why>. 배제: <rejected alternative — why not>.
 
-1. Identify the issue the decision belongs to (the workstream issue whose
-   path was chosen). Ambiguous → ask which issue anchors the decision.
+1. Identify the anchor the decision belongs to: the workstream issue whose
+   path was chosen (default), or the project itself when the decision spans
+   workstreams (e.g. a roadmap path selection). Ambiguous → ask which issue
+   or project anchors the decision.
 2. Draft the comment from the template; show the draft.
-3. On confirmation, `save_comment` with `issueId`.
+3. On confirmation, `save_comment` with `issueId` — or `projectId` for a
+   project-scoped decision; the tool accepts exactly one parent.
 
 A decision that changes the dependency topology is not just a comment — it is
 also a `close`-style structure delta (edge change). Do both.


### PR DESCRIPTION
## What

New plugin `unfold` — Linear loop moment router. `/unfold [moment] [project]`가 여섯 습관 순간(open/next/deploy/decide/close/roadmap)을 Linear MCP 읽기 또는 최소 쓰기(구조·결정만)로 라우팅.

## Why

Linear-substrate 설계 세션(2026-07-02)의 습관 루프를 수동 호출 가능한 스킬로 — 우선 손으로 불러 쓰며 습관을 형성. Extended Mind 소속이라 cc-plugin 착지 (workspace-map Constellation; rubric상 프로토콜 아닌 유틸리티 — epistemic-protocols 아님).

## Notes

- pace-layering 내장: 상태는 자동 파생만 읽고, 쓰기는 decide 코멘트·close 구조 델타 2순간뿐
- unblocked 도출 알고리즘·순간별 절차는 references/moments.md (progressive disclosure)
- 프로젝트 ID 하드코딩 없음 — repo명/이슈 식별자에서 추론, zero-shot portable
