### PR TITLE
Update video-understanding skill to gemini-3.5-flash

### DIFF
--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/skills/video-understanding/SKILL.md
+++ b/google/skills/video-understanding/SKILL.md
@@ -18,8 +18,8 @@ development. Inputs are plain dicts — no `types.*` wrappers — and output is 
 ## Prerequisites
 
 ```bash
-# Install SDK (Interactions API requires >= 2.0.0)
-uv pip install "google-genai>=2.0.0"
+# Install SDK (Interactions API requires >= 2.3.0)
+uv pip install "google-genai>=2.3.0"
 
 # Set API key
 export GEMINI_API_KEY="your-api-key"
@@ -29,7 +29,7 @@ export GEMINI_API_KEY="your-api-key"
 
 ### 1. Files API Upload (Recommended for local files)
 
-For files >20MB (or when reusing a video across prompts), use Files API for reliable upload.
+For files that would push the request past 20MB once base64-encoded (raw size above ~15MB), or when reusing a video across prompts, use Files API for reliable upload.
 
 ```python
 import os
@@ -61,7 +61,7 @@ interaction = client.interactions.create(
 print(interaction.output_text)
 ```
 
-### 2. Inline Data (For small files <20MB)
+### 2. Inline Data (total request <20MB after base64 encoding — raw size up to ~15MB)
 
 ```python
 import base64
@@ -195,6 +195,21 @@ interaction = client.interactions.create(
 print(interaction.output_text)
 ```
 
+### Server-Side Storage (`store`)
+
+By default the Interactions API stores every interaction server-side (`store=true`).
+The bundled script passes `store=False` — a one-shot analysis has no reason to
+persist requests. Note `store=False` is incompatible with `previous_interaction_id`
+chaining and `background=true`; omit it if you build multi-turn flows on top.
+
+```python
+interaction = client.interactions.create(
+    model="gemini-3.5-flash",
+    input=[...],
+    store=False,  # do not persist this interaction server-side
+)
+```
+
 ## Token Calculation
 
 Understanding token costs for capacity planning:
@@ -225,8 +240,8 @@ Understanding token costs for capacity planning:
 ## Workflow
 
 1. **Determine input method:**
-   - Local file >20MB → Files API upload
-   - Local file <20MB → Inline data
+   - Local file above ~15MB raw (>20MB once base64-encoded) → Files API upload
+   - Smaller local file → Inline data
    - YouTube public URL → Direct URL
 
 2. **Choose analysis type** based on user request

--- a/google/skills/video-understanding/SKILL.md
+++ b/google/skills/video-understanding/SKILL.md
@@ -29,7 +29,7 @@ export GEMINI_API_KEY="your-api-key"
 
 ### 1. Files API Upload (Recommended for local files)
 
-For files >100MB or videos >1 minute, use Files API for reliable upload.
+For files >20MB (or when reusing a video across prompts), use Files API for reliable upload.
 
 ```python
 from google import genai

--- a/google/skills/video-understanding/SKILL.md
+++ b/google/skills/video-understanding/SKILL.md
@@ -174,7 +174,7 @@ Reduce token usage with lower resolution:
 
 ```python
 config = types.GenerateContentConfig(
-    media_resolution="low"  # 66 tokens/frame vs 258 default
+    media_resolution=types.MediaResolution.MEDIA_RESOLUTION_LOW  # 66 tokens/frame vs 258 default
 )
 
 response = client.models.generate_content(

--- a/google/skills/video-understanding/SKILL.md
+++ b/google/skills/video-understanding/SKILL.md
@@ -32,6 +32,8 @@ export GEMINI_API_KEY="your-api-key"
 For files >20MB (or when reusing a video across prompts), use Files API for reliable upload.
 
 ```python
+import os
+
 from google import genai
 
 client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))

--- a/google/skills/video-understanding/SKILL.md
+++ b/google/skills/video-understanding/SKILL.md
@@ -8,7 +8,7 @@ model: sonnet
 
 # Video Understanding with Gemini
 
-Analyze video content using Google Gemini 3 Flash API. Extract summaries, transcripts, timestamps, and answer questions about video content from local files or YouTube URLs.
+Analyze video content using Google Gemini 3.5 Flash API. Extract summaries, transcripts, timestamps, and answer questions about video content from local files or YouTube URLs.
 
 ## Prerequisites
 
@@ -45,7 +45,7 @@ if video_file.state.name == "FAILED":
 
 # Analyze
 response = client.models.generate_content(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     contents=[video_file, "Summarize this video"]
 )
 print(response.text)
@@ -60,7 +60,7 @@ with open("/path/to/short_video.mp4", "rb") as f:
     video_data = base64.standard_b64encode(f.read()).decode("utf-8")
 
 response = client.models.generate_content(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     contents=[
         {"inline_data": {"mime_type": "video/mp4", "data": video_data}},
         "What is happening in this video?"
@@ -74,7 +74,7 @@ response = client.models.generate_content(
 from google.genai import types
 
 response = client.models.generate_content(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     contents=types.Content(
         parts=[
             types.Part(
@@ -142,7 +142,7 @@ Analyze specific segments only:
 from google.genai import types
 
 response = client.models.generate_content(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     contents=[
         types.Part(
             file_data=types.FileData(file_uri=video_file.uri),
@@ -178,7 +178,7 @@ config = types.GenerateContentConfig(
 )
 
 response = client.models.generate_content(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     contents=[video_file, prompt],
     config=config
 )

--- a/google/skills/video-understanding/SKILL.md
+++ b/google/skills/video-understanding/SKILL.md
@@ -10,11 +10,16 @@ model: sonnet
 
 Analyze video content using Google Gemini 3.5 Flash API. Extract summaries, transcripts, timestamps, and answer questions about video content from local files or YouTube URLs.
 
+Uses the **Interactions API** (`client.interactions.create`), the current standard idiom
+in Google's docs. `generateContent` still works, but Interactions is the default for new
+development. Inputs are plain dicts — no `types.*` wrappers — and output is read from
+`interaction.output_text`.
+
 ## Prerequisites
 
 ```bash
-# Install SDK
-uv pip install google-genai
+# Install SDK (Interactions API requires >= 2.0.0)
+uv pip install "google-genai>=2.0.0"
 
 # Set API key
 export GEMINI_API_KEY="your-api-key"
@@ -44,11 +49,14 @@ if video_file.state.name == "FAILED":
     raise ValueError("Video processing failed")
 
 # Analyze
-response = client.models.generate_content(
+interaction = client.interactions.create(
     model="gemini-3.5-flash",
-    contents=[video_file, "Summarize this video"]
+    input=[
+        {"type": "text", "text": "Summarize this video"},
+        {"type": "video", "uri": video_file.uri, "mime_type": video_file.mime_type},
+    ],
 )
-print(response.text)
+print(interaction.output_text)
 ```
 
 ### 2. Inline Data (For small files <20MB)
@@ -59,33 +67,27 @@ import base64
 with open("/path/to/short_video.mp4", "rb") as f:
     video_data = base64.standard_b64encode(f.read()).decode("utf-8")
 
-response = client.models.generate_content(
+interaction = client.interactions.create(
     model="gemini-3.5-flash",
-    contents=[
-        {"inline_data": {"mime_type": "video/mp4", "data": video_data}},
-        "What is happening in this video?"
-    ]
+    input=[
+        {"type": "text", "text": "What is happening in this video?"},
+        {"type": "video", "data": video_data, "mime_type": "video/mp4"},
+    ],
 )
+print(interaction.output_text)
 ```
 
 ### 3. YouTube URL (Public videos only)
 
 ```python
-from google.genai import types
-
-response = client.models.generate_content(
+interaction = client.interactions.create(
     model="gemini-3.5-flash",
-    contents=types.Content(
-        parts=[
-            types.Part(
-                file_data=types.FileData(
-                    file_uri="https://www.youtube.com/watch?v=VIDEO_ID"
-                )
-            ),
-            types.Part(text="Summarize this video with key timestamps")
-        ]
-    )
+    input=[
+        {"type": "text", "text": "Summarize this video with key timestamps"},
+        {"type": "video", "uri": "https://www.youtube.com/watch?v=VIDEO_ID"},
+    ],
 )
+print(interaction.output_text)
 ```
 
 **YouTube Limits:**
@@ -134,9 +136,11 @@ prompt = "What tools are used in this tutorial?"
 
 ## Advanced Configuration
 
-### Video Clipping
+### Video Clipping (legacy generate_content only)
 
-Analyze specific segments only:
+The Interactions API has no offset parameter — `video_metadata` offsets are silently
+ignored (verified: a clipped request bills the full video's tokens). To analyze a
+specific segment, use the legacy `generate_content` call, which still honors offsets:
 
 ```python
 from google.genai import types
@@ -154,11 +158,13 @@ response = client.models.generate_content(
         "Summarize this segment"
     ]
 )
+print(response.text)
 ```
 
-### Frame Rate Control
+### Frame Rate Control (legacy generate_content only)
 
-Adjust sampling rate for different content types:
+Custom `fps` is likewise unavailable in the Interactions API; use the legacy
+`generate_content` call via `types.VideoMetadata`:
 
 ```python
 # Default: 1 FPS
@@ -170,18 +176,19 @@ video_metadata=types.VideoMetadata(fps=0.5)  # 1 frame per 2 seconds
 
 ### Resolution Control
 
-Reduce token usage with lower resolution:
+Reduce token usage with lower resolution. `media_resolution` is a request-level
+parameter under `generation_config`, so it applies to every source (local and YouTube):
 
 ```python
-config = types.GenerateContentConfig(
-    media_resolution=types.MediaResolution.MEDIA_RESOLUTION_LOW  # 66 tokens/frame vs 258 default
-)
-
-response = client.models.generate_content(
+interaction = client.interactions.create(
     model="gemini-3.5-flash",
-    contents=[video_file, prompt],
-    config=config
+    input=[
+        {"type": "text", "text": prompt},
+        {"type": "video", "uri": video_file.uri, "mime_type": video_file.mime_type},
+    ],
+    generation_config={"media_resolution": "MEDIA_RESOLUTION_LOW"},  # 66 tokens/frame vs 258 default
 )
+print(interaction.output_text)
 ```
 
 ## Token Calculation
@@ -221,9 +228,9 @@ Understanding token costs for capacity planning:
 2. **Choose analysis type** based on user request
 
 3. **Configure optimization:**
-   - Long videos → Use clipping for specific segments
-   - Token budget → Use low resolution
-   - Static content → Lower FPS
+   - Token budget → Use low resolution (`--low-res` / `media_resolution`)
+   - Long videos → Clip specific segments (legacy `generate_content` only)
+   - Static content → Lower FPS (legacy `generate_content` only)
 
 4. **Execute and iterate** based on results
 
@@ -246,7 +253,7 @@ for f in client.files.list():
 
 ```python
 try:
-    response = client.models.generate_content(...)
+    interaction = client.interactions.create(...)
 except Exception as e:
     if "PERMISSION_DENIED" in str(e):
         # Check API key or quota
@@ -272,5 +279,5 @@ Utility scripts for common operations:
 - [ ] Input method selected (Files API / inline / YouTube)
 - [ ] Analysis type chosen (summary / transcript / timestamps / visual / QnA)
 - [ ] Token budget considered (use low-res if needed)
-- [ ] Clipping configured for long videos (if applicable)
+- [ ] Clipping configured for long videos (legacy `generate_content`, if applicable)
 - [ ] Cleanup planned for uploaded files

--- a/google/skills/video-understanding/SKILL.md
+++ b/google/skills/video-understanding/SKILL.md
@@ -176,17 +176,19 @@ video_metadata=types.VideoMetadata(fps=0.5)  # 1 frame per 2 seconds
 
 ### Resolution Control
 
-Reduce token usage with lower resolution. `media_resolution` is a request-level
-parameter under `generation_config`, so it applies to every source (local and YouTube):
+Reduce token usage with lower resolution. `resolution` is a per-item field on the video
+input part (values: `low`, `medium`, `high`, `ultra_high`), so it applies to every source
+(local and YouTube) by tagging each video part. `generation_config` has no matching
+resolution key in the Interactions API — such a key there would be silently ignored:
 
 ```python
 interaction = client.interactions.create(
     model="gemini-3.5-flash",
     input=[
         {"type": "text", "text": prompt},
-        {"type": "video", "uri": video_file.uri, "mime_type": video_file.mime_type},
+        {"type": "video", "uri": video_file.uri, "mime_type": video_file.mime_type,
+         "resolution": "low"},  # 66 tokens/frame vs 258 default
     ],
-    generation_config={"media_resolution": "MEDIA_RESOLUTION_LOW"},  # 66 tokens/frame vs 258 default
 )
 print(interaction.output_text)
 ```
@@ -228,7 +230,7 @@ Understanding token costs for capacity planning:
 2. **Choose analysis type** based on user request
 
 3. **Configure optimization:**
-   - Token budget → Use low resolution (`--low-res` / `media_resolution`)
+   - Token budget → Use low resolution (`--low-res` / per-item `resolution`)
    - Long videos → Clip specific segments (legacy `generate_content` only)
    - Static content → Lower FPS (legacy `generate_content` only)
 

--- a/google/skills/video-understanding/references/api-reference.md
+++ b/google/skills/video-understanding/references/api-reference.md
@@ -78,7 +78,7 @@ response = client.models.generate_content(
     config=types.GenerateContentConfig(
         temperature=0.7,
         max_output_tokens=8192,
-        media_resolution="low",  # Reduce token usage
+        media_resolution=types.MediaResolution.MEDIA_RESOLUTION_LOW,  # Reduce token usage
     )
 )
 ```
@@ -310,7 +310,7 @@ Audio processing specs:
 
 ### Optimize Token Usage
 
-1. Use `media_resolution="low"` for non-visual analysis
+1. Use `media_resolution=types.MediaResolution.MEDIA_RESOLUTION_LOW` for non-visual analysis
 2. Set appropriate FPS for content type
 3. Use clipping to analyze only relevant segments
 4. Delete uploaded files after use

--- a/google/skills/video-understanding/references/api-reference.md
+++ b/google/skills/video-understanding/references/api-reference.md
@@ -4,7 +4,7 @@ Detailed API documentation for video analysis with Gemini.
 
 ## Model
 
-- `gemini-3-flash-preview`: 1M Latest capabilities
+- `gemini-3.5-flash`: 1M Latest capabilities
 
 ## Files API
 
@@ -62,7 +62,7 @@ client.files.delete(name=video_file.name)
 
 ```python
 response = client.models.generate_content(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     contents=[video_file, "Your prompt here"]
 )
 ```
@@ -73,7 +73,7 @@ response = client.models.generate_content(
 from google.genai import types
 
 response = client.models.generate_content(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     contents=[video_file, prompt],
     config=types.GenerateContentConfig(
         temperature=0.7,
@@ -133,7 +133,7 @@ video_metadata=types.VideoMetadata(
 
 ```python
 response = client.models.generate_content(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     contents=types.Content(
         parts=[
             types.Part(
@@ -178,7 +178,7 @@ with open("video.mp4", "rb") as f:
 video_data = base64.standard_b64encode(video_bytes).decode("utf-8")
 
 response = client.models.generate_content(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     contents=[
         {
             "inline_data": {
@@ -197,7 +197,7 @@ Gemini 2.5+ supports up to 10 videos per request:
 
 ```python
 response = client.models.generate_content(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     contents=[
         video_file_1,
         video_file_2,
@@ -355,7 +355,7 @@ for start, end in segments:
 
 # Combine
 final = client.models.generate_content(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     contents=[
         f"Segment summaries:\n{chr(10).join(summaries)}",
         "Create a unified summary"

--- a/google/skills/video-understanding/references/api-reference.md
+++ b/google/skills/video-understanding/references/api-reference.md
@@ -2,6 +2,12 @@
 
 Detailed API documentation for video analysis with Gemini.
 
+Examples use the **Interactions API** (`client.interactions.create`), the current standard
+idiom. Inputs are plain dicts (no `types.*` wrappers) and output is read from
+`interaction.output_text`. `generateContent` still works and remains the fallback for the
+two capabilities the Interactions API does not expose — video clipping and custom fps
+(both noted inline below). Requires `google-genai >= 2.0.0`.
+
 ## Model
 
 - `gemini-3.5-flash`: 1M Latest capabilities
@@ -61,40 +67,62 @@ client.files.delete(name=video_file.name)
 ### Basic Request
 
 ```python
-response = client.models.generate_content(
+interaction = client.interactions.create(
     model="gemini-3.5-flash",
-    contents=[video_file, "Your prompt here"]
+    input=[
+        {"type": "text", "text": "Your prompt here"},
+        {"type": "video", "uri": video_file.uri, "mime_type": video_file.mime_type},
+    ],
 )
+print(interaction.output_text)
 ```
 
 ### With Configuration
+
+Request-level settings go in `generation_config`; `response_format` moves to a top-level
+parameter (it was nested inside `GenerateContentConfig` under generateContent):
+
+```python
+interaction = client.interactions.create(
+    model="gemini-3.5-flash",
+    input=[
+        {"type": "text", "text": prompt},
+        {"type": "video", "uri": video_file.uri, "mime_type": video_file.mime_type},
+    ],
+    generation_config={
+        "temperature": 0.7,
+        "max_output_tokens": 8192,
+        "media_resolution": "MEDIA_RESOLUTION_LOW",  # Reduce token usage
+    },
+)
+print(interaction.output_text)
+```
+
+## Video Metadata Options (legacy generate_content only)
+
+The Interactions API has no video-metadata parameter: `video_metadata` offsets and `fps`
+are silently ignored (a clipped Interactions request was verified to bill the full video's
+token count). Clipping and custom fps therefore require the legacy `generate_content` call.
+
+### Clipping (Start/End Offset)
 
 ```python
 from google.genai import types
 
 response = client.models.generate_content(
     model="gemini-3.5-flash",
-    contents=[video_file, prompt],
-    config=types.GenerateContentConfig(
-        temperature=0.7,
-        max_output_tokens=8192,
-        media_resolution=types.MediaResolution.MEDIA_RESOLUTION_LOW,  # Reduce token usage
-    )
+    contents=[
+        types.Part(
+            file_data=types.FileData(file_uri=video_file.uri),
+            video_metadata=types.VideoMetadata(
+                start_offset="30s",    # Start at 30 seconds
+                end_offset="120s"      # End at 2 minutes
+            )
+        ),
+        "Summarize this segment",
+    ],
 )
-```
-
-## Video Metadata Options
-
-### Clipping (Start/End Offset)
-
-```python
-types.Part(
-    file_data=types.FileData(file_uri=video_file.uri),
-    video_metadata=types.VideoMetadata(
-        start_offset="30s",    # Start at 30 seconds
-        end_offset="120s"      # End at 2 minutes
-    )
-)
+print(response.text)
 ```
 
 **Offset formats:**
@@ -132,19 +160,14 @@ video_metadata=types.VideoMetadata(
 ### Basic Usage
 
 ```python
-response = client.models.generate_content(
+interaction = client.interactions.create(
     model="gemini-3.5-flash",
-    contents=types.Content(
-        parts=[
-            types.Part(
-                file_data=types.FileData(
-                    file_uri="https://www.youtube.com/watch?v=VIDEO_ID"
-                )
-            ),
-            types.Part(text="Summarize this video")
-        ]
-    )
+    input=[
+        {"type": "text", "text": "Summarize this video"},
+        {"type": "video", "uri": "https://www.youtube.com/watch?v=VIDEO_ID"},
+    ],
 )
+print(interaction.output_text)
 ```
 
 ### Supported URL Formats
@@ -177,33 +200,30 @@ with open("video.mp4", "rb") as f:
 
 video_data = base64.standard_b64encode(video_bytes).decode("utf-8")
 
-response = client.models.generate_content(
+interaction = client.interactions.create(
     model="gemini-3.5-flash",
-    contents=[
-        {
-            "inline_data": {
-                "mime_type": "video/mp4",
-                "data": video_data
-            }
-        },
-        "Describe this video"
-    ]
+    input=[
+        {"type": "text", "text": "Describe this video"},
+        {"type": "video", "data": video_data, "mime_type": "video/mp4"},
+    ],
 )
+print(interaction.output_text)
 ```
 
 ## Multi-Video Analysis
 
-Gemini 2.5+ supports up to 10 videos per request:
+Pass multiple video parts in a single `input` list (up to 10 videos per request):
 
 ```python
-response = client.models.generate_content(
+interaction = client.interactions.create(
     model="gemini-3.5-flash",
-    contents=[
-        video_file_1,
-        video_file_2,
-        "Compare these two videos"
-    ]
+    input=[
+        {"type": "text", "text": "Compare these two videos"},
+        {"type": "video", "uri": video_file_1.uri, "mime_type": video_file_1.mime_type},
+        {"type": "video", "uri": video_file_2.uri, "mime_type": video_file_2.mime_type},
+    ],
 )
+print(interaction.output_text)
 ```
 
 ## Token Calculation
@@ -251,12 +271,12 @@ tokens = estimate_tokens(300, "default")  # ~87,000 tokens
 import time
 import random
 
-def generate_with_retry(client, model, contents, max_retries=3):
+def generate_with_retry(client, model, input_parts, max_retries=3):
     for attempt in range(max_retries):
         try:
-            return client.models.generate_content(
+            return client.interactions.create(
                 model=model,
-                contents=contents
+                input=input_parts,
             )
         except Exception as e:
             if "RESOURCE_EXHAUSTED" in str(e) and attempt < max_retries - 1:
@@ -266,6 +286,10 @@ def generate_with_retry(client, model, contents, max_retries=3):
             else:
                 raise
 ```
+
+The error codes above are surfaced as exceptions raised by `interactions.create` (the
+underlying status codes are unchanged from generateContent), so the same `str(e)` checks
+apply.
 
 ## Timestamp Prompting
 
@@ -310,9 +334,9 @@ Audio processing specs:
 
 ### Optimize Token Usage
 
-1. Use `media_resolution=types.MediaResolution.MEDIA_RESOLUTION_LOW` for non-visual analysis
-2. Set appropriate FPS for content type
-3. Use clipping to analyze only relevant segments
+1. Use `generation_config={"media_resolution": "MEDIA_RESOLUTION_LOW"}` for non-visual analysis
+2. Set appropriate FPS for content type (legacy `generate_content` only)
+3. Use clipping to analyze only relevant segments (legacy `generate_content` only)
 4. Delete uploaded files after use
 
 ### Prompt Engineering
@@ -336,9 +360,9 @@ prompt = """Analyze this video and return JSON:
 
 ### Handling Long Videos
 
-1. Split into segments using clipping
+1. Split into segments using clipping (per-segment clipping uses the legacy `generate_content` call)
 2. Analyze segments separately
-3. Combine results with a final summary prompt
+3. Combine results with a final summary prompt (text-only → Interactions API)
 
 ```python
 segments = [
@@ -349,18 +373,16 @@ segments = [
 
 summaries = []
 for start, end in segments:
-    # Analyze each segment
+    # Analyze each segment with legacy generate_content + VideoMetadata (clipping)
     ...
     summaries.append(response.text)
 
-# Combine
-final = client.models.generate_content(
+# Combine (text-only)
+final = client.interactions.create(
     model="gemini-3.5-flash",
-    contents=[
-        f"Segment summaries:\n{chr(10).join(summaries)}",
-        "Create a unified summary"
-    ]
+    input=f"Segment summaries:\n{chr(10).join(summaries)}\n\nCreate a unified summary",
 )
+print(final.output_text)
 ```
 
 ## Supported MIME Types
@@ -380,11 +402,11 @@ final = client.models.generate_content(
 ## SDK Installation
 
 ```bash
-# Using uv (recommended)
-uv pip install google-genai
+# Using uv (recommended) — Interactions API requires >= 2.0.0
+uv pip install "google-genai>=2.0.0"
 
 # Using pip
-pip install google-genai
+pip install "google-genai>=2.0.0"
 ```
 
 ## Authentication

--- a/google/skills/video-understanding/references/api-reference.md
+++ b/google/skills/video-understanding/references/api-reference.md
@@ -80,19 +80,21 @@ print(interaction.output_text)
 ### With Configuration
 
 Request-level settings go in `generation_config`; `response_format` moves to a top-level
-parameter (it was nested inside `GenerateContentConfig` under generateContent):
+parameter (it was nested inside `GenerateContentConfig` under generateContent). Media
+resolution is NOT one of those request-level settings — it's a per-item field on the
+video part instead:
 
 ```python
 interaction = client.interactions.create(
     model="gemini-3.5-flash",
     input=[
         {"type": "text", "text": prompt},
-        {"type": "video", "uri": video_file.uri, "mime_type": video_file.mime_type},
+        {"type": "video", "uri": video_file.uri, "mime_type": video_file.mime_type,
+         "resolution": "low"},  # per-item media resolution
     ],
     generation_config={
         "temperature": 0.7,
         "max_output_tokens": 8192,
-        "media_resolution": "MEDIA_RESOLUTION_LOW",  # Reduce token usage
     },
 )
 print(interaction.output_text)
@@ -334,7 +336,7 @@ Audio processing specs:
 
 ### Optimize Token Usage
 
-1. Use `generation_config={"media_resolution": "MEDIA_RESOLUTION_LOW"}` for non-visual analysis
+1. Use the per-item `"resolution": "low"` field on video parts for non-visual analysis
 2. Set appropriate FPS for content type (legacy `generate_content` only)
 3. Use clipping to analyze only relevant segments (legacy `generate_content` only)
 4. Delete uploaded files after use

--- a/google/skills/video-understanding/references/api-reference.md
+++ b/google/skills/video-understanding/references/api-reference.md
@@ -6,7 +6,7 @@ Examples use the **Interactions API** (`client.interactions.create`), the curren
 idiom. Inputs are plain dicts (no `types.*` wrappers) and output is read from
 `interaction.output_text`. `generateContent` still works and remains the fallback for the
 two capabilities the Interactions API does not expose — video clipping and custom fps
-(both noted inline below). Requires `google-genai >= 2.0.0`.
+(both noted inline below). Requires `google-genai >= 2.3.0` (Google's documented SDK floor for the Interactions API).
 
 ## Model
 
@@ -76,6 +76,10 @@ interaction = client.interactions.create(
 )
 print(interaction.output_text)
 ```
+
+Interactions are stored server-side by default (`store=true`). For one-shot
+requests pass `store=False`; it is incompatible with `previous_interaction_id`
+and `background=true`.
 
 ### With Configuration
 
@@ -192,7 +196,7 @@ https://www.youtube.com/embed/VIDEO_ID
 
 ## Inline Data
 
-For small videos (<20MB):
+For small videos — the 20MB limit is TOTAL request size after base64 encoding (~15MB raw):
 
 ```python
 import base64
@@ -404,11 +408,11 @@ print(final.output_text)
 ## SDK Installation
 
 ```bash
-# Using uv (recommended) — Interactions API requires >= 2.0.0
-uv pip install "google-genai>=2.0.0"
+# Using uv (recommended) — Interactions API requires >= 2.3.0
+uv pip install "google-genai>=2.3.0"
 
 # Using pip
-pip install "google-genai>=2.0.0"
+pip install "google-genai>=2.3.0"
 ```
 
 ## Authentication

--- a/google/skills/video-understanding/scripts/analyze_video.py
+++ b/google/skills/video-understanding/scripts/analyze_video.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 """
-Video Analysis with Gemini API
+Video Analysis with Gemini Interactions API
 
 Supports:
 - Local file upload via Files API
 - YouTube URL analysis
 - Multiple analysis types: summary, transcript, timestamps, QnA
+
+Uses the Interactions API (client.interactions.create), the current standard for
+new development. generateContent still works, but Interactions is the default idiom
+in the official docs. Video clipping (--start/--end) has no Interactions equivalent,
+so that path alone falls back to the legacy generate_content call (see analyze_clip).
 
 Usage:
     python analyze_video.py /path/to/video.mp4 "Summarize this video"
@@ -16,6 +21,9 @@ Usage:
 
 Environment:
     GEMINI_API_KEY - Google AI API key (required)
+
+Install:
+    uv pip install "google-genai>=2.0.0"
 """
 
 import argparse
@@ -27,9 +35,9 @@ from pathlib import Path
 
 try:
     from google import genai
-    from google.genai import types
+    from google.genai import types  # only for the legacy clipping fallback
 except ImportError:
-    print("Error: google-genai not installed. Run: uv pip install google-genai")
+    print('Error: google-genai not installed. Run: uv pip install "google-genai>=2.0.0"')
     sys.exit(1)
 
 
@@ -66,6 +74,18 @@ Format each as: [MM:SS] Description""",
 - Visual transitions and effects""",
 }
 
+# Extension -> MIME type
+MIME_TYPES = {
+    ".mp4": "video/mp4",
+    ".mpeg": "video/mpeg",
+    ".mov": "video/mov",
+    ".avi": "video/avi",
+    ".webm": "video/webm",
+    ".wmv": "video/wmv",
+    ".flv": "video/x-flv",
+    ".3gp": "video/3gpp",
+}
+
 
 def is_youtube_url(source: str) -> bool:
     """Check if source is a YouTube URL."""
@@ -77,7 +97,27 @@ def is_youtube_url(source: str) -> bool:
     return any(p in source.lower() for p in youtube_patterns)
 
 
-def upload_video(client: genai.Client, file_path: str) -> types.File:
+def generation_config(low_res: bool):
+    """Interactions generation_config dict for the request, or None.
+
+    media_resolution is a request-level parameter, so --low-res applies to every
+    input source (local file and YouTube alike).
+    """
+    if low_res:
+        return {"media_resolution": "MEDIA_RESOLUTION_LOW"}
+    return None
+
+
+def create_interaction(client: genai.Client, input_parts: list, low_res: bool):
+    """Run an Interactions API request, omitting generation_config when unset."""
+    kwargs = {"model": MODEL, "input": input_parts}
+    config = generation_config(low_res)
+    if config is not None:
+        kwargs["generation_config"] = config
+    return client.interactions.create(**kwargs)
+
+
+def upload_video(client: genai.Client, file_path: str):
     """Upload video file and wait for processing."""
     print(f"Uploading: {file_path}")
 
@@ -97,6 +137,51 @@ def upload_video(client: genai.Client, file_path: str) -> types.File:
     return video_file
 
 
+def analyze_clip(
+    client: genai.Client,
+    file_path: str,
+    prompt: str,
+    low_res: bool,
+    start_offset: str,
+    end_offset: str,
+) -> str:
+    """Analyze a clipped segment of a local video.
+
+    The Interactions API has no offset parameter (video_metadata is silently
+    ignored), so clipping falls back to the legacy generate_content call, which
+    still honors start/end offsets via types.VideoMetadata.
+    """
+    print("Clipping requested -> using legacy generate_content "
+          "(Interactions API has no offset support)")
+    video_file = upload_video(client, file_path)
+
+    metadata = types.VideoMetadata()
+    if start_offset:
+        metadata.start_offset = start_offset
+    if end_offset:
+        metadata.end_offset = end_offset
+
+    config = None
+    if low_res:
+        config = types.GenerateContentConfig(
+            media_resolution=types.MediaResolution.MEDIA_RESOLUTION_LOW
+        )
+
+    print("Analyzing...")
+    response = client.models.generate_content(
+        model=MODEL,
+        contents=[
+            types.Part(
+                file_data=types.FileData(file_uri=video_file.uri),
+                video_metadata=metadata,
+            ),
+            prompt,
+        ],
+        config=config,
+    )
+    return response.text
+
+
 def analyze_local_file(
     client: genai.Client,
     file_path: str,
@@ -105,96 +190,57 @@ def analyze_local_file(
     start_offset: str = None,
     end_offset: str = None,
 ) -> str:
-    """Analyze a local video file."""
+    """Analyze a local video file via the Interactions API."""
     path = Path(file_path)
 
     if not path.exists():
         raise FileNotFoundError(f"Video file not found: {file_path}")
 
+    # Clipping has no Interactions equivalent -> legacy fallback.
+    if start_offset or end_offset:
+        return analyze_clip(client, file_path, prompt, low_res, start_offset, end_offset)
+
     file_size = path.stat().st_size
 
-    # Use inline data for small files (<20MB)
+    # Use inline data for small files (<20MB), Files API otherwise.
     if file_size < 20 * 1024 * 1024:
         print("Using inline data (file < 20MB)")
         with open(file_path, "rb") as f:
             video_data = base64.standard_b64encode(f.read()).decode("utf-8")
 
-        # Determine MIME type
-        suffix = path.suffix.lower()
-        mime_types = {
-            ".mp4": "video/mp4",
-            ".mpeg": "video/mpeg",
-            ".mov": "video/mov",
-            ".avi": "video/avi",
-            ".webm": "video/webm",
-            ".wmv": "video/wmv",
-            ".flv": "video/x-flv",
-            ".3gp": "video/3gpp",
-        }
-        mime_type = mime_types.get(suffix, "video/mp4")
-
-        contents = [
-            {"inline_data": {"mime_type": mime_type, "data": video_data}},
-            prompt,
+        mime_type = MIME_TYPES.get(path.suffix.lower(), "video/mp4")
+        input_parts = [
+            {"type": "text", "text": prompt},
+            {"type": "video", "data": video_data, "mime_type": mime_type},
         ]
     else:
-        # Use Files API for larger files
         print("Using Files API (file >= 20MB)")
         video_file = upload_video(client, file_path)
+        input_parts = [
+            {"type": "text", "text": prompt},
+            {"type": "video", "uri": video_file.uri, "mime_type": video_file.mime_type},
+        ]
 
-        # Build content with optional metadata
-        if start_offset or end_offset:
-            metadata = types.VideoMetadata()
-            if start_offset:
-                metadata.start_offset = start_offset
-            if end_offset:
-                metadata.end_offset = end_offset
-
-            contents = [
-                types.Part(
-                    file_data=types.FileData(file_uri=video_file.uri),
-                    video_metadata=metadata,
-                ),
-                prompt,
-            ]
-        else:
-            contents = [video_file, prompt]
-
-    # Configure request
-    config = None
-    if low_res:
-        config = types.GenerateContentConfig(
-            media_resolution=types.MediaResolution.MEDIA_RESOLUTION_LOW
-        )
-
-    # Generate response
     print("Analyzing...")
-    response = client.models.generate_content(
-        model=MODEL,
-        contents=contents,
-        config=config,
-    )
-
-    return response.text
+    interaction = create_interaction(client, input_parts, low_res)
+    return interaction.output_text
 
 
-def analyze_youtube(client: genai.Client, url: str, prompt: str) -> str:
-    """Analyze a YouTube video."""
+def analyze_youtube(
+    client: genai.Client,
+    url: str,
+    prompt: str,
+    low_res: bool = False,
+) -> str:
+    """Analyze a YouTube video via the Interactions API."""
     print(f"Analyzing YouTube: {url}")
 
-    response = client.models.generate_content(
-        model=MODEL,
-        contents=types.Content(
-            parts=[
-                types.Part(
-                    file_data=types.FileData(file_uri=url)
-                ),
-                types.Part(text=prompt),
-            ]
-        ),
-    )
-
-    return response.text
+    input_parts = [
+        {"type": "text", "text": prompt},
+        {"type": "video", "uri": url},
+    ]
+    interaction = create_interaction(client, input_parts, low_res)
+    return interaction.output_text
 
 
 def main():
@@ -226,11 +272,11 @@ def main():
     )
     parser.add_argument(
         "--start",
-        help="Start offset (e.g., '30s', '1m30s')",
+        help="Start offset (e.g., '30s', '1m30s'); local files only",
     )
     parser.add_argument(
         "--end",
-        help="End offset (e.g., '120s', '5m')",
+        help="End offset (e.g., '120s', '5m'); local files only",
     )
     parser.add_argument(
         "--model",
@@ -262,7 +308,10 @@ def main():
 
     try:
         if is_youtube_url(args.source):
-            result = analyze_youtube(client, args.source, prompt)
+            if args.start or args.end:
+                print("Warning: --start/--end are ignored for YouTube sources "
+                      "(clipping is supported for local files only)", file=sys.stderr)
+            result = analyze_youtube(client, args.source, prompt, low_res=args.low_res)
         else:
             result = analyze_local_file(
                 client,

--- a/google/skills/video-understanding/scripts/analyze_video.py
+++ b/google/skills/video-understanding/scripts/analyze_video.py
@@ -78,6 +78,7 @@ Format each as: [MM:SS] Description""",
 MIME_TYPES = {
     ".mp4": "video/mp4",
     ".mpeg": "video/mpeg",
+    ".mpg": "video/mpg",
     ".mov": "video/mov",
     ".avi": "video/avi",
     ".webm": "video/webm",
@@ -97,24 +98,20 @@ def is_youtube_url(source: str) -> bool:
     return any(p in source.lower() for p in youtube_patterns)
 
 
-def generation_config(low_res: bool):
-    """Interactions generation_config dict for the request, or None.
+def create_interaction(client: genai.Client, input_parts: list, low_res: bool):
+    """Run an Interactions API request.
 
-    media_resolution is a request-level parameter, so --low-res applies to every
-    input source (local file and YouTube alike).
+    Media resolution is a per-item field on video parts ("resolution": "low");
+    generation_config has no media_resolution key in the Interactions API (an
+    unknown key there is silently ignored), so --low-res is applied by tagging
+    each video part. Per-item means it covers every source (local and YouTube).
     """
     if low_res:
-        return {"media_resolution": "MEDIA_RESOLUTION_LOW"}
-    return None
-
-
-def create_interaction(client: genai.Client, input_parts: list, low_res: bool):
-    """Run an Interactions API request, omitting generation_config when unset."""
-    kwargs = {"model": MODEL, "input": input_parts}
-    config = generation_config(low_res)
-    if config is not None:
-        kwargs["generation_config"] = config
-    return client.interactions.create(**kwargs)
+        input_parts = [
+            {**p, "resolution": "low"} if p.get("type") == "video" else p
+            for p in input_parts
+        ]
+    return client.interactions.create(model=MODEL, input=input_parts)
 
 
 def upload_video(client: genai.Client, file_path: str):

--- a/google/skills/video-understanding/scripts/analyze_video.py
+++ b/google/skills/video-understanding/scripts/analyze_video.py
@@ -23,7 +23,7 @@ Environment:
     GEMINI_API_KEY - Google AI API key (required)
 
 Install:
-    uv pip install "google-genai>=2.0.0"
+    uv pip install "google-genai>=2.3.0"
 """
 
 import argparse
@@ -37,7 +37,7 @@ try:
     from google import genai
     from google.genai import types  # only for the legacy clipping fallback
 except ImportError:
-    print('Error: google-genai not installed. Run: uv pip install "google-genai>=2.0.0"')
+    print('Error: google-genai not installed. Run: uv pip install "google-genai>=2.3.0"')
     sys.exit(1)
 
 
@@ -105,13 +105,17 @@ def create_interaction(client: genai.Client, input_parts: list, low_res: bool):
     generation_config has no media_resolution key in the Interactions API (an
     unknown key there is silently ignored), so --low-res is applied by tagging
     each video part. Per-item means it covers every source (local and YouTube).
+
+    Requests are sent with store=False: this is a one-shot analysis utility (no
+    previous_interaction_id chaining, no background execution), so interactions
+    are not persisted server-side.
     """
     if low_res:
         input_parts = [
             {**p, "resolution": "low"} if p.get("type") == "video" else p
             for p in input_parts
         ]
-    return client.interactions.create(model=MODEL, input=input_parts)
+    return client.interactions.create(model=MODEL, input=input_parts, store=False)
 
 
 def upload_video(client: genai.Client, file_path: str):
@@ -199,9 +203,11 @@ def analyze_local_file(
 
     file_size = path.stat().st_size
 
-    # Use inline data for small files (<20MB), Files API otherwise.
-    if file_size < 20 * 1024 * 1024:
-        print("Using inline data (file < 20MB)")
+    # The 20MB inline limit is TOTAL request size; base64 inflates ~4/3,
+    # so compare the encoded size, not the raw file size.
+    encoded_size = file_size * 4 // 3
+    if encoded_size < 20 * 1024 * 1024:
+        print("Using inline data (encoded size < 20MB)")
         with open(file_path, "rb") as f:
             video_data = base64.standard_b64encode(f.read()).decode("utf-8")
 
@@ -211,7 +217,7 @@ def analyze_local_file(
             {"type": "video", "data": video_data, "mime_type": mime_type},
         ]
     else:
-        print("Using Files API (file >= 20MB)")
+        print("Using Files API (encoded size >= 20MB)")
         video_file = upload_video(client, file_path)
         input_parts = [
             {"type": "text", "text": prompt},

--- a/google/skills/video-understanding/scripts/analyze_video.py
+++ b/google/skills/video-understanding/scripts/analyze_video.py
@@ -34,7 +34,7 @@ except ImportError:
 
 
 # Default model
-MODEL = "gemini-3-flash-preview"
+MODEL = "gemini-3.5-flash"
 
 # Analysis type prompts
 PROMPTS = {
@@ -196,6 +196,8 @@ def analyze_youtube(client: genai.Client, url: str, prompt: str) -> str:
 
 
 def main():
+    global MODEL
+
     parser = argparse.ArgumentParser(
         description="Analyze video with Gemini API",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -254,7 +256,6 @@ def main():
     client = genai.Client(api_key=api_key)
 
     # Update model if specified
-    global MODEL
     MODEL = args.model
 
     try:

--- a/google/skills/video-understanding/scripts/analyze_video.py
+++ b/google/skills/video-understanding/scripts/analyze_video.py
@@ -163,7 +163,9 @@ def analyze_local_file(
     # Configure request
     config = None
     if low_res:
-        config = types.GenerateContentConfig(media_resolution="low")
+        config = types.GenerateContentConfig(
+            media_resolution=types.MediaResolution.MEDIA_RESOLUTION_LOW
+        )
 
     # Generate response
     print("Analyzing...")


### PR DESCRIPTION
## What

Four commits, in order:

1. **`gemini-3-flash-preview` → `gemini-3.5-flash`** across the skill (13 model-id sites + prose), plus a fix for a pre-existing `SyntaxError` in `analyze_video.py` (`MODEL` read before its `global` declaration — the script could never run as-is). Plugin 1.4.1 → 1.4.2.
2. **`media_resolution` fixed to the `MediaResolution` enum** — the string `"low"` is not a valid value (SDK warns and forwards the invalid value; verified on google-genai 1.59.0 and 2.10.0). Plugin → 1.4.3.
3. **Migration to the Interactions API** (`client.interactions.create`, plain-dict inputs, `interaction.output_text`) — the current standard idiom; `generateContent` remains supported and is kept only as the fallback for video clipping/fps, which the Interactions API does not expose (verified: offsets are silently ignored — a clipped request bills full-video tokens). `--low-res` now applies to YouTube sources too (request-level `generation_config`). Requires `google-genai >= 2.0.0`. Plugin → 1.5.0.
4. **Files API threshold guidance aligned** to the documented 20MB total-request rule (was ">100MB or >1 minute", contradicting the doc's own Workflow section and the script). Plugin → 1.5.1.

## Why

- `gemini-3.5-flash` is the official replacement for `gemini-3-flash-preview` per the [Gemini deprecations page](https://ai.google.dev/gemini-api/docs/deprecations) (stable since 2026-05-19).
- The Interactions API is [GA and the default across Google's docs](https://ai.google.dev/gemini-api/docs/migrate-to-interactions); frontier features are expected to land there first.

## Verification (live, against real API)

- YouTube analysis (default + `--low-res`): coherent Korean summaries, no warnings — exit 0.
- Local inline (<20MB) clip: correct description of test content — exit 0.
- Clipping fallback (`--start/--end` → legacy `generate_content`): works — exit 0.
- Enum/config forms construct warning-free on SDK 1.59.0 and 2.10.0.
- Old-SDK (1.x) failure mode checked: server returns a clear 400 instructing an SDK upgrade with a docs link.


### Review loop round 2 (codex)

- Fixed `--low-res` for the Interactions API: `generation_config={"media_resolution": ...}` is not part of the Interactions schema (SDK 2.10.0 `GenerationConfig` declares no such field; unknown keys are silently accepted and ignored). The correct shape is the per-item `resolution: "low"` field on the video content part (values low/medium/high/ultra_high; confirmed against https://ai.google.dev/gemini-api/docs/media-resolution). Script and both docs updated.
- Caveat: a live A/B on a 4-second synthetic clip showed identical input-token counts for baseline vs low-res in every shape, so the token savings are asserted per API contract/docs, not yet reproduced empirically (test clip likely too small to discriminate).
- Added the missing `.mpg` → `video/mpg` MIME mapping in `analyze_video.py` (both docs already listed it as supported).


### Review loop round 3 (codex)

- `create_interaction` now passes `store=False`: the Interactions API stores every interaction server-side by default, and this one-shot utility uses neither `previous_interaction_id` nor `background=true` (the two documented incompatibilities). Docs note added.
- SDK floor raised from `>=2.0.0` to `>=2.3.0` everywhere: Google's docs state the Interactions floor as google-genai 2.3.0; 2.0.0–2.2.0 expose only an unofficial, untested `interactions` surface (2.3.0 is exactly where the experimental warning + test suite appear).
- Inline-vs-Files-API branching now compares the base64-encoded size (raw × 4/3) against the 20MB limit, which the docs scope to TOTAL request size; docs aligned (~15MB raw rule of thumb).
- Upstream docs note: Google's video page shows an "Inline Data | <100MB" table row that contradicts its own "20MB total request size" prose; we follow the prose.
