### PR TITLE
fix: skill path/convention consistency (pdf-split, handwriting, claude-code-internals, media-download)

### DIFF
--- a/claude-code-internals/.claude-plugin/plugin.json
+++ b/claude-code-internals/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-internals",
   "description": "Claude Code internals explorer",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/claude-code-internals/skills/claude-code-internals/SKILL.md
+++ b/claude-code-internals/skills/claude-code-internals/SKILL.md
@@ -107,68 +107,6 @@ Agent's tool restrictions are passed to Headless CLI via `--allowedTools`:
 
 > **Why this works**: Bash subagent executes the script as an external process. Only the script's stdout appears in session logs, not the intermediate 350K+ lines from `strings`.
 
----
-
-> ⚠️ **Warning (Legacy Mode)**: If using direct subagent delegation below, subagent output is recorded in session logs. Large outputs (>1MB) can cause session file bloat, leading to SIGTRAP crashes on new Claude sessions. Always use `| head -N` to limit results.
-
-## Workflow
-
-### 1. Delegate Binary Exploration
-
-Call Task tool with:
-- `subagent_type`: `Explore`
-- `prompt`: Specify search target and expected output format
-
-Example delegations:
-
-```
-# Feature investigation
-Find Claude Code binary using scripts/find_installation.sh.
-Search for "anthropic-beta" using: strings $BINARY | grep -E "anthropic-beta|20[0-9]{2}-[0-9]{2}" | head -30
-Return: version, matching lines (max 30).
-
-# Settings discovery
-Run find_installation.sh, then search for setting patterns:
-strings $BINARY | grep -E "autoCompact|permission|default.*:" | head -50
-Return: setting names and apparent default values (max 50 lines).
-```
-
-The subagent executes commands and returns summarized findings.
-
-### 2. Subagent Search Commands (Reference)
-
-> **Note**: These commands are for subagent execution, not main context.
-
-```bash
-# Get binary path using find_installation.sh
-source scripts/find_installation.sh
-# Sets: BINARY_PATH variable
-
-# Search with context (ALWAYS limit output!)
-strings "$BINARY_PATH" | grep -B2 -A2 "pattern" | head -50
-
-# Cache for multiple searches (within subagent session)
-strings "$BINARY_PATH" > /tmp/claude-strings.txt
-grep "pattern1" /tmp/claude-strings.txt | head -30
-grep "pattern2" /tmp/claude-strings.txt | head -30
-# Remember to cleanup: rm /tmp/claude-strings.txt
-```
-
-### 3. Investigation Types
-
-| Goal | Approach |
-|------|----------|
-| **Specific feature** | Search for known keywords with `strings \| grep` |
-| **New version changes** | Compare with `known-features.md`, check release notes |
-| **Hidden settings** | Search for setting patterns |
-| **Beta features** | Search for beta headers |
-
-### 4. Analyze & Document
-
-1. Use `grep -B2 -A2` for context
-2. Compare with `references/known-features.md`
-3. Update `known-features.md` with new discoveries
-
 ## Common Investigations
 
 | Task | Approach |

--- a/handwriting/.claude-plugin/plugin.json
+++ b/handwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "handwriting",
   "description": "Apple Notes handwriting reader — scans Apple Pencil drawings via NoteStore.sqlite and reads them multimodally",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/handwriting/skills/handwriting/SKILL.md
+++ b/handwriting/skills/handwriting/SKILL.md
@@ -16,8 +16,8 @@ Apple's built-in handwriting OCR in accuracy, Korean included.
 1. **Scan** — run the bundled scanner (Python stdlib only, read-only, headless):
 
    ```bash
-   uv run "<skill-dir>/scripts/scan_handwriting.py"            # new since watermark (loop mode)
-   uv run "<skill-dir>/scripts/scan_handwriting.py" --all --limit 10   # browse recent (on-demand)
+   uv run "${CLAUDE_PLUGIN_ROOT}/skills/handwriting/scripts/scan_handwriting.py"            # new since watermark (loop mode)
+   uv run "${CLAUDE_PLUGIN_ROOT}/skills/handwriting/scripts/scan_handwriting.py" --all --limit 10   # browse recent (on-demand)
    ```
 
    Each output line is JSON: `note_title`, `modified`, `modified_raw` (the raw

--- a/media-download/.claude-plugin/plugin.json
+++ b/media-download/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "media-download",
   "description": "Media download via yt-dlp with QR decode and metadata extraction",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/media-download/skills/media-download/SKILL.md
+++ b/media-download/skills/media-download/SKILL.md
@@ -35,7 +35,7 @@ Determine the download URL from user input.
 
 **QR code image**: Decode with the bundled script:
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/skills/media-download/scripts/decode_qr.py <image_path>
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/media-download/scripts/decode_qr.py <image_path>
 ```
 
 Output is one URL per line. If multiple URLs are found, confirm which one to use.
@@ -81,7 +81,7 @@ yt-dlp \
 After download, convert the verbose `.info.json` into a slim search-friendly `.meta.json`:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/skills/media-download/scripts/save_metadata.py \
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/media-download/scripts/save_metadata.py \
   ~/Downloads/yt-dlp-output/"<filename>.info.json"
 ```
 

--- a/media-download/skills/media-download/scripts/decode_qr.py
+++ b/media-download/skills/media-download/scripts/decode_qr.py
@@ -1,8 +1,12 @@
-#!/usr/bin/env python3
+#!/usr/bin/env uv run --quiet --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
 """Decode QR codes from image files using zbarimg.
 
 Usage:
-    python3 decode_qr.py <image_path>
+    uv run decode_qr.py <image_path>
 
 Output:
     Decoded URL(s), one per line. Exit code 1 if no QR found.

--- a/media-download/skills/media-download/scripts/save_metadata.py
+++ b/media-download/skills/media-download/scripts/save_metadata.py
@@ -1,9 +1,13 @@
-#!/usr/bin/env python3
+#!/usr/bin/env uv run --quiet --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
 """Extract search-friendly metadata from yt-dlp info JSON.
 
 Usage:
-    python3 save_metadata.py <info_json_path>
-    yt-dlp --dump-json URL | python3 save_metadata.py - -o output.json
+    uv run save_metadata.py <info_json_path>
+    yt-dlp --dump-json URL | uv run save_metadata.py - -o output.json
 
 Reads a yt-dlp .info.json (or stdin with '-') and writes a slim JSON
 containing only fields useful for search and content understanding.

--- a/pdf-split/.claude-plugin/plugin.json
+++ b/pdf-split/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pdf-split",
   "description": "PDF chapter splitting",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/pdf-split/skills/pdf-split/SKILL.md
+++ b/pdf-split/skills/pdf-split/SKILL.md
@@ -33,7 +33,7 @@ Install pypdf via uv inline script dependency:
 Run `scripts/extract_toc.py` to analyze the PDF:
 
 ```bash
-uv run ~/.claude/skills/pdf-split/scripts/extract_toc.py <pdf_path>
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/pdf-split/scripts/extract_toc.py <pdf_path>
 ```
 
 Output includes:
@@ -63,12 +63,12 @@ chapters = [
 Run `scripts/split_by_chapters.py` with the chapter definitions:
 
 ```bash
-uv run ~/.claude/skills/pdf-split/scripts/split_by_chapters.py <pdf_path> <output_dir> --chapters '<json_chapters>'
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/pdf-split/scripts/split_by_chapters.py <pdf_path> <output_dir> --chapters '<json_chapters>'
 ```
 
 Example:
 ```bash
-uv run ~/.claude/skills/pdf-split/scripts/split_by_chapters.py \
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/pdf-split/scripts/split_by_chapters.py \
   ~/book.pdf \
   ~/book_chapters \
   --chapters '[[1,22,"00_Intro"],[23,45,"01_Chapter1"]]'


### PR DESCRIPTION
## Summary

Four small consistency/portability fixes, converging outlier skills onto the repo's dominant conventions. These came out of a craft-consistency grounding review of the full 21-skill set — no rewrites were warranted, only these 4 safest, targeted fixes.

## Fixes

1. **pdf-split — hardcoded home path (portability bug)**
   `pdf-split/skills/pdf-split/SKILL.md` referenced its scripts via a hardcoded `~/.claude/skills/pdf-split/scripts/` path, which breaks on any install where the plugin isn't cloned to that exact location. Replaced all 3 occurrences with `${CLAUDE_PLUGIN_ROOT}/skills/pdf-split/scripts/`, the portable standard already used by media-download, graph-sketch, and manim.

2. **handwriting — placeholder path**
   `handwriting/skills/handwriting/SKILL.md` used a literal `<skill-dir>` placeholder (not a real resolvable path) in its 2 script invocations. Replaced with `${CLAUDE_PLUGIN_ROOT}/skills/handwriting/scripts/`, same standard.

3. **claude-code-internals — Legacy Mode excision**
   Removed the `## Workflow` section (direct-subagent-delegation pattern, flagged with its own "⚠️ Legacy Mode" warning) that sat beside the "Zero-Context Mode (Recommended)" section. Verified via `grep -rn "Legacy Mode" claude-code-internals/` that nothing else (agent, references, scripts) pointed at it — the agent (`agents/claude-code-internals-explorer.md`) already exclusively calls `scripts/analyze-binary.sh`, matching Zero-Context Mode. Downstream generic sections (Common Investigations, Resources, Resource Map, Tips) are untouched and remain valid.

4. **media-download — interpreter standardization (conditional)**
   `media-download/skills/media-download/SKILL.md` invoked its scripts with `python3` while sibling tools use `uv run` + PEP-723 inline metadata. Checked both scripts (`decode_qr.py`, `save_metadata.py`): both are stdlib-only (subprocess/sys, json/sys/pathlib/argparse — no third-party deps), so per the conditional instruction this qualified for the "add a minimal PEP-723 header" path rather than being skipped. Added `# /// script` headers with `dependencies = []` and switched SKILL.md's invocations from `python3` to `uv run`, matching this repo's own documented convention ("Python = PEP 723 + uv", CLAUDE.md).

Each affected plugin's `.claude-plugin/plugin.json` version was bumped (patch) per the repo's bump-on-change policy (`.githooks/check-version-bump.sh`), verified locally against `origin/main` before pushing:

| Plugin | Version |
|---|---|
| pdf-split | 1.1.1 → 1.1.2 |
| handwriting | 1.0.0 → 1.0.1 |
| claude-code-internals | 2.0.6 → 2.0.7 |
| media-download | 0.1.0 → 0.1.1 |

## Verification

```
grep -rn "~/.claude/skills" pdf-split/ handwriting/   → none
grep -rn "<skill-dir>" handwriting/                    → none
grep -n "Legacy Mode" claude-code-internals/.../SKILL.md → none
grep -rn "python3" media-download/                     → none
bash .githooks/check-version-bump.sh --base origin/main → exit 0
```

All `${CLAUDE_PLUGIN_ROOT}/skills/<name>/scripts/<file>` paths referenced were confirmed to correspond to real files in the repo.

Not merging — PR creation is the endpoint; merge stays user-held.
