### PR TITLE
fix(caffeinate): keep the daemon stoppable after macOS prunes /tmp

### DIFF
--- a/caffeinate/.claude-plugin/plugin.json
+++ b/caffeinate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "caffeinate",
   "description": "macOS sleep prevention toggle with battery and network monitoring",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/caffeinate/scripts/smart-caffeinate.sh
+++ b/caffeinate/scripts/smart-caffeinate.sh
@@ -11,9 +11,11 @@
 THRESHOLD=${CAFFEINATE_BATTERY_THRESHOLD:-30}
 CHECK_INTERVAL=60
 GRACE_MAX=2  # consecutive failures before stop
-PIDFILE=/tmp/caffeinate-smart.pid
+# Not /tmp: macOS prunes files there after 3 days, which orphans a long-running daemon
+PIDFILE="${HOME}/.cache/caffeinate-smart.pid"
 
 # Own PID file — daemon is the single owner
+mkdir -p "$(dirname "$PIDFILE")"
 echo "$$" > "$PIDFILE"
 
 # Prevent clamshell sleep on battery

--- a/caffeinate/scripts/toggle.sh
+++ b/caffeinate/scripts/toggle.sh
@@ -3,12 +3,22 @@
 # Output: STARTED or STOPPED
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PIDFILE="/tmp/caffeinate-smart.pid"
+PIDFILE="${HOME}/.cache/caffeinate-smart.pid"
 
 # Check if smart daemon is running (verify it's actually our process)
 PID=$(cat "$PIDFILE" 2>/dev/null)
 if [[ -n "$PID" ]] && ps -p "$PID" -o command= 2>/dev/null | grep -q "smart-caffeinate"; then
-  kill "$PID" 2>/dev/null
+  PIDS="$PID"
+else
+  # Pidfile unreadable — scan instead, so a daemon orphaned by a lost pidfile
+  # (the pre-fix /tmp location, pruned after 3 days) stays stoppable. Without
+  # this the toggle falls through to the start branch and stacks a duplicate.
+  PIDS=$(pgrep -f 'smart-caffeinate\.sh')
+fi
+
+if [[ -n "$PIDS" ]]; then
+  # Kill every match — duplicates may already have stacked up before this fix
+  kill $PIDS 2>/dev/null
   sudo -n pmset -b disablesleep 0 2>/dev/null
   echo "STOPPED"
 else


### PR DESCRIPTION
## Problem

The `smart-caffeinate` daemon is designed to run for days — it holds sleep prevention for an always-on session. But its pidfile lived in `/tmp`, which macOS prunes after ~3 days of no access.

Once the pidfile is gone the daemon is still running, but `toggle.sh` can no longer see it, and falls through to the **start** branch:

```bash
PID=$(cat "$PIDFILE" 2>/dev/null)   # empty — file was pruned
if [[ -n "$PID" ]] && ...           # false
else
  nohup bash "$SCRIPT_DIR/smart-caffeinate.sh" &   # starts a SECOND daemon
```

So past the 3-day mark the toggle silently **inverts**: instead of stopping the daemon it stacks another one, and each holds its own `pmset -b disablesleep 1`. The longer the daemon is meant to run, the more certain this is — the failure is guaranteed by the daemon's intended lifetime, not by unusual use.

Found live on this machine: a daemon at **7d 15h** uptime with its pidfile already pruned, `SleepDisabled 1` in effect, and no working way to turn it off.

## Fix

- **Move the pidfile to `~/.cache`**, which is not swept. Same move this repo already made for skill prompt files in 1cce49c.
- **Fall back to `pgrep -f 'smart-caffeinate\.sh'`** when the pidfile is unreadable, and kill every match.

Both are needed and neither is redundant: relocating the pidfile prevents recurrence, but only the scan can recover a daemon **already** orphaned under the old `/tmp` path — including any duplicates the bug has stacked. Killing all matches is deliberate for that reason.

## Verification

Tested with `kill`, `sudo pmset`, and `nohup` replaced by stubs, run against the live daemon, old script vs new, covering both directions:

| case | conditions | expected | result |
|---|---|---|---|
| old script | pidfile gone + daemon alive | — | `STARTED` — **bug reproduced** |
| new script | pidfile gone + daemon alive | `STOPPED` | ✅ found it by scan |
| new script | no daemon anywhere | `STARTED` | ✅ no false positive |
| new script | valid pidfile | `STOPPED` | ✅ primary path intact |
| new script | stale pid + no daemon | `STARTED` | ✅ kills nothing |

The running daemon and the system's `SleepDisabled` state were left untouched by the test — verified after the run.

## Notes

- Version bumped `1.0.1` → `1.0.2` per the repo's bump-on-change rule.
- No behavior change for a daemon whose pidfile is present and valid.
- Discovered while investigating battery drain; the daemon itself is intentional and was deliberately left running.
