### PR TITLE
cdp-attach: gate target selection when multiple browser profiles present

### DIFF
--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -59,6 +59,15 @@ V2="${CLAUDE_PLUGIN_ROOT}/scripts/v2_interact.py" && $V2 click --selector "a"
 V3="${CLAUDE_PLUGIN_ROOT}/scripts/v3_advanced.py" && $V3 network_start
 ```
 
+### Selecting a target — profile-aware
+
+Before selecting a target for the first time in a session, check for multiple browser profiles: run `$V1 list --contexts`. If it reports **2 or more** contexts and the user has not already named which profile or target to act on:
+
+- **Stop and let the user choose — do not pick one yourself.** Present the contexts as a numbered list, each option labeled by its 2–3 most recognizable open tab titles so the user recognizes the profile at a glance — never lead with the raw `browserContextId`. Keep the context id prefix alongside the label as the machine handle. Wait for the user's pick before selecting or acting.
+- Then narrow to the chosen profile with `--context <id-prefix>` (e.g. `$V1 select 0 --context 3f2a`).
+
+A **single** context, or a target the user has already disambiguated, proceeds without asking. Why this matters: which browser profile to drive is a user-private choice, and `Target.getTargets` exposes no human-readable name for a browser context (only id, title, url, type) — so a context's open tab titles are the only reliable recognition signal. Tabs from different profiles otherwise intermingle in the flat `list`, hiding the multiplicity entirely.
+
 ## Quick Reference
 
 ### v1 — Core (`v1_core.py`)

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -63,8 +63,9 @@ V3="${CLAUDE_PLUGIN_ROOT}/scripts/v3_advanced.py" && $V3 network_start
 
 Before selecting a target for the first time in a session, check for multiple browser profiles: run `$V1 list --contexts`. If it reports **2 or more** contexts and the user has not already named which profile or target to act on:
 
-- **Stop and let the user choose — do not pick one yourself.** Present the contexts as a numbered list, each option labeled by its 2–3 most recognizable open tab titles so the user recognizes the profile at a glance — never lead with the raw `browserContextId`. Keep the context id prefix alongside the label as the machine handle. Wait for the user's pick before selecting or acting.
-- Then narrow to the chosen profile with `--context <id-prefix>` (e.g. `$V1 select 0 --context 3f2a`).
+- **Do not pick one yourself — the choice is the user's.** Build a numbered list of the contexts, each option labeled by its 2–3 most recognizable open tab titles so the user recognizes the profile at a glance — never lead with the raw `browserContextId`. Keep the context id prefix alongside the label as the machine handle.
+- This skill runs forked (`context: fork`), so it cannot pause for user input mid-run: **return that numbered list as the final result, taking no target action in this run** — the main conversation presents the choice and re-invokes with the user's pick. (If running inline instead, ask directly and wait for the pick.)
+- On an invocation that carries the user's pick, narrow to the chosen profile with `--context <id-prefix>` (e.g. `$V1 select 0 --context 3f2a`).
 
 A **single** context, or a target the user has already disambiguated, proceeds without asking. Why this matters: which browser profile to drive is a user-private choice, and `Target.getTargets` exposes no human-readable name for a browser context (only id, title, url, type) — so a context's open tab titles are the only reliable recognition signal. Tabs from different profiles otherwise intermingle in the flat `list`, hiding the multiplicity entirely.
 


### PR DESCRIPTION
## What

When `list --contexts` surfaces **2+ browser contexts** and the user hasn't named which one, the skill now instructs the agent to **stop and present a numbered, tab-title-labeled choice** before selecting a target — instead of narrating raw `browserContextId` GUIDs and proceeding on its own.

## Why

Reported experience: with two profiles open, the agent listed contexts by raw GUID prefix (`EB32B6AB...`, `5A621E7E...`) and moved on, forcing the user to reverse-infer which profile is which from tab contents, with no actual selection step. Which profile to drive is a user-private choice.

## How

- SKILL.md-only, placed in the **primary attach path** (`## Execution`) so it fires even when the user reaches `select` via a flat `list` (never triggering `list --contexts`).
- Label options by their 2–3 most recognizable **tab titles** — `Target.getTargets` exposes no human-readable name for a browser context (only id/title/url/type), so tab content is the only reliable recognition signal. The GUID prefix stays as the machine handle.
- **Conditional / no over-gating**: single context, or an already-named target, proceeds without asking.
- No script change — `_cmd_list_contexts` already emits the tab titles the label needs.

Version bump 1.8.2 → 1.8.3.