### PR TITLE
Move kimi-plus/codex-plus prompt files from /tmp to the session scratchpad

### DIFF
--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/scripts/codex-run.sh
+++ b/codex-plus/scripts/codex-run.sh
@@ -39,11 +39,11 @@ suppressed, so the caller (a subagent) reads that line directly and resumes
 that exact session later with -S. Resume is always by explicit id — there is
 no most-recent fallback, so it is never a race under parallel sessions.
 
-Examples:
-  codex-run.sh /tmp/codex_prompt_a3f9.txt
-  codex-run.sh -m gpt-5.6-terra -r high /tmp/codex_prompt_a3f9.txt
-  codex-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 /tmp/codex_prompt_a3f9.txt
-  codex-run.sh -s workspace-write --full-auto /tmp/codex_prompt_a3f9.txt
+Examples (<scratchpad> = the calling session's scratchpad directory):
+  codex-run.sh <scratchpad>/codex_prompt_a3f9.txt
+  codex-run.sh -m gpt-5.6-terra -r high <scratchpad>/codex_prompt_a3f9.txt
+  codex-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 <scratchpad>/codex_prompt_a3f9.txt
+  codex-run.sh -s workspace-write --full-auto <scratchpad>/codex_prompt_a3f9.txt
 USAGE
   exit "${1:-0}"
 }

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -11,10 +11,10 @@ All prompts passed to `codex` MUST be in English.
 
 ## Prompt Delivery
 1. Generate a short unique suffix (e.g., `a3f9`, timestamp fragment, or task keyword) for this invocation
-2. Write the prompt to `/tmp/codex_prompt_<suffix>.txt` using the Write tool
-3. Execute via wrapper script: `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh [options] /tmp/codex_prompt_<suffix>.txt`
+2. Write the prompt to `<scratchpad>/codex_prompt_<suffix>.txt` using the Write tool — `<scratchpad>` is the session's scratchpad directory, the `/private/tmp/…/scratchpad` path announced in the system prompt; writes there run without permission prompts. When no scratchpad directory is announced, fall back to `/private/tmp`.
+3. Execute via wrapper script: `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh [options] <scratchpad>/codex_prompt_<suffix>.txt`
 
-This per-invocation naming prevents file collisions across parallel sessions and team agents.
+This per-invocation naming prevents file collisions across team agents sharing a session scratchpad; parallel sessions are already isolated by their own scratchpad directories.
 
 ## Context Classification
 
@@ -30,11 +30,11 @@ Before writing the prompt file, classify available context on two orthogonal axe
 **Rules**:
 - **Pointers**: Provide file paths, grep patterns, test commands. A pointer is sufficient — codex re-derives the contents with its own tools, and copying is what you reserve for what it cannot re-derive.
 - **Session Context**: Extract only what is already known from the current conversation. Organize as intent, constraints, and preferences.
-- **No collection requests**: The prompt carries only user-specific information already in hand; when codex needs more, the user supplies it on resume. This bounds the content written into the `/tmp` prompt, leaving pre-prompt orchestration free (e.g., `AskUserQuestion` for model selection).
+- **No collection requests**: The prompt carries only user-specific information already in hand; when codex needs more, the user supplies it on resume. This bounds the content written into the prompt file, leaving pre-prompt orchestration free (e.g., `AskUserQuestion` for model selection).
 
 ### Prompt Template
 
-Structure `/tmp/codex_prompt_<suffix>.txt` with these sections:
+Structure `<scratchpad>/codex_prompt_<suffix>.txt` with these sections:
 
     ## Task
     [User's request — framed as a complete end-to-end objective]
@@ -71,24 +71,24 @@ When the delegated task is image generation or image editing:
    Reasoning effort is selected once and applied identically to all chosen models.
 
 2. Select sandbox mode; default to `--sandbox read-only` unless edits or network access are necessary.
-3. Craft prompt per Context Classification and Prompt Template — classify context, write to `/tmp/codex_prompt_<suffix>.txt`.
+3. Craft prompt per Context Classification and Prompt Template — classify context, write to `<scratchpad>/codex_prompt_<suffix>.txt`.
 4. Delegate execution to a Bash subagent (Task tool) — never run `codex-run.sh` directly in the main session. This keeps codex's verbose banner and full output out of the main context. Give the subagent:
-   - the exact command: `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh [options] /tmp/codex_prompt_<suffix>.txt` with `-m MODEL` / `-r EFFORT` / `-s SANDBOX` / `--full-auto` / `-C DIR`, or `-S <SESSION_ID>` to resume.
+   - the exact command: `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh [options] <scratchpad>/codex_prompt_<suffix>.txt` with `-m MODEL` / `-r EFFORT` / `-s SANDBOX` / `--full-auto` / `-C DIR`, or `-S <SESSION_ID>` to resume.
    - return contract: run the command and return ONLY (a) a concise outcome summary and (b) the session id. codex prints `session id: <uuid>` to stderr; the subagent extracts that line verbatim and returns it as `SESSION_ID: <uuid>`. The wrapper does no parsing — stderr is left unsuppressed precisely so the subagent can read the session id and any failure straight from the output.
    - **Single model**: one subagent call.
    - **Multiple models**: issue parallel subagent calls (one per model) in a single response — same prompt, sandbox, and effort, different `-m`. Each returns its own `SESSION_ID`.
 5. Record each returned `SESSION_ID` against its purpose/model. This {purpose → SESSION_ID} map is the only resume handle.
-6. Resume: write new instructions to a fresh `/tmp/codex_prompt_<suffix>.txt`, then delegate to a Bash subagent running `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> /tmp/codex_prompt_<suffix>.txt`. Resume is always by explicit id, which stays deterministic under parallel sessions. The session keeps its original model/effort/sandbox/`-C` settings.
+6. Resume: write new instructions to a fresh `<scratchpad>/codex_prompt_<suffix>.txt`, then delegate to a Bash subagent running `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> <scratchpad>/codex_prompt_<suffix>.txt`. Resume is always by explicit id, which stays deterministic under parallel sessions. The session keeps its original model/effort/sandbox/`-C` settings.
 7. Summarize each outcome to the user; for parallel work, surface which `SESSION_ID` maps to which branch. Inform the user: "Resume anytime with 'codex resume'."
 
 ### Quick Reference
 Each command below runs **inside a Bash subagent**, which returns the outcome summary plus the `session id: <uuid>` line as `SESSION_ID: <uuid>`.
 
 Base patterns:
-- Read-only analysis — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -m MODEL /tmp/codex_prompt_<suffix>.txt`
-- Apply edits — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s workspace-write --full-auto /tmp/codex_prompt_<suffix>.txt`
-- Network access — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s danger-full-access --full-auto /tmp/codex_prompt_<suffix>.txt`
-- Resume a session — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> /tmp/codex_prompt_<suffix>.txt`; the explicit id is the resume path, deterministic under parallel sessions.
+- Read-only analysis — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -m MODEL <scratchpad>/codex_prompt_<suffix>.txt`
+- Apply edits — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s workspace-write --full-auto <scratchpad>/codex_prompt_<suffix>.txt`
+- Network access — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s danger-full-access --full-auto <scratchpad>/codex_prompt_<suffix>.txt`
+- Resume a session — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> <scratchpad>/codex_prompt_<suffix>.txt`; the explicit id is the resume path, deterministic under parallel sessions.
 
 Modifiers, added to any base pattern above:
 - Different working directory — `-C <DIR>`, applying to the non-resume patterns

--- a/kimi-plus/.claude-plugin/plugin.json
+++ b/kimi-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kimi-plus",
   "description": "Kimi K3 headless coding executor via Claude Code env-swap (Kimi Code membership endpoint), frontend-delegation oriented",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/kimi-plus/scripts/kimi-run.sh
+++ b/kimi-plus/scripts/kimi-run.sh
@@ -68,12 +68,12 @@ Output contract: stdout is the result text followed by a final line
 "SESSION_ID: <uuid>". A non-zero claude exit propagates unchanged, with the
 raw JSON response surfaced on stderr for diagnosis.
 
-Examples:
-  kimi-run.sh /tmp/kimi_prompt_a3f9.txt
-  kimi-run.sh -m 'k3[1m]' /tmp/kimi_prompt_a3f9.txt
-  kimi-run.sh -r high /tmp/kimi_prompt_a3f9.txt
-  kimi-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 /tmp/kimi_prompt_a3f9.txt
-  kimi-run.sh -s workspace-write /tmp/kimi_prompt_a3f9.txt
+Examples (<scratchpad> = the calling session's scratchpad directory):
+  kimi-run.sh <scratchpad>/kimi_prompt_a3f9.txt
+  kimi-run.sh -m 'k3[1m]' <scratchpad>/kimi_prompt_a3f9.txt
+  kimi-run.sh -r high <scratchpad>/kimi_prompt_a3f9.txt
+  kimi-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 <scratchpad>/kimi_prompt_a3f9.txt
+  kimi-run.sh -s workspace-write <scratchpad>/kimi_prompt_a3f9.txt
 USAGE
   exit "${1:-0}"
 }

--- a/kimi-plus/skills/kimi/SKILL.md
+++ b/kimi-plus/skills/kimi/SKILL.md
@@ -11,10 +11,10 @@ All prompts passed to `kimi-run.sh` MUST be in English.
 
 ## Prompt Delivery
 1. Generate a short unique suffix (e.g., `a3f9`, timestamp fragment, or task keyword) for this invocation
-2. Write the prompt to `/tmp/kimi_prompt_<suffix>.txt` using the Write tool
-3. Execute via wrapper script: `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh [options] /tmp/kimi_prompt_<suffix>.txt`
+2. Write the prompt to `<scratchpad>/kimi_prompt_<suffix>.txt` using the Write tool — `<scratchpad>` is the session's scratchpad directory, the `/private/tmp/…/scratchpad` path announced in the system prompt; writes there run without permission prompts. When no scratchpad directory is announced, fall back to `/private/tmp`.
+3. Execute via wrapper script: `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh [options] <scratchpad>/kimi_prompt_<suffix>.txt`
 
-This per-invocation naming prevents file collisions across parallel sessions and team agents.
+This per-invocation naming prevents file collisions across team agents sharing a session scratchpad; parallel sessions are already isolated by their own scratchpad directories.
 
 ## Context Classification
 
@@ -34,7 +34,7 @@ Before writing the prompt file, classify available context on two orthogonal axe
 
 ### Prompt Template
 
-Structure `/tmp/kimi_prompt_<suffix>.txt` with these sections:
+Structure `<scratchpad>/kimi_prompt_<suffix>.txt` with these sections:
 
     ## Task
     [User's request — framed as a complete end-to-end objective]
@@ -63,12 +63,12 @@ Cross-vendor second opinions (architecture review, root-cause analysis, high-sta
 ## Running a Task
 1. Run with the defaults — `k3` (256K context) at `max` effort, thinking on — and pass a different model or effort only when the user names one. For genuinely long-context work (multi-file refactors, very large scratchpad sessions), `-m 'k3[1m]'` opens the 1M window; `kimi-run.sh -h` lists the remaining values.
 2. Select sandbox mode; default to `read-only` unless the task requires edits. Escalate to `workspace-write` for edit tasks with user awareness. Choose `auto` when the task must run its own verification — `workspace-write` permits file edits but still denies arbitrary Bash, so a linter, build, or test will not run under it; `auto` puts a classifier in front of each action instead, so those commands execute while a review layer remains. Under `auto`, state the task's boundary in the prompt itself (what it may touch, what it must not) — that conveyed boundary is what the review layer binds to. `danger-full-access` removes the review layer entirely and requires explicit permission (see Error Handling).
-3. Craft prompt per Context Classification and Prompt Template — classify context, write to `/tmp/kimi_prompt_<suffix>.txt`.
+3. Craft prompt per Context Classification and Prompt Template — classify context, write to `<scratchpad>/kimi_prompt_<suffix>.txt`.
 4. Delegate execution to a Bash subagent (Task tool) — never run `kimi-run.sh` directly in the main session. This keeps kimi's JSON response and full output out of the main context. Give the subagent:
-   - the exact command: `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh [options] /tmp/kimi_prompt_<suffix>.txt` with `-m MODEL` / `-r EFFORT` / `-s SANDBOX` / `-C DIR`, or `-S <SESSION_ID>` to resume.
+   - the exact command: `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh [options] <scratchpad>/kimi_prompt_<suffix>.txt` with `-m MODEL` / `-r EFFORT` / `-s SANDBOX` / `-C DIR`, or `-S <SESSION_ID>` to resume.
    - return contract: run the command and return ONLY (a) a concise outcome summary and (b) the `SESSION_ID: <uuid>` line verbatim, exactly as the script prints it on its final stdout line.
 5. Record each returned `SESSION_ID` against its purpose. This {purpose → SESSION_ID} map is the only resume handle.
-6. Resume: write new instructions to a fresh `/tmp/kimi_prompt_<suffix>.txt`, then delegate to a Bash subagent running `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -S <SESSION_ID> /tmp/kimi_prompt_<suffix>.txt`. See Session Discipline below before resuming with a non-default model.
+6. Resume: write new instructions to a fresh `<scratchpad>/kimi_prompt_<suffix>.txt`, then delegate to a Bash subagent running `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -S <SESSION_ID> <scratchpad>/kimi_prompt_<suffix>.txt`. See Session Discipline below before resuming with a non-default model.
 7. Summarize the outcome to the user. Inform the user: "Resume anytime with the recorded SESSION_ID."
 
 ## Session Discipline
@@ -95,10 +95,10 @@ Kimi Code membership quota operates on a 7-day cycle plus a 5-hour rolling windo
 Each command below runs **inside a Bash subagent**, which returns the outcome summary plus the `SESSION_ID: <uuid>` line.
 
 Base patterns:
-- Read-only analysis — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh /tmp/kimi_prompt_<suffix>.txt`
-- Apply edits — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -s workspace-write /tmp/kimi_prompt_<suffix>.txt`
-- Edit and self-verify (lint/build/test) — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -s auto /tmp/kimi_prompt_<suffix>.txt`
-- Resume a session — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -S <SESSION_ID> /tmp/kimi_prompt_<suffix>.txt`
+- Read-only analysis — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh <scratchpad>/kimi_prompt_<suffix>.txt`
+- Apply edits — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -s workspace-write <scratchpad>/kimi_prompt_<suffix>.txt`
+- Edit and self-verify (lint/build/test) — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -s auto <scratchpad>/kimi_prompt_<suffix>.txt`
+- Resume a session — `${CLAUDE_PLUGIN_ROOT}/scripts/kimi-run.sh -S <SESSION_ID> <scratchpad>/kimi_prompt_<suffix>.txt`
 
 Modifiers, added to any base pattern above:
 - Different working directory — `-C <DIR>`


### PR DESCRIPTION
## Why

kimi-plus / codex-plus prompt files were written to `/tmp/<name>_prompt_<suffix>.txt`, outside the harness's pre-approved write surface — every delegation raised a Write permission prompt. The session scratchpad (`/private/tmp/claude-*/<project>/<session>/scratchpad`, announced in the system prompt) is permission-free and session-isolated, making prompt delivery seamless.

## What

- Both SKILL.mds: prompt path → `<scratchpad>/<name>_prompt_<suffix>.txt`; `<scratchpad>` defined once in Prompt Delivery (session scratchpad from the system prompt; fallback `/private/tmp` when none is announced); collision-rationale sentence updated (sessions are isolated by directory, the suffix guards team agents sharing one).
- Wrapper scripts (`kimi-run.sh`, `codex-run.sh`): usage examples follow the same `<scratchpad>/` shape. No behavioral change — the scripts always accepted any path.
- Version bumps: kimi-plus 0.1.13 → 0.1.14, codex-plus 2.5.0 → 2.5.1.
