### PR TITLE
feat(remote-tmux): launch rc-pool sessions with bypassPermissions (4.2.0)

### DIFF
--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "tmux-tracked `claude remote-control` toolkit: spawn one-off sessions (remote-spawn skill) or keep a self-restarting --spawn-worktree pool host alive per project (rc-pool skill), reachable from the Claude app",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/scripts/rc-pool.sh
+++ b/remote-tmux/scripts/rc-pool.sh
@@ -74,7 +74,7 @@ PY
   if ! tmux new-session -d -s "$sess" -x 220 -y 55 -c "$dir" "$cmd"; then
     echo "ERROR: failed to launch tmux session $sess" >&2; return 1
   fi
-  echo "STARTED-POOL $name  (dir: $dir, capacity: $cap, spawn: worktree, self-restarting)"
+  echo "STARTED-POOL $name  (dir: $dir, capacity: $cap, spawn: worktree, permissions: bypass, self-restarting)"
   echo "  -> reachable in the Claude app once Ready; on-demand sessions get isolated worktrees"
   echo "  -> attach: $ATTACH_ENV tmux attach -t $sess   |   stop: rc-pool.sh down $name"
 }
@@ -83,8 +83,8 @@ _run() {
   local dir="$1" name="$2" cap="$3"
   local log="$TMUX_TMPDIR/rcpool-$name.log"
   cd "$dir" || exit 1
-  echo "[$(date '+%F %T')] rcpool-$name host starting (capacity=$cap spawn=worktree)" >> "$log"
-  claude remote-control --name "$name" --spawn worktree --capacity "$cap"
+  echo "[$(date '+%F %T')] rcpool-$name host starting (capacity=$cap spawn=worktree permission-mode=bypassPermissions)" >> "$log"
+  claude remote-control --name "$name" --spawn worktree --capacity "$cap" --permission-mode bypassPermissions
   echo "[$(date '+%F %T')] rcpool-$name host exited (code $?) — reloading from disk in 3s" >> "$log"
   sleep 3
   exec bash "$SELF" _run "$dir" "$name" "$cap"

--- a/remote-tmux/skills/rc-pool/SKILL.md
+++ b/remote-tmux/skills/rc-pool/SKILL.md
@@ -9,9 +9,10 @@ description: >
 
 # Remote-Control Pool-Host Toggle
 
-Toggle a self-restarting pool host — `claude remote-control --spawn worktree --capacity N`
-— for a project. One singleton per project (tmux session `rcpool-<name>`); the host hosts a
-pool of on-demand, worktree-isolated sessions reachable from claude.ai/code + the mobile app.
+Toggle a self-restarting pool host — `claude remote-control --spawn worktree --capacity N
+--permission-mode bypassPermissions` — for a project. One singleton per project (tmux session
+`rcpool-<name>`); the host hosts a pool of on-demand, worktree-isolated sessions reachable
+from claude.ai/code + the mobile app.
 Sibling of the `remote-spawn` skill (which spawns one fixed session per dir).
 
 Run the script and report the result concisely:
@@ -33,6 +34,9 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/rc-pool.sh" status <name|dir>
 Notes to pass on when relevant:
 - **Trust first**: the `remote-control` subcommand hard-errors (no interactive prompt) on an
   untrusted workspace — run `claude` in the project once and accept the trust dialog before `up`.
+- **Permissions bypassed**: the host launches every session with `--permission-mode
+  bypassPermissions` — this covers the pre-created same-dir session too (not just
+  worktree-isolated ones).
 - **tmux, not launchd**: the host needs a live pane PTY (it exits on EOF under script/nohup);
   login-session resilient, no autostart — re-run `up` after a reboot.
 - One singleton per project; `name` defaults to the project dir's basename.


### PR DESCRIPTION
## 배경

`claude remote-control` CLI는 `--permission-mode <mode>` 플래그(값에 `bypassPermissions` 포함)를 지원하지만, rc-pool 스크립트는 이 플래그를 사용하지 않았습니다. 그 결과 풀 호스트가 띄우는 원격 세션이 default 권한 모드로 떠서, 원격(모바일/claude.ai)에서 붙은 작업 세션이 권한 프롬프트에 막혀 무인 실행이 불가능했습니다.

## 변경 내용

- `remote-tmux/scripts/rc-pool.sh`
  - `_run()`의 실행 라인에 `--permission-mode bypassPermissions` 하드코딩
  - 호스트 시작 로그 라인에 `permission-mode=bypassPermissions` 가시화
  - `up()`의 `STARTED-POOL` 상태 메시지에 `permissions: bypass` 가시화
- `remote-tmux/skills/rc-pool/SKILL.md`
  - 도입부의 호스트 커맨드 인용을 플래그 포함 형태로 확장
  - "Notes to pass on" 목록에 **Permissions bypassed** 항목 추가
- `remote-tmux/.claude-plugin/plugin.json`: `4.1.2` → `4.2.0` 범프 (CI의 bump-on-change 규칙)

## 고려사항

- `--permission-mode`는 호스트가 스폰하는 **모든** 세션에 적용됩니다. `--create-session-in-dir` 기본값이 on이므로, worktree 격리 세션뿐 아니라 사전 생성되는 same-dir 세션에도 bypassPermissions가 적용됩니다.
