### PR TITLE
fix(cdp-attach): drop the positional-argument contract the skill never had

### DIFF
--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -61,7 +61,7 @@ V3="${CLAUDE_PLUGIN_ROOT}/scripts/v3_advanced.py" && $V3 network_start
 
 ### Selecting a target — profile-aware
 
-Before selecting a target for the first time in a session, check for multiple browser profiles: run `$V1 list --contexts`. If it reports **2 or more** contexts and the user has not already named which profile or target to act on:
+Before selecting a target for the first time in a session, check for multiple browser profiles: run `$V1 list --contexts`. A `list --search` that matches no tab counts as the same situation — the target is undetermined, so run this check instead of returning empty-handed. If it reports **2 or more** contexts and the user has not already named which profile or target to act on:
 
 - **Do not pick one yourself — the choice is the user's.** Build a numbered list of the contexts, each option labeled by its 2–3 most recognizable open tab titles so the user recognizes the profile at a glance — never lead with the raw `browserContextId`. Keep the context id prefix alongside the label as the machine handle.
 - This skill runs forked (`context: fork`), so it cannot pause for user input mid-run: **return that numbered list as the final result, taking no target action in this run** — the main conversation presents the choice and re-invokes with the user's pick. (If running inline instead, ask directly and wait for the pick.)

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -6,10 +6,10 @@ description: |
   "automate browser", "inspect accessibility tree", "monitor network",
   "run JavaScript in browser", "fill form in browser", "debug web page",
   or mentions CDP. Attaches to a running CDP instance for browser automation.
+  Pass the user's request verbatim — this skill reads a free-form request, not a subcommand.
 user_invocable: true
 context: fork
 model: sonnet
-argument-hint: "<operation> [args...]"
 ---
 
 # CDP Attach
@@ -400,9 +400,3 @@ Tab attachment and screenshot capture are inherently flaky. When a CDP operation
 ## Protocol Reference
 
 For CDP domain methods, key codes, and device presets, see `references/cdp-protocol.md`.
-
-## Argument Dispatch
-
-When user provides arguments to `/cdp-attach`:
-- Single word matching a subcommand → run directly (e.g., `/cdp-attach list`)
-- Free-form request → map to appropriate v1/v2/v3 command sequence


### PR DESCRIPTION
Closes #115.

## What #115 actually was

The issue reported that context/profile-level targeting was missing. It is not missing — `list --contexts`, `list --context` and `select --context` landed in 5a33c58/a8f94d4, and the multi-profile selection gate in 59000a4/5dce7d8, all before the issue was filed. The remedy the issue proposed ("tell the user N contexts exist and what the selectors are") is already specified in `SKILL.md`. It simply could never be reached.

The reachability defect had two halves, and this PR is one commit per half.

### Half 1 — a positional-argument contract the skill never had

`SKILL.md` contains no `$ARGUMENTS` placeholder and no `arguments:` frontmatter, so per the slash-commands reference the invocation's arguments are simply appended as `ARGUMENTS: <value>` — the skill reads a free-form request and has no positional parsing anywhere. Two surfaces claimed otherwise, for two different audiences:

| Surface | Audience | Removed because |
|---|---|---|
| `argument-hint: "<operation> [args...]"` | human (autocomplete only — never reaches the model) | misdescribed the contract to whoever types the command |
| `## Argument Dispatch` | model (the forked agent) | declared positional dispatch the skill does not implement; a first argument matching neither rule became `list --search <arg>` and terminated on zero matches |

Removal rather than rewrite: free-form interpretation is the default behavior, so a rule restating it earns nothing.

### Half 2 — the gate was still unreachable after the removal

Deleting `## Argument Dispatch` removed the rule that *mandated* the dead end, but nothing then routed the failing path to the gate. `## Typical Workflows` still opens with `v1 list --search "target"` as step 1, and the gate's precondition read *before selecting a target for the first time* — a search matching nothing never reaches selection, so the gate stayed unevaluated and the run still ended empty-handed.

The second commit widens that precondition by one clause: a zero-match search is the same undetermined-target situation, so it runs the same `list --contexts` check. The dispatch section stays gone.

## Caller surface

`description` gains one line so a calling agent passes the request verbatim instead of compressing it to a token — that compression is how `Dia` ended up in the argument slot in the first place. Held to a single line because direct `/cdp-attach` invocation is the primary path.

## Not done here

- **No endpoint (host/port) selection axis.** The reported `/cdp-attach Dia` named the browser application, but the port was already attached, so the value was inert. `state.json` already persists host/port; leaving the selection surface closed keeps the `host+port` lock key intact, which #106's tab-level lock design assumes.
- **No `name -> browserContextId` alias.** `Target.getTargets` exposes no human-readable context name, so an alias needs new state plus invalidation on every browser restart.

## Verification

Verified:

- `cdp-attach/scripts/` diff against `main` is empty — prose-layer change only
- version `1.8.4 -> 1.8.6`; `.githooks/check-version-bump.sh --base origin/main` exits 0 on this branch and exits 1 on a probe commit touching `SKILL.md` without a bump, so the gate is confirmed to discriminate rather than merely pass
- frontmatter parses with `argument-hint` gone and the description line present

Not verified here:

- The behavioral criterion — an unresolvable `/cdp-attach` request with two or more live browser contexts returning the numbered profile list instead of a silent no-op. This needs a live multi-context browser and a forked run; the change is an instruction-layer change, so nothing in this PR executes it.
