### PR TITLE
fix(cdp-attach): launch guidance omitted --user-data-dir, so it opened no port

### DIFF
--- a/cdp-attach/.claude-plugin/plugin.json
+++ b/cdp-attach/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cdp-attach",
   "description": "Attach to running CDP instance: tab management, screenshots, interaction, network/console monitoring",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/cdp-attach/scripts/cdp_client.py
+++ b/cdp-attach/scripts/cdp_client.py
@@ -172,9 +172,13 @@ class CDPClient:
                 "Headless Chrome detected — cdp-attach requires a visible browser.\n"
                 "Silent execution risk: actions occur without user visibility.\n"
                 "\n"
-                "Launch a visible Chrome instance:\n"
-                "  /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome "
-                "--remote-debugging-port=9222"
+                "Launch a visible Chrome instance with a dedicated profile:\n"
+                "  /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome \\\n"
+                '    --user-data-dir="$HOME/.cache/cdp-attach/browser-profile" '
+                "--remote-debugging-port=9222\n"
+                "\n"
+                "--user-data-dir is required: since Chrome 136 the port flag is ignored\n"
+                "on the platform-default profile, so omitting it opens no port silently."
             )
 
     def new_tab(self, url=""):

--- a/cdp-attach/skills/cdp-attach/SKILL.md
+++ b/cdp-attach/skills/cdp-attach/SKILL.md
@@ -21,9 +21,22 @@ Attach to a running Chrome DevTools Protocol instance. Command-level timeouts ar
 A **visible** (headed) CDP-enabled browser must be running. Headless instances are blocked — silent execution without user visibility is a security risk.
 
 ```bash
-# Manual launch (visible browser)
-/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
+# Manual launch (visible browser, dedicated profile)
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --user-data-dir="$HOME/.cache/cdp-attach/browser-profile" --remote-debugging-port=9222
 ```
+
+`--user-data-dir` is required, not decorative. Since Chrome 136 the port flag is
+ignored when the profile directory is the platform default
+([announcement](https://developer.chrome.com/blog/remote-debugging-port)), so the
+command without it opens no port at all — it fails silently, with no error to read.
+Any non-default path works. A Chromium fork may still honour the flag on its own
+default profile; that is fork behaviour and can disappear on any update, so do not
+build on it.
+
+The dedicated profile starts empty — no logins, no extensions, no existing tabs. To
+drive the browser you already work in, leave that browser running and attach to it
+rather than launching a new instance.
 
 > **Note**: `claude --chrome` may launch a headless instance. If `v1 version` shows `HeadlessChrome`, use the manual launch method above instead.
 


### PR DESCRIPTION
## The command we tell people to run does nothing on stock Chrome

Two places print the launch command — `SKILL.md`'s Prerequisites block and the headless guard's `CDPError` text — and both omitted `--user-data-dir`:

```
/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
```

Since Chrome 136 the port flag is ignored when the profile directory is the platform default ([announcement](https://developer.chrome.com/blog/remote-debugging-port)). The command opens no port, and it fails **silently** — no error, nothing to read — so whoever follows the instruction is left guessing.

## Why it was invisible here

The browser in use is a Chromium fork that still honours the flag on its default profile. Measured on this machine:

```
$ ps -o command= -p <dia pid>
/Applications/Dia.app/Contents/MacOS/Dia --remote-debugging-port=9222     # no --user-data-dir
$ curl -s http://127.0.0.1:9222/json/version   → "Browser": "Chrome/150.0.7871.187"
$ lsof -nP -iTCP:9222 -sTCP:LISTEN             → Dia (LISTEN)
```

with the `dia://inspect/#remote-debugging` opt-in checkbox **off**. So the port comes from the fork deviation, not from the sanctioned path — and it can disappear on any update. #106 already called this "업데이트로 사라질 수 있는 비보장 통로"; this confirms the plugin's own instructions were riding it.

## The replacement is verified, not assumed

- Google Chrome **150.0.7871.186** with a non-default `--user-data-dir` + `--remote-debugging-port=9223`: `/json/version` **200**, `/json/list` **200**. So Chrome 147+'s disabling of `/json/*` is default-profile-only, and the existing HTTP code path keeps working on a dedicated profile.
- A second Dia instance on an isolated profile coexists with the primary; the primary's 9222 stayed up throughout.

Both probe browsers were killed and their profile directories removed.

## Not done here

Supporting the **real** browser profile is a separate piece of work: it needs endpoint discovery via `DevToolsActivePort` and moving `/json/list`, `/json/new`, `/json/close` onto CDP methods (Chrome 147+ disables the HTTP endpoints on the default profile). It is also blocked on checking that `revive`'s renderer immunity survives the move — `v1_core.py` grounds that immunity in the endpoints being *browser-process-served*, which the browser-level WebSocket also is, but that has not been tested against a wedged tab. The commit message records the other rejected alternatives (pointing `--user-data-dir` at the default path; copying the profile to keep logins).

## Verification

- `cdp-attach/.claude-plugin/plugin.json` 1.8.6 → 1.8.7; `.githooks/check-version-bump.sh --base origin/main` exits 0
- `python3 -m py_compile cdp-attach/scripts/cdp_client.py` passes; the new error text was rendered and checked to be copy-pasteable (line continuation + indented second line)
- Prose change only otherwise — no behavioural code path touched
