### PR TITLE
feat(codex-plus): default the sandbox to workspace-write with network (2.7.0)

### DIFF
--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.6.5",
+  "version": "2.7.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/scripts/codex-run.sh
+++ b/codex-plus/scripts/codex-run.sh
@@ -14,7 +14,15 @@ CDPATH=
 # Defaults
 readonly DEFAULT_MODEL="gpt-5.6-sol"
 readonly DEFAULT_EFFORT="xhigh"
-readonly DEFAULT_SANDBOX="read-only"
+# workspace-write, not read-only, for one reason: the network. codex exposes no
+# network switch under read-only — the toggle lives in the
+# sandbox_workspace_write table and does nothing while the mode is read-only
+# (verified on 0.144.6: the same request is blocked with the key and without
+# it). Reaching the network therefore costs workspace writes. That cost is
+# being paid, not a judgment that codex ought to be writing. What holds a run
+# to its lane is the role its prompt declares — skills/codex/SKILL.md requires
+# every prompt to state one — not the sandbox.
+readonly DEFAULT_SANDBOX="workspace-write"
 
 MODEL="$DEFAULT_MODEL"
 EFFORT="$DEFAULT_EFFORT"
@@ -31,7 +39,10 @@ Usage: codex-run.sh [options] <prompt_file>
 Options:
   -m, --model MODEL      Model name (default: gpt-5.6-sol)
   -r, --effort EFFORT    Reasoning effort: medium|high|xhigh|max (default: xhigh)
-  -s, --sandbox SANDBOX  Sandbox: read-only|workspace-write|danger-full-access (default: read-only)
+  -s, --sandbox SANDBOX  Sandbox: read-only|workspace-write|danger-full-access
+                         (default: workspace-write, which this wrapper always
+                         runs with network access enabled). read-only has no
+                         network at all — codex offers no switch for it there
   -C, --cwd DIR          Working directory for codex. Pass it again when
                          resuming: `codex exec resume` has no --cd of its own,
                          so this script cd's there before handing off
@@ -145,6 +156,11 @@ if [[ -n "$SESSION_ID" ]]; then
   CODEX_ARGS+=(resume "$SESSION_ID")
 else
   CODEX_ARGS+=(-m "$MODEL" --config "model_reasoning_effort=$EFFORT" --sandbox "$SANDBOX")
+  # The mode and the network are two separate switches: workspace-write on its
+  # own still blocks every outbound connection. Since the network is the whole
+  # reason this wrapper defaults to that mode, bind them here — `-s
+  # workspace-write` must never quietly mean "writes, but still no network".
+  [[ "$SANDBOX" == "workspace-write" ]] && CODEX_ARGS+=(--config "sandbox_workspace_write.network_access=true")
   [[ "$FULL_AUTO" == true ]] && CODEX_ARGS+=(--full-auto)
   [[ -n "$CWD" ]] && CODEX_ARGS+=(-C "$CWD")
 fi

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -61,7 +61,7 @@ A consult asks codex to judge a decision rather than carry out work — the reas
 
 **Take the reviewer's own words, not the summary.** The run goes through a Bash subagent, so its outcome summary is normally all that comes back — which for a consult discards the part that mattered. Pass `-o <FILE>` to write codex's final message verbatim, then read that file instead of relying on the summary. Give that path the same per-invocation uniqueness as the prompt file, plus the model name when consulting several in parallel — one shared path and the reviewers overwrite each other, leaving an answer that reads complete but is not the one you think.
 
-**Read-only, and no ask when the caller already decided.** A consult reads and answers, so `--sandbox read-only` stands. When the caller arrives with the model and reasoning effort already fixed, use those and skip the model/effort question in `## Running a Task` step 1.
+**Leave the sandbox at its default, and no ask when the caller already decided.** Do not reach for `-s`: the default is `workspace-write` with network access, and a consult routinely needs the network to check a claim against a live source rather than against its own recollection. The default permits writes, so what keeps a consult from editing is the reviewer role declared above — not the sandbox. When the caller arrives with the model and reasoning effort already fixed, use those and skip the model/effort question in `## Running a Task` step 1.
 
 ## Image Generation Requests
 
@@ -82,7 +82,7 @@ When the delegated task is image generation or image editing:
 
    Reasoning effort is selected once and applied identically to all chosen models.
 
-2. Select sandbox mode; default to `--sandbox read-only` unless edits or network access are necessary.
+2. Select sandbox mode. Omitting `-s` gives `workspace-write` **with network access** — codex offers no network under `read-only` at all, so this is the only mode short of full access that has any. Pass `-s read-only` when a run must neither touch the tree nor reach off-machine; `-s danger-full-access` only when it must write outside the workspace. Because the default already permits writes, what bounds a run that is meant to only read is the role its prompt declares — state it.
 3. Craft prompt per Context Classification and Prompt Template — classify context, write to `<scratchpad>/codex_prompt_<suffix>.txt`.
 4. Delegate execution to a Bash subagent (Task tool) — never run `codex-run.sh` directly in the main session. This keeps codex's verbose banner and full output out of the main context. Give the subagent:
    - the exact command: `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh [options] <scratchpad>/codex_prompt_<suffix>.txt` with `-m MODEL` / `-r EFFORT` / `-s SANDBOX` / `--full-auto` / `-C DIR`, or `-S <SESSION_ID>` to resume.
@@ -97,9 +97,10 @@ When the delegated task is image generation or image editing:
 Each command below runs **inside a Bash subagent**, which returns the outcome summary plus the `session id: <uuid>` line as `SESSION_ID: <uuid>`.
 
 Base patterns:
-- Read-only analysis — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -m MODEL <scratchpad>/codex_prompt_<suffix>.txt`
-- Apply edits — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s workspace-write --full-auto <scratchpad>/codex_prompt_<suffix>.txt`
-- Network access — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s danger-full-access --full-auto <scratchpad>/codex_prompt_<suffix>.txt`
+- Analysis, network reachable — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -m MODEL <scratchpad>/codex_prompt_<suffix>.txt` (the default sandbox: workspace-write, network on)
+- Apply edits unattended — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh --full-auto <scratchpad>/codex_prompt_<suffix>.txt`
+- Neither writes nor network — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s read-only <scratchpad>/codex_prompt_<suffix>.txt`
+- Write outside the workspace — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s danger-full-access --full-auto <scratchpad>/codex_prompt_<suffix>.txt`
 - Resume a session — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> <scratchpad>/codex_prompt_<suffix>.txt`; the explicit id is the resume path, deterministic under parallel sessions.
 
 Modifiers, added to any base pattern above:


### PR DESCRIPTION
`codex-run.sh` defaulted to `--sandbox read-only`, which blocks every outbound connection — the wrong default for a wrapper whose main use is asking codex to go check something.

## Why the change is bigger than flipping a string

codex exposes **no network switch under `read-only`**. The toggle lives only in the `sandbox_workspace_write` table, and setting it while the mode is `read-only` does nothing. Reaching the network costs workspace writes; there is no cheaper door.

Probed directly against `codex-cli 0.144.6` (`codex sandbox … -- curl https://example.com`):

| mode | network key | result |
|---|---|---|
| *(unsandboxed baseline)* | — | 200 |
| `read-only` | none | blocked |
| `read-only` | `sandbox_workspace_write.network_access=true` | **still blocked** |
| `read-only` | `sandbox_read_only.network_access=true` (speculative path) | **still blocked** |
| `workspace-write` | none | **blocked** |
| `workspace-write` | `sandbox_workspace_write.network_access=true` | 200 |

Two things follow. The permission widening is bought by network access alone — not by any revision of what codex is trusted with. And the mode alone is not enough: without the key, `workspace-write` is still offline.

## What changed

- **`DEFAULT_SANDBOX` → `workspace-write`**, with the reasoning above inscribed at the constant rather than left to be re-derived.
- **Mode and network bound together**: whenever the sandbox is `workspace-write`, the wrapper passes `--config sandbox_workspace_write.network_access=true`. So `-s workspace-write` can never quietly mean "writes, but still no network".
- **`SKILL.md` picks up the bounding the sandbox used to do.** The Consult Mode paragraph no longer asserts `--sandbox read-only`; it says to leave the default alone and names the reviewer-role declaration as what keeps a consult from editing. `## Running a Task` step 2 and the Quick Reference base patterns are rewritten around the new default — `-s read-only` for a run that must neither touch the tree nor reach off-machine, `danger-full-access` still meaning writes *outside* the workspace.

## Evidence

Paired **real** codex run, same prompt and model, only the wrapper differing:

- merged 2.6.5 → `curl: (6) Could not resolve host: example.com` / `000`
- this branch → `200`

Argv is read off a stub `codex` for every `-s` value, and the 2.6.2–2.6.5 contracts were re-run and hold: empty `-C`/`-S`/`-o` rejected by name, second positional rejected, `codex` absent from PATH named (checked with coreutils still present, so the check isn't vacuous), and `-C` restored on resume (verified by having the stub print its own cwd).

## One consequence, named rather than buried

The resume warning fires on options that differ from the default, so `-s workspace-write` with `-S` no longer warns while `-s read-only` now does. Resume ignores both either way — only the heads-up moved. Left alone: that compare-to-default shape predates this change.
