### PR TITLE
chore(codex-plus): drop --full-auto, gpt-5.5, and the workflow restatement

### DIFF
--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/scripts/codex-run.sh
+++ b/codex-plus/scripts/codex-run.sh
@@ -64,7 +64,6 @@ Examples (<scratchpad> = the calling session's scratchpad directory):
   codex-run.sh <scratchpad>/codex_prompt_a3f9.txt
   codex-run.sh -m gpt-5.6-terra -r high <scratchpad>/codex_prompt_a3f9.txt
   codex-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 <scratchpad>/codex_prompt_a3f9.txt
-  codex-run.sh -s read-only <scratchpad>/codex_prompt_a3f9.txt
 USAGE
   exit "${1:-0}"
 }

--- a/codex-plus/scripts/codex-run.sh
+++ b/codex-plus/scripts/codex-run.sh
@@ -27,7 +27,6 @@ readonly DEFAULT_SANDBOX="workspace-write"
 MODEL="$DEFAULT_MODEL"
 EFFORT="$DEFAULT_EFFORT"
 SANDBOX="$DEFAULT_SANDBOX"
-FULL_AUTO=false
 SESSION_ID=""
 CWD=""
 OUTPUT_FILE=""
@@ -41,8 +40,11 @@ Options:
   -r, --effort EFFORT    Reasoning effort: medium|high|xhigh|max (default: xhigh)
   -s, --sandbox SANDBOX  Sandbox: read-only|workspace-write|danger-full-access
                          (default: workspace-write, which this wrapper always
-                         runs with network access enabled). read-only has no
-                         network at all — codex offers no switch for it there
+                         runs with network access enabled, and which already
+                         applies edits unattended — `codex exec` is headless, so
+                         there is no approval step to opt out of and no
+                         --ask-for-approval to set). read-only has no network at
+                         all — codex offers no switch for it there
   -C, --cwd DIR          Working directory for codex. Pass it again when
                          resuming: `codex exec resume` has no --cd of its own,
                          so this script cd's there before handing off
@@ -51,7 +53,6 @@ Options:
   -o, --output-last-message FILE
                          Also write codex's final message to FILE (deterministic
                          capture, decoupled from stdout banner noise)
-  --full-auto            Enable full auto mode
   -h, --help             Show this help
 
 codex prints "session id: <uuid>" to stderr on every run. stderr is not
@@ -63,7 +64,7 @@ Examples (<scratchpad> = the calling session's scratchpad directory):
   codex-run.sh <scratchpad>/codex_prompt_a3f9.txt
   codex-run.sh -m gpt-5.6-terra -r high <scratchpad>/codex_prompt_a3f9.txt
   codex-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 <scratchpad>/codex_prompt_a3f9.txt
-  codex-run.sh -s workspace-write --full-auto <scratchpad>/codex_prompt_a3f9.txt
+  codex-run.sh -s read-only <scratchpad>/codex_prompt_a3f9.txt
 USAGE
   exit "${1:-0}"
 }
@@ -85,7 +86,6 @@ while [[ $# -gt 0 ]]; do
     -C|--cwd) [[ $# -ge 2 && -n "$2" ]] || { echo "Error: $1 requires a non-empty value" >&2; usage 1; }; CWD="$2"; shift 2 ;;
     -S|--session-id) [[ $# -ge 2 && -n "$2" ]] || { echo "Error: $1 requires a non-empty value" >&2; usage 1; }; SESSION_ID="$2"; shift 2 ;;
     -o|--output-last-message) [[ $# -ge 2 && -n "$2" ]] || { echo "Error: $1 requires a non-empty value" >&2; usage 1; }; OUTPUT_FILE="$2"; shift 2 ;;
-    --full-auto) FULL_AUTO=true; shift ;;
     -h|--help) usage 0 ;;
     -*) echo "Unknown option: $1" >&2; usage 1 ;;
     *) [[ -z "${PROMPT_FILE:-}" ]] || { echo "Error: only one prompt file is accepted, got \"$PROMPT_FILE\" and \"$1\"" >&2; usage 1; }; PROMPT_FILE="$1"; shift ;;
@@ -142,7 +142,6 @@ if [[ -n "$SESSION_ID" ]]; then
   [[ "$MODEL" != "$DEFAULT_MODEL" ]] && IGNORED+=("-m $MODEL")
   [[ "$EFFORT" != "$DEFAULT_EFFORT" ]] && IGNORED+=("-r $EFFORT")
   [[ "$SANDBOX" != "$DEFAULT_SANDBOX" ]] && IGNORED+=("-s $SANDBOX")
-  [[ "$FULL_AUTO" == true ]] && IGNORED+=("--full-auto")
   if [[ ${#IGNORED[@]} -gt 0 ]]; then
     echo "Warning: resume ignores options: ${IGNORED[*]} (uses session settings)" >&2
   fi
@@ -161,7 +160,6 @@ else
   # reason this wrapper defaults to that mode, bind them here — `-s
   # workspace-write` must never quietly mean "writes, but still no network".
   [[ "$SANDBOX" == "workspace-write" ]] && CODEX_ARGS+=(--config "sandbox_workspace_write.network_access=true")
-  [[ "$FULL_AUTO" == true ]] && CODEX_ARGS+=(--full-auto)
   [[ -n "$CWD" ]] && CODEX_ARGS+=(-C "$CWD")
 fi
 

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -14,8 +14,6 @@ All prompts passed to `codex` MUST be in English.
 2. Write the prompt to `<scratchpad>/codex_prompt_<suffix>.txt` using the Write tool — `<scratchpad>` is the session's scratchpad directory, the `/private/tmp/…/scratchpad` path announced in the system prompt; writes there run without permission prompts. When no scratchpad directory is announced, fall back to `/private/tmp`.
 3. Execute via wrapper script: `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh [options] <scratchpad>/codex_prompt_<suffix>.txt`
 
-This per-invocation naming prevents file collisions across team agents sharing a session scratchpad; parallel sessions are already isolated by their own scratchpad directories.
-
 ## Context Classification
 
 Before writing the prompt file, classify available context on two orthogonal axes:
@@ -25,12 +23,12 @@ Before writing the prompt file, classify available context on two orthogonal axe
 - **User-specific × Session (already available)** — summarize intent, constraints, and preferences from the current session, **copy-only**.
 - **User-specific × Exploration (needs collection)** — **blocked**; this cell carries no collection requests or questions.
 
-**One boundary — Reference over Copy.** Both rows are two faces of the same partition: *re-derivability by the consumer*. Codex is the consumer that cannot re-derive the parent's session context, but CAN re-derive anything reachable by its own tools under `-C DIR`. The AI-verifiable row is what codex re-derives, so pass a **reference** (path / pattern / command); the User-specific row is what it cannot, so **copy** only that into the prompt. Operational test before each item: *"Can codex re-derive this from shared substrate with its own tools?"* — yes → pass a pointer; no → copy it in.
+**Test each item before including it**: *"Can codex re-derive this from shared substrate with its own tools?"* — yes → pass a pointer; no → copy it in.
 
 **Rules**:
-- **Pointers**: Provide file paths, grep patterns, test commands. A pointer is sufficient — codex re-derives the contents with its own tools, and copying is what you reserve for what it cannot re-derive.
+- **Pointers**: Provide file paths, grep patterns, test commands. Reserve copying for what codex cannot re-derive.
 - **Session Context**: Extract only what is already known from the current conversation. Organize as intent, constraints, and preferences.
-- **No collection requests**: The prompt carries only user-specific information already in hand; when codex needs more, the user supplies it on resume. This bounds the content written into the prompt file, leaving pre-prompt orchestration free (e.g., `AskUserQuestion` for model selection).
+- **No collection requests**: The prompt carries only user-specific information already in hand; when codex needs more, the user supplies it on resume. This bounds the prompt file only — pre-prompt orchestration stays free, so `AskUserQuestion` for model selection is fine.
 
 ### Prompt Template
 
@@ -49,7 +47,7 @@ Structure `<scratchpad>/codex_prompt_<suffix>.txt` with these sections:
     - constraints: [limitations, compatibility requirements]
     - preferences: [coding style, library choices, conventions]
 
-Omit empty sections. `## Pointers` enables codex to self-verify; `## Session Context` provides copy-only background without requiring follow-up.
+Omit empty sections.
 
 ## Consult Mode (review, not execution)
 

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -78,14 +78,13 @@ When the delegated task is image generation or image editing:
    Models to offer:
    - `gpt-5.6-sol` — current default model for Codex CLI tasks.
    - `gpt-5.6-terra` — balanced 5.6 variant; lighter usage, faster than Sol, same effort ladder.
-   - `gpt-5.5` — supplementary model, the prior default.
 
    Reasoning effort is selected once and applied identically to all chosen models.
 
 2. Select sandbox mode. Omitting `-s` gives `workspace-write` **with network access** — codex offers no network under `read-only` at all, so this is the only mode short of full access that has any. Pass `-s read-only` when a run must neither touch the tree nor reach off-machine; `-s danger-full-access` only when it must write outside the workspace. Because the default already permits writes, what bounds a run that is meant to only read is the role its prompt declares — state it.
 3. Craft prompt per Context Classification and Prompt Template — classify context, write to `<scratchpad>/codex_prompt_<suffix>.txt`.
 4. Delegate execution to a Bash subagent (Task tool) — never run `codex-run.sh` directly in the main session. This keeps codex's verbose banner and full output out of the main context. Give the subagent:
-   - the exact command: `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh [options] <scratchpad>/codex_prompt_<suffix>.txt` with `-m MODEL` / `-r EFFORT` / `-s SANDBOX` / `--full-auto` / `-C DIR`, or `-S <SESSION_ID>` to resume.
+   - the exact command: `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh [options] <scratchpad>/codex_prompt_<suffix>.txt` with `-m MODEL` / `-r EFFORT` / `-s SANDBOX` / `-C DIR`, or `-S <SESSION_ID>` to resume.
    - return contract: run the command and return ONLY (a) a concise outcome summary and (b) the session id. codex prints `session id: <uuid>` to stderr; the subagent extracts that line verbatim and returns it as `SESSION_ID: <uuid>`. The wrapper does no parsing — stderr is left unsuppressed precisely so the subagent can read the session id and any failure straight from the output.
    - **Single model**: one subagent call.
    - **Multiple models**: issue parallel subagent calls (one per model) in a single response — same prompt, sandbox, and effort, different `-m`. Each returns its own `SESSION_ID`.
@@ -97,14 +96,13 @@ When the delegated task is image generation or image editing:
 Each command below runs **inside a Bash subagent**, which returns the outcome summary plus the `session id: <uuid>` line as `SESSION_ID: <uuid>`.
 
 Base patterns:
-- Analysis, network reachable — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -m MODEL <scratchpad>/codex_prompt_<suffix>.txt` (the default sandbox: workspace-write, network on)
-- Apply edits unattended — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh --full-auto <scratchpad>/codex_prompt_<suffix>.txt`
+- Analysis or unattended edits, network reachable — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -m MODEL <scratchpad>/codex_prompt_<suffix>.txt` (the default sandbox: workspace-write, network on — it applies edits without prompting, because `codex exec` is headless and has no approval step to opt out of)
 - Neither writes nor network — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s read-only <scratchpad>/codex_prompt_<suffix>.txt`
-- Write outside the workspace — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s danger-full-access --full-auto <scratchpad>/codex_prompt_<suffix>.txt`
+- Write outside the workspace — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -s danger-full-access <scratchpad>/codex_prompt_<suffix>.txt`
 - Resume a session — `${CLAUDE_PLUGIN_ROOT}/scripts/codex-run.sh -S <SESSION_ID> <scratchpad>/codex_prompt_<suffix>.txt`; the explicit id is the resume path, deterministic under parallel sessions.
 
 Modifiers, added to any base pattern above:
-- Different working directory — `-C <DIR>`; pass it again when resuming, since `codex exec resume` has no `--cd` of its own
+- Different working directory — `-C <DIR>`; pass it again on resume (step 6)
 - Model and effort — `-m gpt-5.6-terra`, `-r high`
 - Capture the answer to a file — `-o <FILE>` writes codex's final message to FILE deterministically
 
@@ -113,7 +111,7 @@ After `codex` completes, use `AskUserQuestion` to confirm next steps. Restate mo
 
 ## Error Handling
 - Stop and report failures whenever `codex --version` or a `codex exec` command exits non-zero; request direction before retrying.
-- Before you use high-impact flags (`--full-auto`, `--sandbox danger-full-access`, `--skip-git-repo-check`) ask the user for permission using AskUserQuestion unless it was already given.
+- Before you use high-impact flags (`--sandbox danger-full-access`, `--skip-git-repo-check`) ask the user for permission using AskUserQuestion unless it was already given.
 - When output includes warnings or partial results, summarize them and ask how to adjust using `AskUserQuestion`.
 
 ## Reference Guide
@@ -140,10 +138,3 @@ Read the image reference when the delegated task involves image generation, imag
 **File**: `references/image-gen-models-prompting-guide.ipynb`
 
 Use the notebook directly instead of duplicating its per-use-case guidance here.
-
-## Prompt Crafting Workflow
-
-1. **Clarify first**: Use `AskUserQuestion` for ambiguous requests before crafting prompts
-2. **Classify context**: Apply the 2×2 matrix (see Context Classification) — separate pointers from session context, block user-specific collection requests
-3. **Structure the prompt**: Use the Prompt Template sections. Frame tasks as "complete end-to-end", define constraints explicitly
-4. **Execute and iterate**: Use metaprompting (root-cause analysis + surgical refinement) rather than complete rewrites


### PR DESCRIPTION
Four trims to the portable codex skill. None of them change what a run does.

## `--full-auto` is deprecated

Verified against the installed codex CLI **0.145.0**. The flag is hidden from `--help` but still parsed, and using it prints:

```
warning: `--full-auto` is deprecated; use `--sandbox workspace-write` instead.
```

The wrapper's `DEFAULT_SANDBOX` is already `workspace-write`, so the flag had become fully redundant — its only remaining effect was a warning line on **stderr**, which is the same channel the calling Bash subagent scrapes `session id: <uuid>` from.

Removed from the wrapper (option parse, resume `IGNORED` bookkeeping, argv assembly) and from the skill. Where a caller previously reached for it to get unattended edits, the default sandbox already provides them — `codex exec` is headless, so there is no approval step to opt out of and no `--ask-for-approval` to set. That flag exists only on the **interactive** `codex`, not on `codex exec`.

This is the one change here that would otherwise read as cosmetic.

## `gpt-5.5`

Carried as "supplementary model, the prior default". Per the repo Northstar — *external compatibility, legacy, and future-proofing are by-products, not targets* — a superseded default earns no place in a file loaded into every session. `gpt-5.6-sol` and `gpt-5.6-terra` remain.

## Duplicate `-C`-on-resume warning

It appeared in both Running a Task step 6 and the Quick Reference modifiers. The Quick Reference copy is now a bare mention pointing at step 6, which is where a reader actually needs the full explanation.

## `## Prompt Crafting Workflow`

Restated Context Classification, the Prompt Template, and the AskUserQuestion habit a fourth time, adding nothing. Removed. Nothing referenced it by name.

## Deliberately unchanged

The `danger-full-access` Quick Reference line **stays**. In codex, read-only and network isolation are not orthogonal: the network toggle lives in the `sandbox_workspace_write` table and does nothing under `read-only`, so reaching the network costs workspace writes. I checked for an approval-policy escape and there is none in headless mode, so there is no `auto`-mode analogue to route around the conflict.

Also untouched: the Context Classification 2×2 and its Reference-over-Copy boundary, Consult Mode, the Reference Guide navigation, the network `--config` line (`codex-run.sh:162`) and its comment, and the session-id-from-stderr contract.

## Verification

`bash -n` clean; `-h` exits 0 with no `--full-auto` and no `gpt-5.5`; repo-wide grep for both is zero outside `references/`.

Argv assembly checked with a stub `codex` on `PATH`:

```
default                       [exec] [--skip-git-repo-check] [-m] [gpt-5.6-sol] [--config]
                              [model_reasoning_effort=xhigh] [--sandbox] [workspace-write]
                              [--config] [sandbox_workspace_write.network_access=true]
-s read-only                  [exec] [--skip-git-repo-check] [-m] [gpt-5.6-sol] [--config]
                              [model_reasoning_effort=xhigh] [--sandbox] [read-only]
-S <id>                       [exec] [--skip-git-repo-check] [resume] [<id>]
-S <id> -s read-only -m terra [exec] [--skip-git-repo-check] [resume] [<id>]
                              + Warning: resume ignores options: -m gpt-5.6-terra -s read-only
```

The last two arms are the ones that mattered: the resume path's `IGNORED` array is what I edited, and it still both fires with non-default options and stays quiet without them.

Version `2.7.0` → `2.8.0`; version-bump check passes.
