### PR TITLE
feat(codex-plus): bump default model to gpt-5.6-sol (2.4.0)

### DIFF
--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/scripts/codex-run.sh
+++ b/codex-plus/scripts/codex-run.sh
@@ -41,7 +41,7 @@ no most-recent fallback, so it is never a race under parallel sessions.
 
 Examples:
   codex-run.sh /tmp/codex_prompt_a3f9.txt
-  codex-run.sh -m gpt-5.5 -r high /tmp/codex_prompt_a3f9.txt
+  codex-run.sh -m gpt-5.6-terra -r high /tmp/codex_prompt_a3f9.txt
   codex-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 /tmp/codex_prompt_a3f9.txt
   codex-run.sh -s workspace-write --full-auto /tmp/codex_prompt_a3f9.txt
 USAGE

--- a/codex-plus/scripts/codex-run.sh
+++ b/codex-plus/scripts/codex-run.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # Defaults
-readonly DEFAULT_MODEL="gpt-5.5"
+readonly DEFAULT_MODEL="gpt-5.6-sol"
 readonly DEFAULT_EFFORT="xhigh"
 readonly DEFAULT_SANDBOX="read-only"
 
@@ -22,8 +22,8 @@ usage() {
 Usage: codex-run.sh [options] <prompt_file>
 
 Options:
-  -m, --model MODEL      Model name (default: gpt-5.5)
-  -r, --effort EFFORT    Reasoning effort: medium|high|xhigh (default: xhigh)
+  -m, --model MODEL      Model name (default: gpt-5.6-sol)
+  -r, --effort EFFORT    Reasoning effort: medium|high|xhigh|max (default: xhigh)
   -s, --sandbox SANDBOX  Sandbox: read-only|workspace-write|danger-full-access (default: read-only)
   -C, --cwd DIR          Working directory for codex
   -S, --session-id ID    Resume a specific session by UUID (deterministic;
@@ -41,7 +41,7 @@ no most-recent fallback, so it is never a race under parallel sessions.
 
 Examples:
   codex-run.sh /tmp/codex_prompt_a3f9.txt
-  codex-run.sh -m gpt-5.4 -r high /tmp/codex_prompt_a3f9.txt
+  codex-run.sh -m gpt-5.5 -r high /tmp/codex_prompt_a3f9.txt
   codex-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 /tmp/codex_prompt_a3f9.txt
   codex-run.sh -s workspace-write --full-auto /tmp/codex_prompt_a3f9.txt
 USAGE

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -65,8 +65,8 @@ When the delegated task is image generation or image editing:
 
 | Model | Characteristics |
 |-------|-----------------|
-| `gpt-5.5` | Current default model for Codex CLI tasks |
-| `gpt-5.4` | Supplementary model (prior default) |
+| `gpt-5.6-sol` | Current default model for Codex CLI tasks |
+| `gpt-5.5` | Supplementary model (prior default) |
 
    Reasoning effort is selected once and applied identically to all chosen models.
 
@@ -91,7 +91,7 @@ Each command below runs **inside a Bash subagent**, which returns the outcome su
 | Network access | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s danger-full-access --full-auto /tmp/codex_prompt_<suffix>.txt` |
 | Resume a session | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> /tmp/codex_prompt_<suffix>.txt` (only resume path; deterministic, no --last) |
 | Different dir | Add `-C <DIR>` to non-resume patterns above |
-| Custom model | Add `-m gpt-5.4 -r high` to any pattern above |
+| Custom model | Add `-m gpt-5.5 -r high` to any pattern above |
 | Capture answer to file | Add `-o <FILE>` to write codex's final message to FILE (deterministic) |
 
 ## Following Up

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -66,6 +66,7 @@ When the delegated task is image generation or image editing:
 | Model | Characteristics |
 |-------|-----------------|
 | `gpt-5.6-sol` | Current default model for Codex CLI tasks |
+| `gpt-5.6-terra` | Balanced 5.6 variant — lighter usage, faster than Sol; same effort ladder |
 | `gpt-5.5` | Supplementary model (prior default) |
 
    Reasoning effort is selected once and applied identically to all chosen models.
@@ -91,7 +92,7 @@ Each command below runs **inside a Bash subagent**, which returns the outcome su
 | Network access | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s danger-full-access --full-auto /tmp/codex_prompt_<suffix>.txt` |
 | Resume a session | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> /tmp/codex_prompt_<suffix>.txt` (only resume path; deterministic, no --last) |
 | Different dir | Add `-C <DIR>` to non-resume patterns above |
-| Custom model | Add `-m gpt-5.5 -r high` to any pattern above |
+| Custom model | Add `-m gpt-5.6-terra -r high` to any pattern above |
 | Capture answer to file | Add `-o <FILE>` to write codex's final message to FILE (deterministic) |
 
 ## Following Up


### PR DESCRIPTION
## What

Bumps codex-plus's default Codex CLI model from `gpt-5.5` to `gpt-5.6-sol`
(OpenAI's own new Codex CLI default, released 2026-07-09). `codex-plus` version
2.3.4 → 2.4.0.

- `codex-plus/scripts/codex-run.sh`: `DEFAULT_MODEL` → `gpt-5.6-sol`; help text
  updated; effort help vocabulary gains `max` (`medium|high|xhigh|max`) —
  default stays `xhigh` (effort is an unvalidated pass-through to
  `--config model_reasoning_effort=`, so no code branch needed); usage example
  slides to the prior default (`-m gpt-5.5 -r high`).
- `codex-plus/skills/codex/SKILL.md`: model table current-default row →
  `gpt-5.6-sol`, prior-default row → `gpt-5.5`; quick-reference custom-model
  example slides to `gpt-5.5`.
- `codex-plus/.claude-plugin/plugin.json`: `2.3.4` → `2.4.0`. Checked
  `.claude-plugin/marketplace.json` for a codex-plus version field — none
  exists, nothing to sync there.

## Deliberately left unchanged

- **`ultra` tier** — deferred (auto multi-agent delegation with usage-spike
  warnings), not part of this bump.
- **GPT-5.4 prompting guide** (`references/gpt-5-4_prompting_guide.md`) and its
  pointers in `SKILL.md` (`Read the reference when detailed GPT-5.4 prompting
  guidance is needed`, the `**File**:` line, and the "Key sections" heading) —
  kept as historical reference by decision.
- `gpt-image-*` references and the image-gen notebook — untouched, out of scope.

## Ambiguity found, not edited (flagging per your own "report, don't edit" instruction)

`SKILL.md` line ~120 — `` `Treat reasoning effort as a last-mile knob` -
reasoning_effort selection: none/low/medium/high/xhigh guidance `` — this bullet
is a grep-pattern navigation pointer *describing the content of*
`references/gpt-5-4_prompting_guide.md` (confirmed: that file's own
"Treat reasoning effort as a last-mile knob" section, line 483, documents
`none/low/medium/high/xhigh` and stops at `xhigh` — no `max`). Since the guide
itself is kept untouched as historical reference, appending `/max` to this
pointer would make the SKILL.md description inaccurate (claiming the untouched
guide covers a tier it doesn't). Left as-is; happy to change either way on
confirmation.

## Smoke test

Ran the wrapper end-to-end with no `-m` flag (so the new default applies),
`-r medium` (lowest accepted effort):

```
model: gpt-5.6-sol
provider: openai
approval: never
sandbox: read-only
reasoning effort: medium
session id: 019f495a-2fff-7a13-9346-ed4b94eeea90
...
ok
```

Exit code 0. `bash -n codex-plus/scripts/codex-run.sh` also passes.

## Not merging

Per repo convention — PR only, merge is user-held.
