### PR TITLE
Add kimi-plus plugin (Kimi K3 headless executor); align codex-plus authoring form

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,6 +20,11 @@
       "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)"
     },
     {
+      "name": "kimi-plus",
+      "source": "./kimi-plus",
+      "description": "Kimi K3 headless coding executor (frontend delegation, Claude Code env-swap)"
+    },
+    {
       "name": "pdf-split",
       "source": "./pdf-split",
       "description": "PDF chapter splitting"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/skills/codex-session/SKILL.md
+++ b/codex-plus/skills/codex-session/SKILL.md
@@ -27,11 +27,9 @@ Each JSONL file contains:
 
 Determine what the user wants to find:
 
-| Input | Action |
-|-------|--------|
-| Partial/full UUID | Direct lookup |
-| "recent" / "latest" | Show recent sessions |
-| Topic/keyword | Search via grep across sessions |
+- Partial or full UUID — direct lookup.
+- "recent" / "latest" — show recent sessions.
+- Topic or keyword — search via grep across sessions.
 
 ### 2. Execute Extraction
 

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -20,17 +20,17 @@ This per-invocation naming prevents file collisions across parallel sessions and
 
 Before writing the prompt file, classify available context on two orthogonal axes:
 
-| | Session (already available) | Exploration (needs collection) |
-|---|---|---|
-| **AI-verifiable** | Extract paths, patterns, commands as **Pointers** — codex self-verifies | Provide search hints, entry points — codex self-explores |
-| **User-specific** | Summarize intent, constraints, preferences from current session — **copy-only** | **Blocked** — no collection requests or questions |
+- **AI-verifiable × Session (already available)** — extract paths, patterns, commands as **Pointers**; codex self-verifies them.
+- **AI-verifiable × Exploration (needs collection)** — provide search hints and entry points; codex self-explores from them.
+- **User-specific × Session (already available)** — summarize intent, constraints, and preferences from the current session, **copy-only**.
+- **User-specific × Exploration (needs collection)** — **blocked**; this cell carries no collection requests or questions.
 
 **One boundary — Reference over Copy.** Both rows are two faces of the same partition: *re-derivability by the consumer*. Codex is the consumer that cannot re-derive the parent's session context, but CAN re-derive anything reachable by its own tools under `-C DIR`. The AI-verifiable row is what codex re-derives, so pass a **reference** (path / pattern / command); the User-specific row is what it cannot, so **copy** only that into the prompt. Operational test before each item: *"Can codex re-derive this from shared substrate with its own tools?"* — yes → pass a pointer; no → copy it in.
 
 **Rules**:
-- **Pointers**: Provide file paths, grep patterns, test commands. Do not inline file contents — codex re-derives them with its own tools, so a pointer is sufficient (copying is what you reserve for what it cannot re-derive).
+- **Pointers**: Provide file paths, grep patterns, test commands. A pointer is sufficient — codex re-derives the contents with its own tools, and copying is what you reserve for what it cannot re-derive.
 - **Session Context**: Extract only what is already known from the current conversation. Organize as intent, constraints, and preferences.
-- **No collection requests**: Never embed questions or requests for additional user-specific information in the prompt. If codex needs more context, the user will resume with it. Blocked applies only to content written into `/tmp` prompt, not to pre-prompt orchestration (e.g., `AskUserQuestion` for model selection).
+- **No collection requests**: The prompt carries only user-specific information already in hand; when codex needs more, the user supplies it on resume. This bounds the content written into the `/tmp` prompt, leaving pre-prompt orchestration free (e.g., `AskUserQuestion` for model selection).
 
 ### Prompt Template
 
@@ -56,18 +56,17 @@ Omit empty sections. `## Pointers` enables codex to self-verify; `## Session Con
 When the delegated task is image generation or image editing:
 
 - Include `$imagegen` in the prompt so downstream clients treat it as an explicit image-generation request.
-- Keep the local prompt here minimal and task-specific. Do not restate detailed image prompting doctrine in this skill.
+- Keep the local prompt here minimal and task-specific.
 - Defer prompt construction details to the installed `imagegen` skill when available.
 - Use `references/image-gen-models-prompting-guide.ipynb` only as the backing reference for model choice, prompt structure, text rendering, edits, and multi-image workflows.
 
 ## Running a Task
 1. Ask the user (via `AskUserQuestion`) which model(s) and reasoning effort in a **single prompt with two questions**. Model selection is **multi-select** — multiple models can be chosen for parallel execution.
 
-| Model | Characteristics |
-|-------|-----------------|
-| `gpt-5.6-sol` | Current default model for Codex CLI tasks |
-| `gpt-5.6-terra` | Balanced 5.6 variant — lighter usage, faster than Sol; same effort ladder |
-| `gpt-5.5` | Supplementary model (prior default) |
+   Models to offer:
+   - `gpt-5.6-sol` — current default model for Codex CLI tasks.
+   - `gpt-5.6-terra` — balanced 5.6 variant; lighter usage, faster than Sol, same effort ladder.
+   - `gpt-5.5` — supplementary model, the prior default.
 
    Reasoning effort is selected once and applied identically to all chosen models.
 
@@ -78,22 +77,23 @@ When the delegated task is image generation or image editing:
    - return contract: run the command and return ONLY (a) a concise outcome summary and (b) the session id. codex prints `session id: <uuid>` to stderr; the subagent extracts that line verbatim and returns it as `SESSION_ID: <uuid>`. The wrapper does no parsing — stderr is left unsuppressed precisely so the subagent can read the session id and any failure straight from the output.
    - **Single model**: one subagent call.
    - **Multiple models**: issue parallel subagent calls (one per model) in a single response — same prompt, sandbox, and effort, different `-m`. Each returns its own `SESSION_ID`.
-5. Record each returned `SESSION_ID` against its purpose/model. This {purpose → SESSION_ID} map is the only resume handle — there is no most-recent fallback.
-6. Resume: write new instructions to a fresh `/tmp/codex_prompt_<suffix>.txt`, then delegate to a Bash subagent running `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> /tmp/codex_prompt_<suffix>.txt`. Resume is always by explicit id — deterministic, never a race under parallel sessions. Model/effort/sandbox/`-C` are ignored on resume (the session keeps its original settings).
+5. Record each returned `SESSION_ID` against its purpose/model. This {purpose → SESSION_ID} map is the only resume handle.
+6. Resume: write new instructions to a fresh `/tmp/codex_prompt_<suffix>.txt`, then delegate to a Bash subagent running `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> /tmp/codex_prompt_<suffix>.txt`. Resume is always by explicit id, which stays deterministic under parallel sessions. The session keeps its original model/effort/sandbox/`-C` settings.
 7. Summarize each outcome to the user; for parallel work, surface which `SESSION_ID` maps to which branch. Inform the user: "Resume anytime with 'codex resume'."
 
 ### Quick Reference
 Each command below runs **inside a Bash subagent**, which returns the outcome summary plus the `session id: <uuid>` line as `SESSION_ID: <uuid>`.
 
-| Use case | Command pattern |
-| --- | --- |
-| Read-only analysis | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -m MODEL /tmp/codex_prompt_<suffix>.txt` |
-| Apply edits | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s workspace-write --full-auto /tmp/codex_prompt_<suffix>.txt` |
-| Network access | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s danger-full-access --full-auto /tmp/codex_prompt_<suffix>.txt` |
-| Resume a session | `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> /tmp/codex_prompt_<suffix>.txt` (only resume path; deterministic, no --last) |
-| Different dir | Add `-C <DIR>` to non-resume patterns above |
-| Custom model | Add `-m gpt-5.6-terra -r high` to any pattern above |
-| Capture answer to file | Add `-o <FILE>` to write codex's final message to FILE (deterministic) |
+Base patterns:
+- Read-only analysis — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -m MODEL /tmp/codex_prompt_<suffix>.txt`
+- Apply edits — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s workspace-write --full-auto /tmp/codex_prompt_<suffix>.txt`
+- Network access — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s danger-full-access --full-auto /tmp/codex_prompt_<suffix>.txt`
+- Resume a session — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> /tmp/codex_prompt_<suffix>.txt`; the explicit id is the resume path, deterministic under parallel sessions.
+
+Modifiers, added to any base pattern above:
+- Different working directory — `-C <DIR>`, applying to the non-resume patterns
+- Model and effort — `-m gpt-5.6-terra`, `-r high`
+- Capture the answer to a file — `-o <FILE>` writes codex's final message to FILE deterministically
 
 ## Following Up
 After `codex` completes, use `AskUserQuestion` to confirm next steps. Restate model/reasoning/sandbox when proposing actions.

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "kimi-plus",
+  "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
+  "version": "0.1.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/scripts/kimi-run.sh
+++ b/kimi-plus/scripts/kimi-run.sh
@@ -198,13 +198,33 @@ RAW=$(claude -p --output-format json \
 rc=$?
 set -e
 
+# The coding key was needed only for the claude call above. Drop it now, before
+# the jq subprocesses below, so they never inherit it — this is what makes the
+# "confined to claude's own process tree" claim (see NOTE above) literally true
+# rather than approximately so.
+unset ANTHROPIC_API_KEY
+
 if [[ $rc -ne 0 ]]; then
   printf '%s\n' "$RAW" >&2
   exit "$rc"
 fi
 
+# Guard the JSON parse like the claude call above: malformed or wrong-type JSON
+# makes jq exit non-zero (pipefail propagates it), which under set -e would abort
+# HERE — before the empty-session_id guard below — and never surface the raw
+# response the output contract promises. Capture the parse failure and surface
+# $RAW on stderr, same shape as that guard.
+set +e
 RESULT=$(printf '%s' "$RAW" | jq -r '.result // empty')
+jq_rc_result=$?
 KIMI_SESSION_ID=$(printf '%s' "$RAW" | jq -r '.session_id // empty')
+jq_rc_session=$?
+set -e
+if [[ $jq_rc_result -ne 0 || $jq_rc_session -ne 0 ]]; then
+  echo "Error: claude exited 0 but its response did not parse as JSON — resume handle unavailable. Raw response:" >&2
+  printf '%s\n' "$RAW" >&2
+  exit 1
+fi
 
 # A zero exit with no session_id is an unexpected response shape, not success:
 # the resume handle would be blank and the output contract ("SESSION_ID: <uuid>")
@@ -221,4 +241,13 @@ printf '%s\n' "$RESULT"
 # discard the only resume handle. SESSION_ID stays the last stdout line (the
 # -o write goes to a file, not stdout).
 echo "SESSION_ID: $KIMI_SESSION_ID"
-[[ -n "$OUTPUT_FILE" ]] && printf '%s\n' "$RESULT" > "$OUTPUT_FILE"
+# `if`, not `[[ … ]] && …`: a bare trailing test whose condition is false (no -o)
+# would be the script's LAST command and hand its exit status (1) to the whole
+# script, failing every otherwise-successful default run. An unwritable -o still
+# aborts (set -e) inside the body — after SESSION_ID is already emitted, per the
+# ordering above. The explicit `exit 0` pins the success contract to the code
+# path rather than to whatever command happened to run last.
+if [[ -n "$OUTPUT_FILE" ]]; then
+  printf '%s\n' "$RESULT" > "$OUTPUT_FILE"
+fi
+exit 0

--- a/kimi-plus/scripts/kimi-run.sh
+++ b/kimi-plus/scripts/kimi-run.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Defaults
-readonly DEFAULT_MODEL="k3[1m]"
+readonly DEFAULT_MODEL="k3"
 readonly DEFAULT_EFFORT="max"
 readonly DEFAULT_SANDBOX="read-only"
 
@@ -23,9 +23,12 @@ usage() {
 Usage: kimi-run.sh [options] <prompt_file>
 
 Options:
-  -m, --model MODEL      Model name (default: k3[1m] — 1M context, requires
-                          Allegretto membership). Other valid values: k3,
-                          kimi-for-coding, kimi-for-coding-highspeed.
+  -m, --model MODEL      Model name (default: k3 — 256K context, Moderato+).
+                          Opt-in: 'k3[1m]' requests 1M-context mode, which is
+                          plan-gated at a higher membership tier — a below-tier
+                          call fails; verify your plan before opting in. Other
+                          valid values: kimi-for-coding,
+                          kimi-for-coding-highspeed.
   -r, --effort EFFORT    Reasoning effort, maps to CLAUDE_CODE_EFFORT_LEVEL
                           (default: max)
   -s, --sandbox SANDBOX  Sandbox: read-only|workspace-write|danger-full-access
@@ -54,7 +57,8 @@ raw JSON response surfaced on stderr for diagnosis.
 
 Examples:
   kimi-run.sh /tmp/kimi_prompt_a3f9.txt
-  kimi-run.sh -m k3 -r high /tmp/kimi_prompt_a3f9.txt
+  kimi-run.sh -m 'k3[1m]' /tmp/kimi_prompt_a3f9.txt
+  kimi-run.sh -r high /tmp/kimi_prompt_a3f9.txt
   kimi-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 /tmp/kimi_prompt_a3f9.txt
   kimi-run.sh -s workspace-write /tmp/kimi_prompt_a3f9.txt
 USAGE

--- a/kimi-plus/scripts/kimi-run.sh
+++ b/kimi-plus/scripts/kimi-run.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# kimi-run.sh — Parameterized CLI wrapper that runs the Claude Code CLI
+# env-swapped against the Kimi Code membership coding endpoint (Moonshot's
+# Kimi K3), NOT the paygo Moonshot API. Single entry point for all kimi
+# invocations. Run with -h for usage.
+
+set -euo pipefail
+
+# Defaults
+readonly DEFAULT_MODEL="k3[1m]"
+readonly DEFAULT_EFFORT="max"
+readonly DEFAULT_SANDBOX="read-only"
+
+MODEL="$DEFAULT_MODEL"
+EFFORT="$DEFAULT_EFFORT"
+SANDBOX="$DEFAULT_SANDBOX"
+SESSION_ID=""
+CWD=""
+OUTPUT_FILE=""
+
+usage() {
+  cat <<'USAGE'
+Usage: kimi-run.sh [options] <prompt_file>
+
+Options:
+  -m, --model MODEL      Model name (default: k3[1m] — 1M context, requires
+                          Allegretto membership). Other valid values: k3,
+                          kimi-for-coding, kimi-for-coding-highspeed.
+  -r, --effort EFFORT    Reasoning effort, maps to CLAUDE_CODE_EFFORT_LEVEL
+                          (default: max)
+  -s, --sandbox SANDBOX  Sandbox: read-only|workspace-write|danger-full-access
+                          (default: read-only). read-only passes no permission
+                          flags (headless -p denies permission-requiring tools
+                          by default); workspace-write adds
+                          --permission-mode acceptEdits; danger-full-access
+                          adds --dangerously-skip-permissions.
+  -C, --cwd DIR          Working directory to cd into before invoking claude
+  -S, --session-id ID    Resume a specific session by UUID (adds --resume ID).
+                          Model/effort env still applies per-invocation on
+                          resume — switching models mid-session is a session
+                          discipline concern, not enforced by this script.
+  -o, --output-last-message FILE
+                         Also write kimi's final result text to FILE
+  -h, --help             Show this help
+
+The Kimi Code membership coding key is pulled from gopass at call time
+(entry: api-key/kimi-coding) and exported only into this script's own child
+process (claude) — it is never written to disk or the repo. If the gopass
+entry does not exist yet, the script exits with a one-line error naming it.
+
+Output contract: stdout is the result text followed by a final line
+"SESSION_ID: <uuid>". A non-zero claude exit propagates unchanged, with the
+raw JSON response surfaced on stderr for diagnosis.
+
+Examples:
+  kimi-run.sh /tmp/kimi_prompt_a3f9.txt
+  kimi-run.sh -m k3 -r high /tmp/kimi_prompt_a3f9.txt
+  kimi-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 /tmp/kimi_prompt_a3f9.txt
+  kimi-run.sh -s workspace-write /tmp/kimi_prompt_a3f9.txt
+USAGE
+  exit "${1:-0}"
+}
+
+# Parse options
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -m|--model) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; MODEL="$2"; shift 2 ;;
+    -r|--effort) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; EFFORT="$2"; shift 2 ;;
+    -s|--sandbox) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; SANDBOX="$2"; shift 2 ;;
+    -C|--cwd) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; CWD="$2"; shift 2 ;;
+    -S|--session-id) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; SESSION_ID="$2"; shift 2 ;;
+    -o|--output-last-message) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; OUTPUT_FILE="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    -*) echo "Unknown option: $1" >&2; usage 1 ;;
+    *) PROMPT_FILE="$1"; shift ;;
+  esac
+done
+
+# Validate prompt file
+if [[ -z "${PROMPT_FILE:-}" ]]; then
+  echo "Error: prompt_file is required" >&2
+  usage 1
+fi
+
+if [[ ! -f "$PROMPT_FILE" ]]; then
+  echo "Error: prompt file not found: $PROMPT_FILE" >&2
+  exit 1
+fi
+
+command -v jq >/dev/null 2>&1 || { echo "Error: jq is required (used to parse claude's --output-format json response)" >&2; exit 1; }
+
+# Sandbox tier -> claude permission flags. Same tier names as codex-run.sh
+# for cross-skill consistency.
+PERM_ARGS=()
+case "$SANDBOX" in
+  read-only) ;;
+  workspace-write) PERM_ARGS+=(--permission-mode acceptEdits) ;;
+  danger-full-access) PERM_ARGS+=(--dangerously-skip-permissions) ;;
+  *) echo "Error: unknown sandbox mode: $SANDBOX (expected read-only|workspace-write|danger-full-access)" >&2; usage 1 ;;
+esac
+
+RESUME_ARGS=()
+[[ -n "$SESSION_ID" ]] && RESUME_ARGS+=(--resume "$SESSION_ID")
+
+if [[ -n "$CWD" ]]; then
+  cd "$CWD"
+fi
+
+# Pull the membership coding key from gopass at call time. Never stored in
+# the repo, never persisted to disk — exported only into this script's own
+# process tree (the claude child process invoked below).
+MOONSHOT_CODING_KEY="$(gopass show -o api-key/kimi-coding)" || {
+  echo "Error: gopass entry 'api-key/kimi-coding' not found. Issue the Kimi Code membership coding key and store it via 'gopass insert api-key/kimi-coding' before running kimi-run.sh." >&2
+  exit 1
+}
+
+export ANTHROPIC_BASE_URL="https://api.kimi.com/coding/"
+export ANTHROPIC_AUTH_TOKEN="$MOONSHOT_CODING_KEY"
+export ANTHROPIC_MODEL="$MODEL"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="$MODEL"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="$MODEL"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="$MODEL"
+export ANTHROPIC_DEFAULT_FABLE_MODEL="$MODEL"
+export CLAUDE_CODE_SUBAGENT_MODEL="$MODEL"
+export ENABLE_TOOL_SEARCH=false
+export CLAUDE_CODE_EFFORT_LEVEL="$EFFORT"
+
+# Invoke claude headless against the swapped endpoint. --output-format json
+# is required (not a plain exec like codex-run.sh) because session-id capture
+# here is JSON-based, not a stderr banner grep.
+set +e
+RAW=$(claude -p --output-format json \
+  ${RESUME_ARGS[@]+"${RESUME_ARGS[@]}"} \
+  ${PERM_ARGS[@]+"${PERM_ARGS[@]}"} \
+  < "$PROMPT_FILE")
+rc=$?
+set -e
+
+if [[ $rc -ne 0 ]]; then
+  printf '%s\n' "$RAW" >&2
+  exit "$rc"
+fi
+
+RESULT=$(printf '%s' "$RAW" | jq -r '.result // empty')
+KIMI_SESSION_ID=$(printf '%s' "$RAW" | jq -r '.session_id // empty')
+
+printf '%s\n' "$RESULT"
+[[ -n "$OUTPUT_FILE" ]] && printf '%s\n' "$RESULT" > "$OUTPUT_FILE"
+echo "SESSION_ID: $KIMI_SESSION_ID"

--- a/kimi-plus/scripts/kimi-run.sh
+++ b/kimi-plus/scripts/kimi-run.sh
@@ -132,12 +132,15 @@ export CLAUDE_CODE_SUBAGENT_MODEL="$MODEL"
 export ENABLE_TOOL_SEARCH=false
 export CLAUDE_CODE_EFFORT_LEVEL="$EFFORT"
 
-# Thinking must stay on: the Kimi Code docs state that disabling it routes
-# both K3 and K2.7 Code to K2.6 — a silent model downgrade, not an error.
-# On third-party providers MAX_THINKING_TOKENS=0 omits the `thinking`
-# parameter entirely, so an explicit positive budget is what guarantees it.
-# Caller may override with a different positive value; 0 would defeat the
-# model choice and is not a supported configuration here.
+# Thinking stays on: the Kimi Code docs state a thinking-disabled request
+# routes K3 and K2.7 Code to K2.6, a downgrade that surfaces as lower
+# quality rather than an error. An explicit positive budget keeps the
+# configuration stated rather than inherited. Verified 2026-07: this default
+# yields real thinking blocks on the stream (186 thinking_delta events on a
+# reasoning prompt). Probing MAX_THINKING_TOKENS=0 did NOT suppress thinking
+# here, so this variable's exact effect against this endpoint is unconfirmed
+# — the budget is a safeguard, and the verified claim is only that the
+# default configuration thinks.
 export MAX_THINKING_TOKENS="${MAX_THINKING_TOKENS:-32000}"
 
 # Auto-compact window must match the model's actual context entitlement,

--- a/kimi-plus/scripts/kimi-run.sh
+++ b/kimi-plus/scripts/kimi-run.sh
@@ -72,7 +72,7 @@ while [[ $# -gt 0 ]]; do
     -r|--effort) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; EFFORT="$2"; shift 2 ;;
     -s|--sandbox) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; SANDBOX="$2"; shift 2 ;;
     -C|--cwd) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; CWD="$2"; shift 2 ;;
-    -S|--session-id) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; SESSION_ID="$2"; shift 2 ;;
+    -S|--session-id) [[ $# -ge 2 && -n "$2" ]] || { echo "Error: $1 requires a non-empty session id" >&2; usage 1; }; SESSION_ID="$2"; shift 2 ;;
     -o|--output-last-message) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; OUTPUT_FILE="$2"; shift 2 ;;
     -h|--help) usage 0 ;;
     -*) echo "Unknown option: $1" >&2; usage 1 ;;
@@ -116,8 +116,21 @@ RESUME_ARGS=()
 [[ -n "$SESSION_ID" ]] && RESUME_ARGS+=(--resume "$SESSION_ID")
 
 if [[ -n "$CWD" ]]; then
-  cd "$CWD"
+  # Neutralize CDPATH before cd: with it set, a relative -C could resolve to a
+  # CDPATH entry instead of the intended directory AND cd would print the
+  # resolved path to STDOUT, corrupting the result contract (stdout is the
+  # result text plus the SESSION_ID line, nothing else). `--` guards a $CWD
+  # that begins with `-`. Unset rather than a `CDPATH= cd` prefix: cd is a
+  # special builtin, so a preceding assignment can persist.
+  unset CDPATH
+  cd -- "$CWD"
 fi
+
+# Disable xtrace for the rest of the script: from here the coding key lives in
+# the environment (MOONSHOT_CODING_KEY, then ANTHROPIC_API_KEY), and an inherited
+# `set -x` / `bash -x` would print it verbatim to the trace stream — a log. No-op
+# when tracing is already off.
+set +x
 
 # Pull the membership coding key from gopass at call time. Never stored in
 # the repo, never persisted to disk — held only in this script's process and
@@ -217,7 +230,11 @@ fi
 set +e
 RESULT=$(printf '%s' "$RAW" | jq -r '.result // empty')
 jq_rc_result=$?
-KIMI_SESSION_ID=$(printf '%s' "$RAW" | jq -r '.session_id // empty')
+# `| strings` (not `// empty`): a non-string session_id — a number, or an object
+# that renders multiline — would otherwise pass the empty check below and be
+# emitted as an unusable resume handle. Selecting only string-typed values makes
+# a wrong-typed response fall through to that guard instead.
+KIMI_SESSION_ID=$(printf '%s' "$RAW" | jq -r '.session_id | strings')
 jq_rc_session=$?
 set -e
 if [[ $jq_rc_result -ne 0 || $jq_rc_session -ne 0 ]]; then

--- a/kimi-plus/scripts/kimi-run.sh
+++ b/kimi-plus/scripts/kimi-run.sh
@@ -31,12 +31,25 @@ Options:
                           kimi-for-coding-highspeed.
   -r, --effort EFFORT    Reasoning effort, maps to CLAUDE_CODE_EFFORT_LEVEL
                           (default: max)
-  -s, --sandbox SANDBOX  Sandbox: read-only|workspace-write|danger-full-access
-                          (default: read-only). read-only passes no permission
-                          flags (headless -p denies permission-requiring tools
-                          by default); workspace-write adds
-                          --permission-mode acceptEdits; danger-full-access
-                          adds --dangerously-skip-permissions.
+  -s, --sandbox SANDBOX  Sandbox: read-only|workspace-write|auto|danger-full-access
+                          (default: read-only). Each tier pins its permission
+                          mode explicitly, so an ambient
+                          permissions.defaultMode cannot widen it:
+                            read-only          --permission-mode default
+                                               (reads only; Bash denied)
+                            workspace-write    --permission-mode acceptEdits
+                                               (file edits; arbitrary Bash
+                                               still denied — a linter or build
+                                               will NOT run under this tier)
+                            auto               --permission-mode auto
+                                               (a classifier screens each
+                                               action instead of prompting, so
+                                               lint/build/test do run; use when
+                                               the task must verify its own
+                                               work, and state the boundary in
+                                               the prompt)
+                            danger-full-access --dangerously-skip-permissions
+                                               (no review layer at all)
   -C, --cwd DIR          Working directory to cd into before invoking claude
   -S, --session-id ID    Resume a specific session by UUID (adds --resume ID).
                           Model/effort env still applies per-invocation on
@@ -76,7 +89,9 @@ while [[ $# -gt 0 ]]; do
     -o|--output-last-message) [[ $# -ge 2 ]] || { echo "Error: $1 requires a value" >&2; usage 1; }; OUTPUT_FILE="$2"; shift 2 ;;
     -h|--help) usage 0 ;;
     -*) echo "Unknown option: $1" >&2; usage 1 ;;
-    *) PROMPT_FILE="$1"; shift ;;
+    # Reject a second positional rather than letting it overwrite the first:
+    # silently running the last of several prompt files hides the mistake.
+    *) [[ -z "${PROMPT_FILE:-}" ]] || { echo "Error: unexpected extra argument: $1 (exactly one prompt_file is accepted)" >&2; usage 1; }; PROMPT_FILE="$1"; shift ;;
   esac
 done
 
@@ -106,11 +121,29 @@ command -v jq >/dev/null 2>&1 || { echo "Error: jq is required (used to parse cl
 # for cross-skill consistency.
 PERM_ARGS=()
 case "$SANDBOX" in
-  read-only) ;;
+  # Pinned explicitly rather than left blank: with no --permission-mode flag the
+  # run inherits whatever `permissions.defaultMode` the ambient settings carry,
+  # so a machine configured with `bypassPermissions` silently turns the
+  # advertised read-only lane into full access. Verified: the flag does take
+  # precedence over a settings-file defaultMode.
+  read-only) PERM_ARGS+=(--permission-mode default) ;;
   workspace-write) PERM_ARGS+=(--permission-mode acceptEdits) ;;
+  # auto keeps a review layer (a classifier screens each action) instead of
+  # removing the check entirely, so a boundary conveyed in the prompt has
+  # something to bind to. Unlike acceptEdits it also clears arbitrary Bash —
+  # `npm run lint` / build / test, which acceptEdits denies. Verified accepted
+  # on the Kimi coding endpoint.
+  auto) PERM_ARGS+=(--permission-mode auto) ;;
   danger-full-access) PERM_ARGS+=(--dangerously-skip-permissions) ;;
-  *) echo "Error: unknown sandbox mode: $SANDBOX (expected read-only|workspace-write|danger-full-access)" >&2; usage 1 ;;
+  *) echo "Error: unknown sandbox mode: $SANDBOX (expected read-only|workspace-write|auto|danger-full-access)" >&2; usage 1 ;;
 esac
+
+# The nested session loads installed plugin skills and may invoke them itself.
+# kimi-plus's own skill matches exactly the frontend/boilerplate prompts this
+# wrapper carries, so without this the child can call kimi-run.sh recursively.
+# Blocked at the flag layer, not in the skill's frontmatter: the skill must stay
+# model-invocable in ordinary sessions, where it is the frontend executor.
+SKILL_GUARD_ARGS=(--disallowedTools "Skill(kimi-plus:kimi)" "Skill(kimi-plus:kimi *)")
 
 RESUME_ARGS=()
 [[ -n "$SESSION_ID" ]] && RESUME_ARGS+=(--resume "$SESSION_ID")
@@ -150,7 +183,20 @@ MOONSHOT_CODING_KEY="$(gopass show -o api-key/kimi-coding)" || {
 # and need no unset. Two sources a shell swap cannot neutralize: a settings.json
 # `env` block (outranks shell exports) and a signed-in Claude apps gateway
 # session (cleared only by /logout) — out of scope for this wrapper.
-unset ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_USE_FOUNDRY
+unset ANTHROPIC_AUTH_TOKEN \
+      CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_USE_FOUNDRY \
+      CLAUDE_CODE_USE_ANTHROPIC_AWS CLAUDE_CODE_USE_MANTLE \
+      CLAUDE_CODE_USE_ANTHROPIC_GOOGLE_CLOUD CLAUDE_CODE_USE_GATEWAY \
+      ANTHROPIC_CUSTOM_HEADERS
+# The selector list above is the full set recognized by claude 2.1.215, not just
+# the three headline ones: ANTHROPIC_AWS and MANTLE are documented providers that
+# build their own endpoint from provider credentials (so they bypass this base
+# URL entirely), and GOOGLE_CLOUD/GATEWAY are present in the binary though
+# undocumented — cleared defensively since an unset costs nothing.
+# ANTHROPIC_CUSTOM_HEADERS is a different risk in kind: it is applied at
+# client construction regardless of which host ANTHROPIC_BASE_URL names, so an
+# inherited gateway/org header would be transmitted TO the third-party Kimi
+# endpoint. Routing breakage vs credential disclosure — both closed here.
 
 export ANTHROPIC_BASE_URL="https://api.kimi.com/coding/"
 # The coding endpoint authenticates via ANTHROPIC_API_KEY (x-api-key header),
@@ -207,6 +253,7 @@ set +e
 RAW=$(claude -p --output-format json \
   ${RESUME_ARGS[@]+"${RESUME_ARGS[@]}"} \
   ${PERM_ARGS[@]+"${PERM_ARGS[@]}"} \
+  ${SKILL_GUARD_ARGS[@]+"${SKILL_GUARD_ARGS[@]}"} \
   < "$PROMPT_FILE")
 rc=$?
 set -e
@@ -228,7 +275,11 @@ fi
 # response the output contract promises. Capture the parse failure and surface
 # $RAW on stderr, same shape as that guard.
 set +e
-RESULT=$(printf '%s' "$RAW" | jq -r '.result // empty')
+# `| strings` here too: a missing or non-string .result would otherwise be
+# emitted as blank text (or a JSON-rendered object) while a valid session_id
+# still carried the run to exit 0 — reporting success for a response that never
+# delivered an answer.
+RESULT=$(printf '%s' "$RAW" | jq -r '.result | strings')
 jq_rc_result=$?
 # `| strings` (not `// empty`): a non-string session_id — a number, or an object
 # that renders multiline — would otherwise pass the empty check below and be
@@ -247,7 +298,16 @@ fi
 # the resume handle would be blank and the output contract ("SESSION_ID: <uuid>")
 # unmet. Fail loudly with the raw JSON rather than printing an empty handle.
 if [[ -z "$KIMI_SESSION_ID" ]]; then
-  echo "Error: claude exited 0 but the response carried no session_id — unexpected JSON, resume handle unavailable. Raw response:" >&2
+  echo "Error: claude exited 0 but the response carried no usable session_id — unexpected JSON, resume handle unavailable. Raw response:" >&2
+  printf '%s\n' "$RAW" >&2
+  exit 1
+fi
+
+# Same reasoning for the answer itself: a zero exit that yields no result text is
+# an unexpected shape, not a successful empty answer. Surfacing it as success
+# would hand the caller a blank deliverable that looks like a completed run.
+if [[ -z "$RESULT" ]]; then
+  echo "Error: claude exited 0 but the response carried no result text — unexpected JSON. Raw response:" >&2
   printf '%s\n' "$RAW" >&2
   exit 1
 fi

--- a/kimi-plus/scripts/kimi-run.sh
+++ b/kimi-plus/scripts/kimi-run.sh
@@ -120,10 +120,8 @@ if [[ -n "$CWD" ]]; then
 fi
 
 # Pull the membership coding key from gopass at call time. Never stored in
-# the repo, never persisted to disk. Claude keeps the key for its own API
-# calls but SCRUB (exported below) strips it from the Bash/hook/MCP-stdio
-# subprocesses claude spawns — without which every tool the kimi session runs
-# inherits the key (docs: subprocesses inherit the parent env by default).
+# the repo, never persisted to disk — held only in this script's process and
+# copied into the exported ANTHROPIC_API_KEY below.
 MOONSHOT_CODING_KEY="$(gopass show -o api-key/kimi-coding)" || {
   echo "Error: gopass entry 'api-key/kimi-coding' not found. Issue the Kimi Code membership coding key and store it via 'gopass insert api-key/kimi-coding' before running kimi-run.sh." >&2
   exit 1
@@ -146,6 +144,12 @@ export ANTHROPIC_BASE_URL="https://api.kimi.com/coding/"
 # per its official docs — NOT ANTHROPIC_AUTH_TOKEN, which is the paygo
 # api.moonshot.ai convention.
 export ANTHROPIC_API_KEY="$MOONSHOT_CODING_KEY"
+# Drop the intermediate so it never reaches claude's env. Normally a non-exported
+# local stays out of the child's env, but an inherited `allexport` (exported
+# SHELLOPTS) would auto-export this custom-named var and leak the raw key to
+# claude and its tools. Unsetting the source makes that moot — ANTHROPIC_API_KEY
+# already holds a copy.
+unset MOONSHOT_CODING_KEY
 export ANTHROPIC_MODEL="$MODEL"
 export ANTHROPIC_DEFAULT_OPUS_MODEL="$MODEL"
 export ANTHROPIC_DEFAULT_SONNET_MODEL="$MODEL"
@@ -154,11 +158,13 @@ export ANTHROPIC_DEFAULT_FABLE_MODEL="$MODEL"
 export CLAUDE_CODE_SUBAGENT_MODEL="$MODEL"
 export ENABLE_TOOL_SEARCH=false
 export CLAUDE_CODE_EFFORT_LEVEL="$EFFORT"
-# Strip Anthropic/cloud credentials from the subprocesses claude spawns (Bash
-# tool, hooks, MCP stdio) — the parent keeps them for API calls. Confines the
-# coding key to claude itself instead of every tool it runs; matters most under
-# workspace-write / danger-full-access, which execute arbitrary commands.
-export CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1
+# NOTE: do not set CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 here. On claude 2.1.215 it
+# forces permission mode to `default` and blocks the Edit tool under
+# --permission-mode acceptEdits / --dangerously-skip-permissions (verified by
+# isolated A/B run), which would break the workspace-write and danger-full-access
+# lanes this wrapper advertises. The key is already confined to claude's own
+# process tree (gopass, never persisted); edit-lane function outranks that
+# defense-in-depth here.
 
 # Thinking stays on: the Kimi Code docs state a thinking-disabled request
 # routes K3 and K2.7 Code to K2.6, a downgrade that surfaces as lower
@@ -210,5 +216,9 @@ if [[ -z "$KIMI_SESSION_ID" ]]; then
 fi
 
 printf '%s\n' "$RESULT"
-[[ -n "$OUTPUT_FILE" ]] && printf '%s\n' "$RESULT" > "$OUTPUT_FILE"
+# Emit the resume handle BEFORE the optional -o write: the session already
+# exists server-side, so an unwritable -o path must not abort (set -e) and
+# discard the only resume handle. SESSION_ID stays the last stdout line (the
+# -o write goes to a file, not stdout).
 echo "SESSION_ID: $KIMI_SESSION_ID"
+[[ -n "$OUTPUT_FILE" ]] && printf '%s\n' "$RESULT" > "$OUTPUT_FILE"

--- a/kimi-plus/scripts/kimi-run.sh
+++ b/kimi-plus/scripts/kimi-run.sh
@@ -119,7 +119,10 @@ MOONSHOT_CODING_KEY="$(gopass show -o api-key/kimi-coding)" || {
 }
 
 export ANTHROPIC_BASE_URL="https://api.kimi.com/coding/"
-export ANTHROPIC_AUTH_TOKEN="$MOONSHOT_CODING_KEY"
+# The coding endpoint authenticates via ANTHROPIC_API_KEY (x-api-key header),
+# per its official docs — NOT ANTHROPIC_AUTH_TOKEN, which is the paygo
+# api.moonshot.ai convention.
+export ANTHROPIC_API_KEY="$MOONSHOT_CODING_KEY"
 export ANTHROPIC_MODEL="$MODEL"
 export ANTHROPIC_DEFAULT_OPUS_MODEL="$MODEL"
 export ANTHROPIC_DEFAULT_SONNET_MODEL="$MODEL"
@@ -128,6 +131,14 @@ export ANTHROPIC_DEFAULT_FABLE_MODEL="$MODEL"
 export CLAUDE_CODE_SUBAGENT_MODEL="$MODEL"
 export ENABLE_TOOL_SEARCH=false
 export CLAUDE_CODE_EFFORT_LEVEL="$EFFORT"
+
+# Auto-compact window must match the model's actual context entitlement,
+# or compaction fires at the wrong boundary (docs: 262144 for k3/256K,
+# 1048576 for k3[1m]).
+case "$MODEL" in
+  "k3[1m]") export CLAUDE_CODE_AUTO_COMPACT_WINDOW=1048576 ;;
+  *)        export CLAUDE_CODE_AUTO_COMPACT_WINDOW=262144 ;;
+esac
 
 # Invoke claude headless against the swapped endpoint. --output-format json
 # is required (not a plain exec like codex-run.sh) because session-id capture

--- a/kimi-plus/scripts/kimi-run.sh
+++ b/kimi-plus/scripts/kimi-run.sh
@@ -118,6 +118,18 @@ MOONSHOT_CODING_KEY="$(gopass show -o api-key/kimi-coding)" || {
   exit 1
 }
 
+# Neutralize inherited credentials that OUTRANK ANTHROPIC_API_KEY, or the swap
+# is silently hijacked (docs: Authentication precedence). ANTHROPIC_AUTH_TOKEN
+# (rank 2, sent as Authorization: Bearer) beats ANTHROPIC_API_KEY (rank 3,
+# x-api-key) — the request still hits the Kimi base URL but with the wrong
+# credential in the wrong header (401, or a wrong-identity success if the
+# endpoint also accepts the bearer). The cloud-provider selectors rank above
+# both. CLAUDE_CODE_OAUTH_TOKEN and on-disk OAuth login rank BELOW the API key
+# and need no unset. Two sources a shell swap cannot neutralize: a settings.json
+# `env` block (outranks shell exports) and a signed-in Claude apps gateway
+# session (cleared only by /logout) — out of scope for this wrapper.
+unset ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_USE_BEDROCK CLAUDE_CODE_USE_VERTEX CLAUDE_CODE_USE_FOUNDRY
+
 export ANTHROPIC_BASE_URL="https://api.kimi.com/coding/"
 # The coding endpoint authenticates via ANTHROPIC_API_KEY (x-api-key header),
 # per its official docs — NOT ANTHROPIC_AUTH_TOKEN, which is the paygo
@@ -169,6 +181,15 @@ fi
 
 RESULT=$(printf '%s' "$RAW" | jq -r '.result // empty')
 KIMI_SESSION_ID=$(printf '%s' "$RAW" | jq -r '.session_id // empty')
+
+# A zero exit with no session_id is an unexpected response shape, not success:
+# the resume handle would be blank and the output contract ("SESSION_ID: <uuid>")
+# unmet. Fail loudly with the raw JSON rather than printing an empty handle.
+if [[ -z "$KIMI_SESSION_ID" ]]; then
+  echo "Error: claude exited 0 but the response carried no session_id — unexpected JSON, resume handle unavailable. Raw response:" >&2
+  printf '%s\n' "$RAW" >&2
+  exit 1
+fi
 
 printf '%s\n' "$RESULT"
 [[ -n "$OUTPUT_FILE" ]] && printf '%s\n' "$RESULT" > "$OUTPUT_FILE"

--- a/kimi-plus/scripts/kimi-run.sh
+++ b/kimi-plus/scripts/kimi-run.sh
@@ -91,6 +91,15 @@ if [[ ! -f "$PROMPT_FILE" ]]; then
   exit 1
 fi
 
+# Anchor a relative prompt path to the invocation cwd BEFORE any -C cd. The -f
+# check above resolves against the current cwd, but the `< "$PROMPT_FILE"`
+# redirection at invocation runs after the cd — so with -C a relative path would
+# validate here yet read a different (or missing) same-named file afterward.
+case "$PROMPT_FILE" in
+  /*) : ;;
+  *)  PROMPT_FILE="$PWD/$PROMPT_FILE" ;;
+esac
+
 command -v jq >/dev/null 2>&1 || { echo "Error: jq is required (used to parse claude's --output-format json response)" >&2; exit 1; }
 
 # Sandbox tier -> claude permission flags. Same tier names as codex-run.sh
@@ -111,8 +120,10 @@ if [[ -n "$CWD" ]]; then
 fi
 
 # Pull the membership coding key from gopass at call time. Never stored in
-# the repo, never persisted to disk — exported only into this script's own
-# process tree (the claude child process invoked below).
+# the repo, never persisted to disk. Claude keeps the key for its own API
+# calls but SCRUB (exported below) strips it from the Bash/hook/MCP-stdio
+# subprocesses claude spawns — without which every tool the kimi session runs
+# inherits the key (docs: subprocesses inherit the parent env by default).
 MOONSHOT_CODING_KEY="$(gopass show -o api-key/kimi-coding)" || {
   echo "Error: gopass entry 'api-key/kimi-coding' not found. Issue the Kimi Code membership coding key and store it via 'gopass insert api-key/kimi-coding' before running kimi-run.sh." >&2
   exit 1
@@ -143,16 +154,23 @@ export ANTHROPIC_DEFAULT_FABLE_MODEL="$MODEL"
 export CLAUDE_CODE_SUBAGENT_MODEL="$MODEL"
 export ENABLE_TOOL_SEARCH=false
 export CLAUDE_CODE_EFFORT_LEVEL="$EFFORT"
+# Strip Anthropic/cloud credentials from the subprocesses claude spawns (Bash
+# tool, hooks, MCP stdio) — the parent keeps them for API calls. Confines the
+# coding key to claude itself instead of every tool it runs; matters most under
+# workspace-write / danger-full-access, which execute arbitrary commands.
+export CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1
 
 # Thinking stays on: the Kimi Code docs state a thinking-disabled request
 # routes K3 and K2.7 Code to K2.6, a downgrade that surfaces as lower
-# quality rather than an error. An explicit positive budget keeps the
-# configuration stated rather than inherited. Verified 2026-07: this default
-# yields real thinking blocks on the stream (186 thinking_delta events on a
-# reasoning prompt). Probing MAX_THINKING_TOKENS=0 did NOT suppress thinking
-# here, so this variable's exact effect against this endpoint is unconfirmed
-# — the budget is a safeguard, and the verified claim is only that the
-# default configuration thinks.
+# quality rather than an error. Unset the inherited off-switch so the wrapper's
+# thinking-on contract is not silently overridden by parent env. Verified
+# 2026-07: this default yields real thinking blocks on the stream (186
+# thinking_delta events on a reasoning prompt). Probing MAX_THINKING_TOKENS=0
+# did NOT suppress thinking here (this endpoint omits the param rather than
+# forcing off), so the budget below is a stated safeguard, not a guarantee; the
+# verified claim is only that the default configuration thinks. Left overridable
+# (`:-`) so a task can raise the budget.
+unset CLAUDE_CODE_DISABLE_THINKING
 export MAX_THINKING_TOKENS="${MAX_THINKING_TOKENS:-32000}"
 
 # Auto-compact window must match the model's actual context entitlement,

--- a/kimi-plus/scripts/kimi-run.sh
+++ b/kimi-plus/scripts/kimi-run.sh
@@ -132,6 +132,14 @@ export CLAUDE_CODE_SUBAGENT_MODEL="$MODEL"
 export ENABLE_TOOL_SEARCH=false
 export CLAUDE_CODE_EFFORT_LEVEL="$EFFORT"
 
+# Thinking must stay on: the Kimi Code docs state that disabling it routes
+# both K3 and K2.7 Code to K2.6 — a silent model downgrade, not an error.
+# On third-party providers MAX_THINKING_TOKENS=0 omits the `thinking`
+# parameter entirely, so an explicit positive budget is what guarantees it.
+# Caller may override with a different positive value; 0 would defeat the
+# model choice and is not a supported configuration here.
+export MAX_THINKING_TOKENS="${MAX_THINKING_TOKENS:-32000}"
+
 # Auto-compact window must match the model's actual context entitlement,
 # or compaction fires at the wrong boundary (docs: 262144 for k3/256K,
 # 1048576 for k3[1m]).

--- a/kimi-plus/skills/kimi/SKILL.md
+++ b/kimi-plus/skills/kimi/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: kimi-plus
+description: |
+  This skill should be used when the user asks to "run kimi", "use kimi", "delegate to kimi", "kimi resume", or requests frontend-delegation work suited to a lightweight resumable executor — scratchpad HTML iteration, visual/UI iteration loops, screenshot-to-component passes, component scaffolding, or mass boilerplate generation (stories, test skeletons). Executes tasks via the Claude Code CLI env-swapped to the Kimi K3 coding endpoint, with session management.
+---
+
+# Kimi Skill Guide
+
+## Language
+All prompts passed to `kimi-run.sh` MUST be in English.
+
+## Prompt Delivery
+1. Generate a short unique suffix (e.g., `a3f9`, timestamp fragment, or task keyword) for this invocation
+2. Write the prompt to `/tmp/kimi_prompt_<suffix>.txt` using the Write tool
+3. Execute via wrapper script: `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh [options] /tmp/kimi_prompt_<suffix>.txt`
+
+This per-invocation naming prevents file collisions across parallel sessions and team agents.
+
+## Context Classification
+
+Before writing the prompt file, classify available context on two orthogonal axes:
+
+| | Session (already available) | Exploration (needs collection) |
+|---|---|---|
+| **AI-verifiable** | Extract paths, patterns, commands as **Pointers** — the kimi session self-verifies | Provide search hints, entry points — the kimi session self-explores |
+| **User-specific** | Summarize intent, constraints, preferences from current session — **copy-only** | **Blocked** — no collection requests or questions |
+
+**One boundary — Reference over Copy.** Both rows are two faces of the same partition: *re-derivability by the consumer*. The kimi session is the consumer that cannot re-derive the parent's session context, but CAN re-derive anything reachable under its `-C DIR` with its own tools. The AI-verifiable row is what it re-derives, so pass a **reference** (path / pattern / command); the User-specific row is what it cannot, so **copy** only that into the prompt. Operational test before each item: *"Can the kimi session re-derive this from shared substrate with its own tools?"* — yes → pass a pointer; no → copy it in.
+
+**Rules**:
+- **Pointers**: Provide file paths, grep patterns, test commands. Do not inline file contents — the kimi session re-derives them with its own tools, so a pointer is sufficient (copying is what you reserve for what it cannot re-derive).
+- **Session Context**: Extract only what is already known from the current conversation. Organize as intent, constraints, and preferences.
+- **No collection requests**: Never embed questions or requests for additional user-specific information in the prompt. If kimi needs more context, the user will resume with it.
+
+### Prompt Template
+
+Structure `/tmp/kimi_prompt_<suffix>.txt` with these sections:
+
+    ## Task
+    [User's request — framed as a complete end-to-end objective]
+
+    ## Pointers
+    - files: [relevant file paths for kimi to read/verify]
+    - patterns: [grep patterns or keywords to explore]
+    - commands: [test/build commands if relevant]
+
+    ## Session Context
+    - intent: [user's goal in one sentence]
+    - constraints: [limitations, compatibility requirements]
+    - preferences: [coding style, library choices, conventions]
+
+Omit empty sections. `## Pointers` enables the kimi session to self-verify; `## Session Context` provides copy-only background without requiring follow-up.
+
+## Intended Role
+
+Kimi is a lightweight, resumable headless coding executor packaged like `codex-plus` but scoped to a different lane:
+
+- **Visual/UI iteration loops** — scratchpad HTML iteration, screenshot-to-component passes, quick front-end prototyping cycles.
+- **Mass boilerplate generation** — component scaffolding, stories, test skeletons, repetitive structural code.
+
+Cross-vendor second opinions (architecture review, root-cause analysis, high-stakes reasoning) stay with `codex-plus`. This skill is the frontend-delegation executor lane, not a substitute for codex's review/analysis role.
+
+## Running a Task
+1. **No per-invocation model/effort ask** (unlike codex-plus) — defaults are `k3[1m]` (1M context) + `max` effort. Deviate only when the user explicitly names a different model (`k3`, `kimi-for-coding`, `kimi-for-coding-highspeed`) or effort.
+2. Select sandbox mode; default to `read-only` unless the task requires edits. Escalate to `workspace-write` for edit tasks with user awareness; `danger-full-access` requires explicit permission (see Error Handling).
+3. Craft prompt per Context Classification and Prompt Template — classify context, write to `/tmp/kimi_prompt_<suffix>.txt`.
+4. Delegate execution to a Bash subagent (Task tool) — never run `kimi-run.sh` directly in the main session. This keeps kimi's JSON response and full output out of the main context. Give the subagent:
+   - the exact command: `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh [options] /tmp/kimi_prompt_<suffix>.txt` with `-m MODEL` / `-r EFFORT` / `-s SANDBOX` / `-C DIR`, or `-S <SESSION_ID>` to resume.
+   - return contract: run the command and return ONLY (a) a concise outcome summary and (b) the `SESSION_ID: <uuid>` line verbatim, exactly as the script prints it on its final stdout line.
+5. Record each returned `SESSION_ID` against its purpose. This {purpose → SESSION_ID} map is the only resume handle.
+6. Resume: write new instructions to a fresh `/tmp/kimi_prompt_<suffix>.txt`, then delegate to a Bash subagent running `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -S <SESSION_ID> /tmp/kimi_prompt_<suffix>.txt`. See Session Discipline below before resuming with a non-default model.
+7. Summarize the outcome to the user. Inform the user: "Resume anytime with the recorded SESSION_ID."
+
+## Session Discipline
+
+One model per session. Switching models mid-session invalidates Moonshot's context cache and forces an expensive re-prefill. When resuming with `-S`, always pass the same `-m MODEL` the session started with — the script does not enforce or remember this, so track it in the {purpose → SESSION_ID} map alongside the model used.
+
+## Quota Awareness
+
+Kimi Code membership quota operates on a 7-day cycle plus a 5-hour rolling window, shared across devices and keys. On quota or 429-style errors, stop and report to the user — never retry-loop against a quota wall.
+
+## Prerequisites
+
+- A Kimi Code membership: Allegretto tier or higher for the default `k3[1m]` (1M context) model; Moderato tier caps K3 at 256K context (use `-m k3` instead of `k3[1m]` if the membership is Moderato).
+- A coding key stored at gopass entry `api-key/kimi-coding`. `kimi-run.sh` pulls it at call time and never persists it.
+
+## Error Handling
+- Stop and report failures whenever a `kimi-run.sh` invocation exits non-zero; the script surfaces the raw JSON response on stderr — relay it and ask direction before retrying.
+- Missing gopass entry (`api-key/kimi-coding`): surface the prerequisite to the user rather than attempting a workaround.
+- Before using `-s danger-full-access`, ask the user for permission unless it was already given.
+- Quota/429-style errors: stop immediately, report, do not retry-loop (see Quota Awareness).
+
+### Quick Reference
+Each command below runs **inside a Bash subagent**, which returns the outcome summary plus the `SESSION_ID: <uuid>` line.
+
+| Use case | Command pattern |
+| --- | --- |
+| Read-only analysis | `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh /tmp/kimi_prompt_<suffix>.txt` |
+| Apply edits | `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -s workspace-write /tmp/kimi_prompt_<suffix>.txt` |
+| Resume a session | `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -S <SESSION_ID> /tmp/kimi_prompt_<suffix>.txt` |
+| Different dir | Add `-C <DIR>` to any pattern above |
+| Custom model | Add `-m k3 -r high` to any pattern above (name explicitly when deviating from defaults) |
+| Capture answer to file | Add `-o <FILE>` to write kimi's final result text to FILE |
+
+## Following Up
+After `kimi-run.sh` completes, use `AskUserQuestion` to confirm next steps when the outcome is ambiguous or partial.

--- a/kimi-plus/skills/kimi/SKILL.md
+++ b/kimi-plus/skills/kimi/SKILL.md
@@ -61,7 +61,7 @@ Kimi is a lightweight, resumable headless coding executor packaged like `codex-p
 Cross-vendor second opinions (architecture review, root-cause analysis, high-stakes reasoning) stay with `codex-plus`. This skill is the frontend-delegation executor lane, not a substitute for codex's review/analysis role.
 
 ## Running a Task
-1. **No per-invocation model/effort ask** (unlike codex-plus) — defaults are `k3[1m]` (1M context) + `max` effort. Deviate only when the user explicitly names a different model (`k3`, `kimi-for-coding`, `kimi-for-coding-highspeed`) or effort.
+1. **No per-invocation model/effort ask** (unlike codex-plus) — defaults are `k3` (256K context, Moderato+) + `max` effort. Deviate only when the user explicitly names a different model (`k3[1m]`, `kimi-for-coding`, `kimi-for-coding-highspeed`) or effort. `k3[1m]` (1M context) is opt-in and plan-gated at a higher tier (see Prerequisites) — reserve it for genuinely long-context work (multi-file refactors, very large scratchpad sessions).
 2. Select sandbox mode; default to `read-only` unless the task requires edits. Escalate to `workspace-write` for edit tasks with user awareness; `danger-full-access` requires explicit permission (see Error Handling).
 3. Craft prompt per Context Classification and Prompt Template — classify context, write to `/tmp/kimi_prompt_<suffix>.txt`.
 4. Delegate execution to a Bash subagent (Task tool) — never run `kimi-run.sh` directly in the main session. This keeps kimi's JSON response and full output out of the main context. Give the subagent:
@@ -81,7 +81,7 @@ Kimi Code membership quota operates on a 7-day cycle plus a 5-hour rolling windo
 
 ## Prerequisites
 
-- A Kimi Code membership: Allegretto tier or higher for the default `k3[1m]` (1M context) model; Moderato tier caps K3 at 256K context (use `-m k3` instead of `k3[1m]` if the membership is Moderato).
+- A Kimi Code membership: Moderato tier or higher for the default `k3` (256K context). The opt-in `k3[1m]` (1M context) is gated at a higher tier — official docs state Allegretto+, while the membership pricing page has been read as Allegro+ (sources disagree as of 2026-07); verify the actual entitlement on the subscribed plan before opting in, and expect a below-tier call to fail rather than degrade.
 - A coding key stored at gopass entry `api-key/kimi-coding`. `kimi-run.sh` pulls it at call time and never persists it.
 
 ## Error Handling
@@ -99,7 +99,7 @@ Each command below runs **inside a Bash subagent**, which returns the outcome su
 | Apply edits | `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -s workspace-write /tmp/kimi_prompt_<suffix>.txt` |
 | Resume a session | `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -S <SESSION_ID> /tmp/kimi_prompt_<suffix>.txt` |
 | Different dir | Add `-C <DIR>` to any pattern above |
-| Custom model | Add `-m k3 -r high` to any pattern above (name explicitly when deviating from defaults) |
+| Custom model | Add `-m 'k3[1m]'` (plan-gated 1M opt-in) or `-r high` to any pattern above (name explicitly when deviating from defaults) |
 | Capture answer to file | Add `-o <FILE>` to write kimi's final result text to FILE |
 
 ## Following Up

--- a/kimi-plus/skills/kimi/SKILL.md
+++ b/kimi-plus/skills/kimi/SKILL.md
@@ -20,10 +20,10 @@ This per-invocation naming prevents file collisions across parallel sessions and
 
 Before writing the prompt file, classify available context on two orthogonal axes:
 
-| | Session (already available) | Exploration (needs collection) |
-|---|---|---|
-| **AI-verifiable** | Extract paths, patterns, commands as **Pointers** — the kimi session self-verifies | Provide search hints, entry points — the kimi session self-explores |
-| **User-specific** | Summarize intent, constraints, preferences from current session — **copy-only** | **Blocked** — no collection requests or questions |
+- **AI-verifiable × Session (already available)** — extract paths, patterns, commands as **Pointers**; the kimi session self-verifies them.
+- **AI-verifiable × Exploration (needs collection)** — provide search hints and entry points; the kimi session self-explores from them.
+- **User-specific × Session (already available)** — summarize intent, constraints, and preferences from the current session, **copy-only**.
+- **User-specific × Exploration (needs collection)** — **blocked**; this cell carries no collection requests or questions.
 
 **One boundary — Reference over Copy.** Both rows are two faces of the same partition: *re-derivability by the consumer*. The kimi session is the consumer that cannot re-derive the parent's session context, but CAN re-derive anything reachable under its `-C DIR` with its own tools. The AI-verifiable row is what it re-derives, so pass a **reference** (path / pattern / command); the User-specific row is what it cannot, so **copy** only that into the prompt. Operational test before each item: *"Can the kimi session re-derive this from shared substrate with its own tools?"* — yes → pass a pointer; no → copy it in.
 
@@ -94,14 +94,16 @@ Kimi Code membership quota operates on a 7-day cycle plus a 5-hour rolling windo
 ### Quick Reference
 Each command below runs **inside a Bash subagent**, which returns the outcome summary plus the `SESSION_ID: <uuid>` line.
 
-| Use case | Command pattern |
-| --- | --- |
-| Read-only analysis | `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh /tmp/kimi_prompt_<suffix>.txt` |
-| Apply edits | `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -s workspace-write /tmp/kimi_prompt_<suffix>.txt` |
-| Resume a session | `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -S <SESSION_ID> /tmp/kimi_prompt_<suffix>.txt` |
-| Different dir | Add `-C <DIR>` to any pattern above |
-| Custom model | Add `-m 'k3[1m]'` (plan-gated 1M opt-in) or `-r high` to any pattern above (name explicitly when deviating from defaults) |
-| Capture answer to file | Add `-o <FILE>` to write kimi's final result text to FILE |
+Base patterns:
+- Read-only analysis — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh /tmp/kimi_prompt_<suffix>.txt`
+- Apply edits — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -s workspace-write /tmp/kimi_prompt_<suffix>.txt`
+- Resume a session — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -S <SESSION_ID> /tmp/kimi_prompt_<suffix>.txt`
+
+Modifiers, added to any base pattern above:
+- Different working directory — `-C <DIR>`
+- Long-context opt-in — `-m 'k3[1m]'`, plan-gated at a higher membership tier
+- Deeper reasoning — `-r high`
+- Capture the answer to a file — `-o <FILE>` writes kimi's final result text to FILE
 
 ## Following Up
 After `kimi-run.sh` completes, use `AskUserQuestion` to confirm next steps when the outcome is ambiguous or partial.

--- a/kimi-plus/skills/kimi/SKILL.md
+++ b/kimi-plus/skills/kimi/SKILL.md
@@ -102,7 +102,7 @@ Base patterns:
 Modifiers, added to any base pattern above:
 - Different working directory — `-C <DIR>`
 - Long-context opt-in — `-m 'k3[1m]'`, plan-gated at a higher membership tier
-- Deeper reasoning — `-r high`
+- Change reasoning effort — `-r EFFORT` (the default is already `max`, the ceiling; `-r high` is *lower*, for lighter runs)
 - Capture the answer to a file — `-o <FILE>` writes kimi's final result text to FILE
 
 ## Following Up

--- a/kimi-plus/skills/kimi/SKILL.md
+++ b/kimi-plus/skills/kimi/SKILL.md
@@ -81,7 +81,8 @@ Kimi Code membership quota operates on a 7-day cycle plus a 5-hour rolling windo
 
 ## Prerequisites
 
-- A Kimi Code membership: Moderato tier or higher for the default `k3` (256K context). The opt-in `k3[1m]` (1M context) is gated at a higher tier — official docs state Allegretto+, while the membership pricing page has been read as Allegro+ (sources disagree as of 2026-07); verify the actual entitlement on the subscribed plan before opting in, and expect a below-tier call to fail rather than degrade.
+- A Kimi Code membership: Moderato tier or higher for the default `k3` (256K context). The opt-in `k3[1m]` (1M context) needs Allegretto or above — an Allegretto key was verified to be accepted for `k3[1m]` (2026-07), matching the official docs; the membership pricing page had been read as gating it at Allegro+, and that reading is not what the API enforces. Acceptance was confirmed at the call level only — it does not prove the server served a full 1M window rather than falling back.
+- Keep thinking enabled. Per the Kimi Code docs, disabling it routes both K3 and K2.7 Code to K2.6 — a silent model downgrade, not an error.
 - A coding key stored at gopass entry `api-key/kimi-coding`. `kimi-run.sh` pulls it at call time and never persists it.
 
 ## Error Handling

--- a/kimi-plus/skills/kimi/SKILL.md
+++ b/kimi-plus/skills/kimi/SKILL.md
@@ -61,7 +61,7 @@ Kimi is a lightweight, resumable headless coding executor packaged like `codex-p
 Cross-vendor second opinions (architecture review, root-cause analysis, high-stakes reasoning) stay with `codex-plus`. This skill is the frontend-delegation executor lane, not a substitute for codex's review/analysis role.
 
 ## Running a Task
-1. **No per-invocation model/effort ask** (unlike codex-plus) — defaults are `k3` (256K context, Moderato+) + `max` effort. Deviate only when the user explicitly names a different model (`k3[1m]`, `kimi-for-coding`, `kimi-for-coding-highspeed`) or effort. `k3[1m]` (1M context) is opt-in and plan-gated at a higher tier (see Prerequisites) — reserve it for genuinely long-context work (multi-file refactors, very large scratchpad sessions).
+1. Run with the defaults — `k3` (256K context) at `max` effort, thinking on — and pass a different model or effort only when the user names one. For genuinely long-context work (multi-file refactors, very large scratchpad sessions), `-m 'k3[1m]'` opens the 1M window; `kimi-run.sh -h` lists the remaining values.
 2. Select sandbox mode; default to `read-only` unless the task requires edits. Escalate to `workspace-write` for edit tasks with user awareness; `danger-full-access` requires explicit permission (see Error Handling).
 3. Craft prompt per Context Classification and Prompt Template — classify context, write to `/tmp/kimi_prompt_<suffix>.txt`.
 4. Delegate execution to a Bash subagent (Task tool) — never run `kimi-run.sh` directly in the main session. This keeps kimi's JSON response and full output out of the main context. Give the subagent:
@@ -81,8 +81,8 @@ Kimi Code membership quota operates on a 7-day cycle plus a 5-hour rolling windo
 
 ## Prerequisites
 
-- A Kimi Code membership: Moderato tier or higher for the default `k3` (256K context). The opt-in `k3[1m]` (1M context) needs Allegretto or above — an Allegretto key was verified to be accepted for `k3[1m]` (2026-07), matching the official docs; the membership pricing page had been read as gating it at Allegro+, and that reading is not what the API enforces. Acceptance was confirmed at the call level only — it does not prove the server served a full 1M window rather than falling back.
-- Thinking is on by default and should stay on: per the Kimi Code docs, disabling it routes both K3 and K2.7 Code to K2.6 — a silent model downgrade, not an error. `kimi-run.sh` exports a positive `MAX_THINKING_TOKENS` (default 32000) because on third-party providers a value of 0 omits the `thinking` parameter entirely. Never pass `MAX_THINKING_TOKENS=0` to this skill.
+- A Kimi Code membership: Moderato or higher for the default `k3` (256K context); `k3[1m]` (1M context) needs Allegretto or above, verified accepted at the call level (2026-07) — acceptance on its own leaves open whether a full 1M window was served.
+- Thinking runs on by default and stays on: the Kimi Code docs state that a thinking-disabled request routes K3 and K2.7 Code to K2.6, a downgrade that surfaces as lower quality rather than an error. `kimi-run.sh` exports a positive `MAX_THINKING_TOKENS` (default 32000); keep it positive, and raise it when a task needs a deeper budget. Verified 2026-07: the default configuration returns real thinking content on the stream.
 - A coding key stored at gopass entry `api-key/kimi-coding`. `kimi-run.sh` pulls it at call time and never persists it.
 
 ## Error Handling

--- a/kimi-plus/skills/kimi/SKILL.md
+++ b/kimi-plus/skills/kimi/SKILL.md
@@ -62,7 +62,7 @@ Cross-vendor second opinions (architecture review, root-cause analysis, high-sta
 
 ## Running a Task
 1. Run with the defaults — `k3` (256K context) at `max` effort, thinking on — and pass a different model or effort only when the user names one. For genuinely long-context work (multi-file refactors, very large scratchpad sessions), `-m 'k3[1m]'` opens the 1M window; `kimi-run.sh -h` lists the remaining values.
-2. Select sandbox mode; default to `read-only` unless the task requires edits. Escalate to `workspace-write` for edit tasks with user awareness; `danger-full-access` requires explicit permission (see Error Handling).
+2. Select sandbox mode; default to `read-only` unless the task requires edits. Escalate to `workspace-write` for edit tasks with user awareness. Choose `auto` when the task must run its own verification — `workspace-write` permits file edits but still denies arbitrary Bash, so a linter, build, or test will not run under it; `auto` puts a classifier in front of each action instead, so those commands execute while a review layer remains. Under `auto`, state the task's boundary in the prompt itself (what it may touch, what it must not) — that conveyed boundary is what the review layer binds to. `danger-full-access` removes the review layer entirely and requires explicit permission (see Error Handling).
 3. Craft prompt per Context Classification and Prompt Template — classify context, write to `/tmp/kimi_prompt_<suffix>.txt`.
 4. Delegate execution to a Bash subagent (Task tool) — never run `kimi-run.sh` directly in the main session. This keeps kimi's JSON response and full output out of the main context. Give the subagent:
    - the exact command: `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh [options] /tmp/kimi_prompt_<suffix>.txt` with `-m MODEL` / `-r EFFORT` / `-s SANDBOX` / `-C DIR`, or `-S <SESSION_ID>` to resume.
@@ -86,7 +86,7 @@ Kimi Code membership quota operates on a 7-day cycle plus a 5-hour rolling windo
 - A coding key stored at gopass entry `api-key/kimi-coding`. `kimi-run.sh` pulls it at call time and never persists it.
 
 ## Error Handling
-- Stop and report failures whenever a `kimi-run.sh` invocation exits non-zero; the script surfaces the raw JSON response on stderr — relay it and ask direction before retrying.
+- Stop and report failures whenever a `kimi-run.sh` invocation exits non-zero. When the failure came from claude or from processing its response, the script surfaces the raw JSON on stderr — relay it and ask direction before retrying. Setup failures (bad arguments, a missing prompt file, an unreachable `-C` directory, a missing gopass entry, an unwritable `-o` path) print a one-line stderr message instead, with no JSON to relay.
 - Missing gopass entry (`api-key/kimi-coding`): surface the prerequisite to the user rather than attempting a workaround.
 - Before using `-s danger-full-access`, ask the user for permission unless it was already given.
 - Quota/429-style errors: stop immediately, report, do not retry-loop (see Quota Awareness).
@@ -97,6 +97,7 @@ Each command below runs **inside a Bash subagent**, which returns the outcome su
 Base patterns:
 - Read-only analysis — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh /tmp/kimi_prompt_<suffix>.txt`
 - Apply edits — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -s workspace-write /tmp/kimi_prompt_<suffix>.txt`
+- Edit and self-verify (lint/build/test) — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -s auto /tmp/kimi_prompt_<suffix>.txt`
 - Resume a session — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -S <SESSION_ID> /tmp/kimi_prompt_<suffix>.txt`
 
 Modifiers, added to any base pattern above:

--- a/kimi-plus/skills/kimi/SKILL.md
+++ b/kimi-plus/skills/kimi/SKILL.md
@@ -82,7 +82,7 @@ Kimi Code membership quota operates on a 7-day cycle plus a 5-hour rolling windo
 ## Prerequisites
 
 - A Kimi Code membership: Moderato tier or higher for the default `k3` (256K context). The opt-in `k3[1m]` (1M context) needs Allegretto or above — an Allegretto key was verified to be accepted for `k3[1m]` (2026-07), matching the official docs; the membership pricing page had been read as gating it at Allegro+, and that reading is not what the API enforces. Acceptance was confirmed at the call level only — it does not prove the server served a full 1M window rather than falling back.
-- Keep thinking enabled. Per the Kimi Code docs, disabling it routes both K3 and K2.7 Code to K2.6 — a silent model downgrade, not an error.
+- Thinking is on by default and should stay on: per the Kimi Code docs, disabling it routes both K3 and K2.7 Code to K2.6 — a silent model downgrade, not an error. `kimi-run.sh` exports a positive `MAX_THINKING_TOKENS` (default 32000) because on third-party providers a value of 0 omits the `thinking` parameter entirely. Never pass `MAX_THINKING_TOKENS=0` to this skill.
 - A coding key stored at gopass entry `api-key/kimi-coding`. `kimi-run.sh` pulls it at call time and never persists it.
 
 ## Error Handling

--- a/kimi-plus/skills/kimi/SKILL.md
+++ b/kimi-plus/skills/kimi/SKILL.md
@@ -28,9 +28,9 @@ Before writing the prompt file, classify available context on two orthogonal axe
 **One boundary — Reference over Copy.** Both rows are two faces of the same partition: *re-derivability by the consumer*. The kimi session is the consumer that cannot re-derive the parent's session context, but CAN re-derive anything reachable under its `-C DIR` with its own tools. The AI-verifiable row is what it re-derives, so pass a **reference** (path / pattern / command); the User-specific row is what it cannot, so **copy** only that into the prompt. Operational test before each item: *"Can the kimi session re-derive this from shared substrate with its own tools?"* — yes → pass a pointer; no → copy it in.
 
 **Rules**:
-- **Pointers**: Provide file paths, grep patterns, test commands. Do not inline file contents — the kimi session re-derives them with its own tools, so a pointer is sufficient (copying is what you reserve for what it cannot re-derive).
+- **Pointers**: Provide file paths, grep patterns, test commands. A pointer is sufficient — the kimi session re-derives the contents with its own tools, and copying is what you reserve for what it cannot re-derive.
 - **Session Context**: Extract only what is already known from the current conversation. Organize as intent, constraints, and preferences.
-- **No collection requests**: Never embed questions or requests for additional user-specific information in the prompt. If kimi needs more context, the user will resume with it.
+- **No collection requests**: The prompt carries only user-specific information already in hand; when kimi needs more, the user supplies it on resume.
 
 ### Prompt Template
 
@@ -58,7 +58,7 @@ Kimi is a lightweight, resumable headless coding executor packaged like `codex-p
 - **Visual/UI iteration loops** — scratchpad HTML iteration, screenshot-to-component passes, quick front-end prototyping cycles.
 - **Mass boilerplate generation** — component scaffolding, stories, test skeletons, repetitive structural code.
 
-Cross-vendor second opinions (architecture review, root-cause analysis, high-stakes reasoning) stay with `codex-plus`. This skill is the frontend-delegation executor lane, not a substitute for codex's review/analysis role.
+Cross-vendor second opinions (architecture review, root-cause analysis, high-stakes reasoning) stay with `codex-plus`. This skill is the frontend-delegation executor lane.
 
 ## Running a Task
 1. Run with the defaults — `k3` (256K context) at `max` effort, thinking on — and pass a different model or effort only when the user names one. For genuinely long-context work (multi-file refactors, very large scratchpad sessions), `-m 'k3[1m]'` opens the 1M window; `kimi-run.sh -h` lists the remaining values.


### PR DESCRIPTION
## Summary

Adds `kimi-plus`, a plugin packaging Moonshot's Kimi K3 as a lightweight,
resumable headless coding executor for frontend delegation (scratchpad HTML
iteration, component/boilerplate generation) — a sibling to `codex-plus`,
mirroring its structural pattern (`.claude-plugin/plugin.json`,
`scripts/<name>-run.sh` wrapper, `skills/<name>/SKILL.md`).

The final two commits extend the scope to `codex-plus`: since `kimi-plus` was
authored from it as a template, an authoring-form pass on one skill would have
forked prose the two share verbatim. Both are aligned in the same PR.

## Decisions taken

- **Engine**: the Claude Code CLI itself, env-swapped (`ANTHROPIC_BASE_URL`,
  `ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL` + per-tier default-model vars) to the
  Kimi Code **membership coding endpoint** (`https://api.kimi.com/coding/`),
  rather than the paygo Moonshot API. The coding endpoint authenticates via
  `ANTHROPIC_API_KEY` (`x-api-key`); `ANTHROPIC_AUTH_TOKEN` is the paygo
  convention and would have produced 401s.
- **Billing**: Kimi Code Allegretto membership. The coding key is pulled from
  gopass (`api-key/kimi-coding`) at call time and exported only into the child
  `claude` process — never persisted to the repo or disk.
- **Skeleton**: an independent sibling plugin rather than an extension of
  `codex-plus`. `codex-plus` wraps the `codex` CLI (stderr session-id banner,
  `codex resume <id>`, `--sandbox`); `kimi-plus` wraps `claude -p
  --output-format json` (JSON `session_id`, `--resume <id>`,
  `--permission-mode` / `--dangerously-skip-permissions`). The CLI surfaces are
  disjoint enough that a shared script would cost more than two small siblings
  on the same template.
- **Defaults**: `k3` (256K context) at `max` effort with thinking on, and no
  per-invocation model/effort ask — this is meant as a low-friction delegation
  lane. `-m 'k3[1m]'` is an explicit opt-in for genuinely long-context work.

## Verification

Verified live against the endpoint:

- Smoke run end-to-end: `claude -p` through the swapped env, JSON parse,
  `SESSION_ID` line returned.
- Resume: `-S <SESSION_ID>` preserves session identity and recalls prior-turn
  content.
- Tier gate: an Allegretto key was accepted for `k3[1m]`, settling a
  discrepancy between the docs and the pricing page in the docs' favour.
  Acceptance at the call level leaves open whether a full 1M window is served.
- Thinking: the default configuration returns real thinking content on the
  stream (186 `thinking_delta` events on a reasoning prompt, with reasoning
  text distinct from the answer).

Static checks: `bash -n` on the wrapper, `jq empty` on both `plugin.json` and
`marketplace.json`, `kimi-run.sh -h` exits 0. Error paths (missing prompt-file
arg, nonexistent prompt file, missing gopass entry) each exit 1 with a one-line
error under `set -euo pipefail`.

**Unconfirmed, recorded rather than claimed**: probing
`MAX_THINKING_TOKENS=0` did not suppress thinking across two trials, so whether
that variable is the operative control against this endpoint is unknown —
distinguishing a client-side clamp from a server-side default would need raw
outbound HTTP inspection. The positive budget the wrapper exports is a
safeguard; the verified claim is only that the default configuration thinks.

## Authoring-form pass (both skills)

- **Tables → bullets.** An agent reads a skill file linearly, so a grid cell
  arrives detached from the row and column headers that qualify it. Converted:
  the 2×2 context classification in both skills, plus the model list, Quick
  Reference, and codex-session's input→action list.
- **Quick Reference split** into base patterns and modifiers — the "add `-C` to
  any pattern above" rows were never commands to run.
- **White-bear audit applied to both** where a positive statement carried the
  same force: `Do not inline file contents` → `A pointer is sufficient`;
  `Never embed questions…` → `The prompt carries only information already in
  hand`; codex's `there is no most-recent fallback` / `no --last` dropped
  against `the only resume handle`.
- **Kept deliberately**: "never run the wrapper directly in the main session"
  and "never retry-loop against a quota wall" encode real boundaries, which the
  audit's load-bearing test preserves.
- **Not aligned deliberately** — genuine behavioural differences, not drift:
  codex's pre-prompt orchestration clause (it asks the user to pick a model;
  kimi runs on defaults), and codex's multi-model and image-generation
  sections, which have no kimi twin.

## Files

- `kimi-plus/.claude-plugin/plugin.json`, `kimi-plus/scripts/kimi-run.sh`,
  `kimi-plus/skills/kimi/SKILL.md`
- `.claude-plugin/marketplace.json` (registered `kimi-plus` entry)
- `codex-plus/.claude-plugin/plugin.json`,
  `codex-plus/skills/codex/SKILL.md`, `codex-plus/skills/codex-session/SKILL.md`
  (authoring-form alignment only — no behavioural change)
