### PR TITLE
chore(remote-tmux): resolve .claude.json through CLAUDE_CONFIG_DIR

### DIFF
--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "tmux-tracked `claude remote-control` toolkit: spawn one-off sessions (remote-spawn skill) or keep a self-restarting --spawn-worktree pool host alive per project (rc-pool skill), reachable from the Claude app",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/scripts/rc-pool.sh
+++ b/remote-tmux/scripts/rc-pool.sh
@@ -60,7 +60,12 @@ up() {
   # workspace -> the loop would crash-loop. Verify trust up front; do NOT auto-trust.
   python3 - "$dir" <<'PY' || { echo "ERROR: workspace not trusted — run 'claude' in $dir once, accept the trust dialog, then retry" >&2; return 1; }
 import json, os, sys
-d = json.load(open(os.path.expanduser("~/.claude.json")))
+# `.claude.json` does NOT go through the usual config-dir resolver. Its resolver is
+# `path.join(CLAUDE_CONFIG_DIR || homedir(), ".claude.json")` — the base is the RAW
+# variable falling back to $HOME, NOT to $HOME/.claude. `or` matches `||`, which falls
+# back on an empty string too (unlike the `??` used for paths inside the config dir).
+base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~")
+d = json.load(open(os.path.join(base, ".claude.json")))
 sys.exit(0 if d.get("projects", {}).get(sys.argv[1], {}).get("hasTrustDialogAccepted") else 1)
 PY
   local sess="rcpool-$name"


### PR DESCRIPTION
Part of a three-repo pass making user-config paths portable. `CLAUDE_CONFIG_DIR` is unset today, so the intended outcome is **zero behaviour change now** and portability afterwards.

## The one locus, and why it is the awkward one

`remote-tmux/scripts/rc-pool.sh` verifies workspace trust before spawning, by reading `~/.claude.json` through `os.path.expanduser`. Relocate the config directory and it checks the wrong file, then refuses to spawn.

This file looks like every other `~/.claude…` hit and is not. The 2.1.220 binary has **two** resolvers:

| what | resolver |
|---|---|
| anything inside the config dir | `CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude")` |
| `~/.claude.json` | `path.join(CLAUDE_CONFIG_DIR \|\| os.homedir(), ".claude.json")` |

The second takes the **raw** variable as its base and falls back to `$HOME` — not to `$HOME/.claude` — and uses `||`, which falls back on an empty string too. Python's `or` reproduces `||` exactly, so:

```python
base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~")
d = json.load(open(os.path.join(base, ".claude.json")))
```

The `is None` test that is correct for config-dir paths would be wrong here. The comment in the diff records that, so the next reader does not "fix" it into the other form.

## Left alone, with reasons

- `docs/skill-style-guide.md`, `claude-code-internals/references/*` — documentation describing the default layout; no path is resolved.
- `.claude/rules/cdp-attach.md`, `cdp-attach/skills/cdp-attach/SKILL.md` — "see `<path>`" pointers into the user's own global rules. A `${...}` form would be inert there anyway: `Read`/`Grep`/`Glob` perform no shell expansion, and a tilde inside `${VAR:-~/.claude}` stays literal even in quotes.
- `excalidraw-host/README.md` — human install instructions.
- `make-deck/…/deck-skeleton.html` — `~/.claude/.write/`, the write skill's own directory rather than a harness path. Where user drafts should live is a separate, user-held question.

`docs/skill-style-guide.md` already bans hardcoded `~/.claude/...` paths for skill scripts ("breaks portability across installs", PR #102 `fcd3862`). This extends that existing rule to the one script it had not reached.

## Verification

- `bash -n` on `rc-pool.sh`.
- The python heredoc extracted **as committed** and run through `py_compile`.
- Path resolution probed under unset / empty / set and compared against Node's `path.join` under the `||` resolver:

```
        this change              harness reference
unset   /Users/choi/.claude.json  /Users/choi/.claude.json
empty   /Users/choi/.claude.json  /Users/choi/.claude.json
set     /tmp/cfg/.claude.json     /tmp/cfg/.claude.json
```

The unset row equals the pre-edit `expanduser("~/.claude.json")` exactly.

`remote-tmux` version bumped 4.2.0 → 4.2.1 per Bump-on-change (patch: today's behaviour is unchanged, the fix is portability).

Merge is yours.
