### PR TITLE
docs(unfold): fix unblocked derivation — relation type is not API-cleared on blocker completion

### DIFF
--- a/unfold/.claude-plugin/plugin.json
+++ b/unfold/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "unfold",
   "description": "Linear loop moment router — unfold the whole picture, next unblocked actions, runbook invariants, decision log, and roadmap from Linear; write only structure and decisions, never state",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/unfold/skills/unfold/SKILL.md
+++ b/unfold/skills/unfold/SKILL.md
@@ -8,7 +8,7 @@ description: |
   (next), "배포 순서" / "머지 전 확인" / "deploy order" (deploy), "이 길로
   가는 이유 기록" / "결정 남겨줘" / "log this decision" (decide), "세션 정리"
   / "구조 변경 반영" / "wrap up the span" (close), "로드맵" / "게이트 어디까지
-  왔지" / "roadmap" (roadmap). Reads auto-derived state from Linear via MCP;
+  왔지" / "roadmap" (roadmap). Reads current state from Linear via MCP;
   writes ONLY structure and decisions (never status). Invoked as
   /unfold [moment] [project].
 ---
@@ -17,16 +17,18 @@ description: |
 
 Route a recurring cognitive moment to the right Linear read or minimal write.
 The substrate premise: the whole picture (workstreams, dependency DAG, gates,
-runbook) lives in Linear as structure; state (issue status, milestone %,
-blocked-relations) is auto-derived by Linear and the GitHub integration.
+runbook) lives in Linear as structure; issue status and milestone % are
+auto-derived by Linear and the GitHub integration. Current blocked/unblocked
+sets are derived on read from those statuses and stored dependency edges.
 Unfold READS that picture on demand instead of reconstructing it from memory,
 and confines WRITES to the two moments where a human hand belongs: decisions
 and structure deltas.
 
 ## Core rule — pace layering
 
-- **Read freely**: issue status, milestone progress %, blocked/unblocked sets
-  are system-maintained. Pull them; never cache-and-trust stale copies.
+- **Read freely**: issue status and milestone progress % are system-maintained;
+  blocked/unblocked sets are derived on read from current statuses and stored
+  dependency edges. Never cache-and-trust stale copies.
 - **Write only structure and decisions**: new workstream issues, `blockedBy`
   edges, runbook documents, one-line decision comments.
 - **Never hand-write state**: do not set issue status, milestone completion,
@@ -84,8 +86,8 @@ moment. Summary:
 
 | Moment | Reads | Writes | Emit |
 |---|---|---|---|
-| `open` | project, milestones (%), open issues + relations, documents | — | current gate + % · unblocked next actions · runbook pointer |
-| `next` | open issues + relations | — | unblocked list only, ranked |
+| `open` | project, milestones (%), open issues + relations + blocker statuses, documents | — | current gate + % · unblocked next actions · runbook pointer |
+| `next` | open issues + relations + blocker statuses | — | unblocked list only, ranked |
 | `deploy` | runbook document | — | ordering invariants section only |
 | `decide` | the target issue | `save_comment` | one-line decision log (draft → confirm → write) |
 | `close` | this session's work | `save_issue` / `save_document` | structure-delta checklist → minimal writes |

--- a/unfold/skills/unfold/references/catalog.md
+++ b/unfold/skills/unfold/references/catalog.md
@@ -18,11 +18,11 @@ records what the prototype proved.
 - **SLOW (hand-written once)**: runbook documents (topology, order,
   invariants), milestone gates, the issue tree, `blocks`/`blockedBy`
   dependency edges, decision comments. Updated only when the plan changes.
-- **FAST (system-maintained, never touched by hand)**: issue status (the
+- **FAST (read at need, never touched by hand)**: issue status (the
   GitHub integration transitions it on PR events), milestone progress %
-  (auto-computed), blocked relations (Linear auto-demotes them when the
-  blocker completes), live facts (image existence, deploy applied — never
-  stored in Linear; read from their source).
+  (auto-computed), current blocked/unblocked sets (derived on read from issue
+  status + stored dependency edges), live facts (image existence, deploy
+  applied — never stored in Linear; read from their source).
 - Why: manual mirroring leads to missed updates → accumulated error → a stale
   whole-picture read back as truth — context pollution. Making the manual
   surface zero removes that chain entirely.
@@ -44,7 +44,7 @@ pure lookup table — not a convergence loop.
 | Cognitive job (why) | Content (topology) | Form the rubric picks | Linear realization (MCP-verified) |
 |---|---|---|---|
 | Re-see the whole picture, extract actions (review-and-orient) | multi-PR dependencies, parallel (graph) | **visual map** — dependency diagram | `blocks`/`blockedBy` DAG → Linear graph/board views (native, always queryable) |
-| What deploys next? what is unblocked? (execute-and-resume / live-monitor) | graph | prose runbook + small dependency view / status board | "unblocked" filtered issue list + milestone gates |
+| What deploys next? what is unblocked? (execute-and-resume / live-monitor) | graph | prose runbook + small dependency view / status board | derived "unblocked" issue list + milestone gates |
 | Runbook distill → fresh session (execute-and-resume) | linear procedure | **cold markdown runbook** (the only cell that routes to authoring protocols) | project `save_document` |
 | Where are we right now? (live-monitor) | linear | status board / state readout | `list_*` reads → local cache → a one-line statusline |
 | Why this order? path selection (decide) | linear narrative | causal / decision log | issue or project `save_comment` — decision threads |
@@ -59,8 +59,8 @@ closing.
 
 | Moment (trigger) | Skill moment | Job | Where to read / write |
 |---|---|---|---|
-| Opening a span (session start) | `open` | read: current gate + unblocked set, then start | project overview (milestone % + runbook pointer) → unblocked filter |
-| "What next?" | `next` | read: ONLY the unblocked set — never scan the whole board | "not done & no blockers" filter (items surface here automatically when blockers complete) |
+| Opening a span (session start) | `open` | read: current gate + unblocked set, then start | project overview (milestone % + runbook pointer) → unblocked derivation |
+| "What next?" | `next` | read: ONLY the unblocked set — never scan the whole board | "not done & no active blockers" derivation (items surface when blocker status changes and the set is re-derived) |
 | Right before deploy/merge | `deploy` | read: ordering invariants (not status) | project runbook document, ordering-invariants section |
 | Choosing a path | `decide` | **write (the only recurring hand-write)**: one line on why this path | `save_comment` on the issue (or project) — decision log |
 | Closing a span (/clear, distill, worker exit) | `close` | write: structural deltas only — new workstream issues, edge changes, runbook updates; distilled handoffs → project doc | `save_issue` (blockedBy) / `save_document`. State is not written |
@@ -76,9 +76,9 @@ webhooks do not cover milestones).
 
 - Structure only was written; the first read-back already showed gate 1 at
   100% and gate 2 at 25%, auto-computed.
-- The automatic chain: `PR merge → issue auto-Done → gate % auto-updates →
-  successor issue's blocked relation auto-clears → the next action surfaces
-  in the unblocked filter` — no hand anywhere in the chain.
+- The hand-free chain: `PR merge → issue auto-Done → gate % auto-updates →
+  next read derives the successor as unblocked → the next action surfaces` —
+  no hand anywhere in the chain.
 - One precondition: the team's Git automations mapping (Team Settings →
   Workflow) must be on for the first link to fire, and the PR must reference
   the issue (identifier in the branch name, or a magic word in the PR body).

--- a/unfold/skills/unfold/references/moments.md
+++ b/unfold/skills/unfold/references/moments.md
@@ -1,24 +1,32 @@
 # Unfold — Per-Moment Procedures
 
 Detailed execution for each moment. All reads treat Linear as the source of
-truth for structure and auto-derived state; live-system facts (image in a
-registry, deploy applied) are never read from Linear — go to their source.
+truth for structure and current issue/milestone state; live-system facts (image
+in a registry, deploy applied) are never read from Linear — go to their source.
 
 ## Shared: unblocked derivation
 
-Linear auto-demotes a `blockedBy` relation to `related` when the blocking
-issue completes, so "currently blocked" is live. There is no server-side
-"unblocked" filter — derive client-side:
+Linear's [issue-relations docs](https://linear.app/docs/issue-relations)
+describe a resolved blocker's relation moving under Related in the issue
+sidebar. API/MCP reads can still return the original `blocks`/`blockedBy`
+relation after completion. The MCP exposes no server-side `unblocked`
+filter — derive client-side:
 
 1. `list_issues` scoped to the project, excluding completed/canceled states.
 2. For candidates, `get_issue` with `includeRelations: true`.
-3. `unblocked(i)` ≡ `relations.blockedBy` is empty ∧ status type is not
-   completed/canceled.
-4. Rank: In Progress first, then Todo within the earliest un-done milestone
+3. For each distinct `blockedBy` issue, obtain its `statusType` (`get_issue`
+   unless already known from another bounded read).
+4. `unblocked(i)` ≡ `i.statusType` is not completed/canceled ∧ every
+   `relations.blockedBy` issue has `statusType` completed.
+5. Rank: In Progress first, then Todo within the earliest un-done milestone
    (gate order = milestone sortOrder), then priority.
 
+`canceled` blockers do not satisfy step 4; Linear's docs do not say whether
+`canceled` counts as resolved.
+
 Keep calls bounded: derive relations only for issues in the earliest one or
-two open gates, not the whole project.
+two open gates, deduplicate `blockedBy` IDs, and fetch only unknown blocker
+statuses — not the whole project.
 
 ## open — span-open orient
 


### PR DESCRIPTION
## What

Corrects the `unfold` skill's "unblocked derivation" — its premise about Linear
blocked-by relations was wrong for the code path the skill actually consumes.

## The defect

The doc opened with:

> Linear auto-demotes a `blockedBy` relation to `related` when the blocking issue completes, so "currently blocked" is live.

This conflates two behaviors:

- **UI (true):** Linear's [issue-relations docs](https://linear.app/docs/issue-relations) do state a resolved blocker's relation moves under "Related" — but that text sits in the issue *sidebar* description, a UI-rendering context.
- **API/MCP (false):** the API — which is what the skill reads — can still return the original `blocks`/`blockedBy` relation after the blocker completes.

So the old step-3 test (`relations.blockedBy` is empty) never became true by virtue of a blocker completing. An issue whose only blocker was Done read as blocked **indefinitely**. `next`/`open`, which consume this derivation, would silently drop such an issue from the unblocked set.

## Evidence

Live query against a real workspace via the Linear MCP:

- `ROO-8`: status Done, `completedAt` 2026-07-18T07:58Z
- `ROO-9`, queried >24h later: `relations.blockedBy` still `[ROO-8]` — not moved to `relatedTo`
- `ROO-8`'s own `relations.blocks` likewise unchanged

The 24h+ gap rules out sync lag.

## Fix (minimal, factual — no restructuring)

- **`references/moments.md`** — replace the auto-demote premise with the observed behavior; rewrite the predicate to check each `blockedBy` issue's own `statusType` rather than relation emptiness. `get_issue` relation entries carry only `id`/`title` (no status), so one `get_issue` per distinct unknown blocker is implied — bounded by deduplicating blocker IDs and limiting to the earliest one or two gates, preserving the file's existing bounded-call rule.
- **`SKILL.md`** — "auto-derived state" → "current state"; blocked/unblocked reframed as derived-on-read from status + stored edges; `open`/`next` reads note blocker statuses.
- **`references/catalog.md`** — same reframing in the pace-layering table, the form rubric, the moment table, and the prototype evidence chain.
- **`plugin.json`** — version bump 0.2.1 → 0.2.2 (patch; per repo bump-on-change rule).

## Deliberately conservative on what Linear leaves open

- States only the **observed** behavior (API can return the completed blocker), not the inferred mechanism (render-time UI computation) — Linear does not document the mechanism.
- Treats `canceled` blockers as **non-releasing**, with an explicit note that Linear's docs do not define whether canceled counts as "resolved".

## Does not undercut "never hand-write state"

Dependency edges stay hand-written structure; issue status stays system-maintained; blocked/unblocked becomes a current read-time derivation from both.
