### PR TITLE
feat(skill-review): wrap plugin-dev:skill-reviewer with belonging tests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -98,6 +98,11 @@
       "name": "unfold",
       "source": "./unfold",
       "description": "Linear loop moment router — unfold the whole picture, next unblocked actions, runbook invariants, decision log, and roadmap from Linear; write only structure and decisions, never state"
+    },
+    {
+      "name": "skill-review",
+      "source": "./skill-review",
+      "description": "Skill reviewer — wraps plugin-dev:skill-reviewer for structure and triggering, then applies belonging tests that route each finding to the skill body, references/, the enforcement layer, or the commit message"
     }
   ]
 }

--- a/skill-review/.claude-plugin/plugin.json
+++ b/skill-review/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "skill-review",
+  "description": "Skill reviewer — wraps plugin-dev:skill-reviewer for structure and triggering, then applies belonging tests that route each finding to the skill body, references/, the enforcement layer, or the commit message",
+  "version": "0.1.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/skill-review/skills/skill-review/SKILL.md
+++ b/skill-review/skills/skill-review/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: skill-review
+description: |
+  This skill should be used when the user asks to "review my skill", "review this
+  skill", "check this SKILL.md", "audit a skill", "is this skill too long",
+  "why does this skill keep growing", "스킬 리뷰", "스킬 검토해줘", or wants a
+  SKILL.md checked before opening a PR. Also use after creating or substantially
+  editing a SKILL.md. Wraps the plugin-dev:skill-reviewer agent for structure and
+  triggering, then applies belonging tests that route each finding to the skill
+  body, references/, the enforcement layer, or the commit message.
+---
+
+# Skill Review
+
+Two questions, different owners.
+
+`plugin-dev:skill-reviewer` answers **is this too long, and is it in the right
+file?** — frontmatter, trigger phrases, imperative voice, word count, progressive
+disclosure. For content that does not belong in SKILL.md it has one route:
+`references/`.
+
+This skill answers **does this belong at all?** and supplies the other routes —
+the enforcement layer, the commit message, or out.
+
+A skill bloats for several unrelated reasons at once, and a single word-count
+verdict cannot tell them apart. The tests below separate them.
+
+## Pass 1 — structure (delegate)
+
+Launch the `plugin-dev:skill-reviewer` agent against the target SKILL.md, passing
+an absolute path. It reads only. Keep its report; pass 2 builds on it instead of
+repeating it.
+
+## Pass 2 — belonging
+
+Read the skill body and apply five tests. Each returns a verdict and a route.
+
+| Test | Ask of each passage | Failing content routes to |
+|---|---|---|
+| **Execution relevance** | Does a model *executing* this skill act differently because of it? | commit message |
+| **Ownership** | Is this a fact about this skill's own surface, or another tool's option space? | out |
+| **Channel** | Is it already enforced somewhere read on demand — `--help`, a validator, a schema? | enforcement layer |
+| **Salience** | Does naming a thing in order to forbid it introduce it? | out, or restate as the positive instruction |
+| **Friction** | Does an example make a high-impact path the frictionless one? | trim the example to its safe form |
+
+**Extract before deleting.** Operative clauses hide inside rationale paragraphs; a
+passage that is nine-tenths provenance can still carry the one instruction that
+changes behaviour. Pull that residue out first, then remove what remains.
+
+Worked failures for each test, and the shape of a residue extraction, are in
+`references/belonging.md` — consult it while running this pass.
+
+## Pass 3 — enforcement drift (conditional)
+
+Run this only when the skill ships something that enforces its claims: a wrapper
+script, a validator, a `--help`, a schema. A pure-prose procedure skill has no
+enforcement layer and skips the pass.
+
+The pass compares what the skill claims against what the enforcement layer does,
+established by running it rather than reading it. Procedure: `references/drift.md`.
+
+## Report
+
+Group findings by route rather than by severity — the route is what the user acts
+on.
+
+```
+## Skill Review: <name>
+
+### Structure
+<the agent's findings, condensed — do not restate them in full>
+
+### Belonging
+| Finding | Test | Route |
+|---|---|---|
+| <quote or line ref> | <test name> | keep / references/ / enforcement / commit message / out |
+
+### Drift          (only when pass 3 ran)
+| Claim | Observed | Verdict |
+
+### Net
+<current word count → projected, and the single change with the largest effect>
+```
+
+Give the projected count as an estimate. How much survives depends on how much
+residue extraction preserves, which is not knowable before the edit.
+
+When findings route to the commit message, draft that text too — content moved
+without a destination written for it tends to be lost instead of relocated.
+
+## Additional Resources
+
+- **`references/belonging.md`** — the five tests in depth: what each failure looks
+  like in real skill prose, the residue-extraction procedure, and before/after
+  pairs. Consult while running pass 2.
+- **`references/drift.md`** — pass 3 procedure: verifying claims against an
+  enforcement layer, establishing absence across more than one channel, and
+  demonstrating a guard with a known-fail and known-pass pair. Consult when the
+  skill under review ships a script, validator, or schema.

--- a/skill-review/skills/skill-review/references/belonging.md
+++ b/skill-review/skills/skill-review/references/belonging.md
@@ -1,0 +1,151 @@
+# Belonging tests — worked detail
+
+Depth for pass 2. Each section gives the failure's shape in real skill prose, why
+it costs, and where the content goes.
+
+The five tests are independent. A passage can fail more than one, and the route is
+decided by the first test it fails in the order below — execution relevance is the
+coarsest filter, so run it first.
+
+---
+
+## 1. Execution relevance → commit message
+
+**Ask:** does a model *executing* this skill act differently because of this
+sentence?
+
+A skill is a state surface: it asserts what to do now. Rationale, provenance,
+epistemic status, and rejected alternatives are then-records — they explain how the
+skill came to say what it says. Both are worth keeping; only one is worth loading
+into every session that touches the skill.
+
+Failure shapes, all common:
+
+- **Mechanism stories.** Two paragraphs explaining why a guard exists and how it is
+  implemented, when the executing model only needs to know that a certain call is
+  unavailable and what to do instead.
+- **Epistemic annotations.** "Verified 2026-07", "this is inference, not
+  measurement", "unconfirmed against the live endpoint". Real and worth recording,
+  but no action follows from reading them.
+- **Provenance links.** The vendor doc URL that justified a default value.
+- **Design-decision notes.** "Corrected here in prose rather than by editing the
+  script, because …" — addressed to a maintainer, not to the running model.
+- **Reassurance.** "Reading this file cannot destabilize the run." Nothing to do.
+- **Reviewer-directed material.** An "unverified — read before merging" list belongs
+  in the pull request, which is where a reviewer is standing.
+
+Route the content to the commit message body, and write that text as part of the
+review rather than leaving it as an instruction to write it later.
+
+### The residue-extraction procedure
+
+Never delete a paragraph wholesale. Operative clauses hide inside rationale.
+
+1. Mark every clause that names an action, a threshold, or a condition.
+2. Rewrite those clauses as standalone instructions in the skill.
+3. Move what is left to the commit message.
+4. Re-read the new instruction alone: if it no longer makes sense without the
+   removed context, keep the minimum context as a subordinate clause.
+
+Worked example — before:
+
+> The wrapper streams the event log to a file beside the prompt. Open it to check a
+> long run mid-flight. Expect buffered bursts rather than a smooth tick: the tool
+> block-flushes, so a mid-run read shows accumulated progress arriving in chunks
+> (verified: progress events were present in the file well before the run
+> finished). It is a bystander — it never gates the result path, so reading it
+> cannot destabilize the run, and there is no always-on transform to pay for.
+> Byte-bound it or filter with `jq`; a bare line-based `tail` will not cap it,
+> because one event can be many megabytes.
+
+After — skill keeps:
+
+> The wrapper streams the event log to a file beside the prompt; open it to check a
+> long run mid-flight. Read it byte-bounded or with a `jq` field filter — one event
+> can be many megabytes, so a line-based `tail` will not cap it. Expect progress in
+> buffered chunks rather than a smooth tick.
+
+Commit message takes: the verification note, and the bystander reasoning about why
+reading it is safe.
+
+---
+
+## 2. Ownership → out
+
+**Ask:** is this a fact about this skill's own surface, or about another tool's?
+
+A skill that wraps an external CLI, API, or model tends to accumulate that tool's
+option space: its accepted values, its version differences, its error taxonomy. The
+content is accurate and still does not belong. It drifts on the other tool's
+schedule, and nobody reviewing this skill will notice when it goes stale.
+
+Signals:
+
+- A table of values some other tool accepts, where the skill itself uses two of them.
+- Version notes about the wrapped tool's behaviour changes.
+- Mappings between the wrapped tool's vocabulary and a third party's.
+
+The test is sharper than "is this too detailed", and it catches passages that pass
+every size check. If the fact is not about this skill's own surface, moving it to
+`references/` only relocates the drift — route it out, and let the wrapped tool's
+own documentation carry it.
+
+---
+
+## 3. Channel → enforcement layer
+
+**Ask:** is this already enforced somewhere that is read on demand?
+
+A SKILL.md loads on every turn that touches it. A wrapper's `--help`, a validator's
+error message, and a schema are read only when needed or when something breaks.
+Content that exists in both places is duplication with a delivery schedule, and the
+two copies will eventually disagree — at which point the copy the model reads every
+turn is the wrong one.
+
+When a fact is enforced, the skill should state the working choice, not the full
+accepted set. When it is *not* enforced but should be, that is the finding: propose
+the guard rather than a longer paragraph.
+
+A guard that rejects a bad value converts a silent wrong result into a loud stop.
+That is worth more than any amount of prose warning about the same value, and it
+removes the reason the prose existed.
+
+---
+
+## 4. Salience → out, or restate positively
+
+**Ask:** does naming this thing in order to forbid it introduce it?
+
+A written prohibition puts the prohibited action into every session's context.
+Where the behaviour would not have occurred unprompted, the prohibition is the
+thing that raises it — the instruction creates its own target.
+
+A prohibition earns its place only when the behaviour has an observed nonzero base
+rate: evidence it actually happens. Absent that, prefer the positive statement of
+what to do, which occupies the same space and leaves no residue.
+
+The characteristic failure is an enumeration written to warn against part of
+itself — listing several options in order to say that two of them are traps. Delete
+the enumeration and state the options that are actually chosen. What the reader
+never learns, the reader never reaches for.
+
+Where a prohibition does qualify, keep it and note the evidence in the commit
+message rather than in the skill.
+
+---
+
+## 5. Friction → trim the example
+
+**Ask:** does an example make a high-impact path the frictionless one?
+
+Examples get copied. A complete, ready-to-run command line for a destructive or
+high-privilege operation lowers the cost of exactly the action the skill elsewhere
+gates. The gate has to be read to work; the command only has to be seen.
+
+This is not an argument for removing every mention of the dangerous mode — a caller
+who deliberately needs it should still find it documented in the options list. It is
+an argument against pre-assembling it.
+
+Same reasoning, smaller stakes: an example that passes a flag already set by
+default. It teaches a habit that does nothing and grows every example that copies
+it.

--- a/skill-review/skills/skill-review/references/drift.md
+++ b/skill-review/skills/skill-review/references/drift.md
@@ -1,0 +1,98 @@
+# Enforcement drift — pass 3
+
+Run this pass when the skill under review ships something that enforces its claims:
+a wrapper script, a validator, a `--help`, a JSON schema, a config template. A
+pure-prose procedure skill has no enforcement layer; skip the pass and say so in
+the report rather than leaving the section blank.
+
+The pass answers one question per claim: **does the enforcement layer actually do
+what the skill says it does?**
+
+---
+
+## Establish by running, not by reading
+
+Read the script to find candidate claims. Confirm them by executing it. A claim
+confirmed by reading is a claim about the reader's understanding of the code.
+
+Inventory the skill's checkable assertions first — default values, accepted inputs,
+what a flag does, what the output contains, what gets rejected. Then exercise each
+one. Most can be checked without a live API call: usage output, argument parsing,
+and pre-flight validation all run before any network work.
+
+Where a real invocation is unavoidable, a stub on `PATH` that prints the arguments
+and environment it received, then exits, reveals what the wrapper actually hands
+off. That reads the handoff boundary — which is the thing in question — without
+paying for the downstream call.
+
+---
+
+## Absence needs more than one channel
+
+Presence is proved by one hit. Absence is not disproved by one miss, and this
+asymmetry is the pass's most reliable source of wrong conclusions.
+
+Two failure shapes worth checking for directly:
+
+- **A value assigned outside the pattern searched.** A variable exported inside a
+  conditional or `case` block does not match a search anchored to the start of a
+  line. The variable is set; the search says it is not.
+- **An option omitted from generated help.** A deprecated flag can remain fully
+  functional while no longer appearing in `--help`. The help text says it is gone;
+  the parser still accepts it, often with a warning that lands in whatever channel
+  the caller is scraping for something else.
+
+Before concluding that something is absent, calibrate the check with an input known
+to be absent. If a deliberately invented flag name produces the same result as the
+flag under test, the check cannot distinguish them and proves nothing about either.
+
+A short-circuiting argument defeats this too: `--help` is commonly processed before
+argument validation, so pairing an unknown flag with `--help` may exit cleanly and
+say nothing about whether the flag is recognised.
+
+---
+
+## A guard needs a known-fail and a known-pass
+
+A check that only ever passes is indistinguishable from a check that is not wired
+up. Demonstrating a guard requires both arms:
+
+- **Known-fail** — an input the guard should reject. Confirm it is rejected, and
+  confirm the rejection names the guard's own reason rather than some later error.
+- **Known-pass** — an input the guard should admit. Confirm it clears the guard.
+  The proof that it cleared is that execution reaches a *different* failure or
+  succeeds; a pass arm that fails for the same reason as the fail arm has shown
+  nothing.
+
+Choose the fail arm to discriminate. When a guard has been narrowed, the arm that
+demonstrates the narrowing is an input that was previously valid — not one that was
+always invalid, which would have been rejected before the change too.
+
+---
+
+## Check the skill's own verification claims for staleness
+
+Skills and their pull requests often carry a table of checks that were run. Those
+tables are written once and rarely revisited, so they record the enforcement
+layer as it was at the time of writing.
+
+Re-run the table rather than trusting it. A stale row is worse than a missing one:
+a reader who reproduces it sees a mismatch and cannot tell whether the skill, the
+tool, or their own environment is wrong. Common stale entries are counted output
+("prints an N-line usage"), enumerated accepted values, and error message text —
+each of which changes whenever the enforcement layer is edited.
+
+Report each as `Claim | Observed | Verdict`, and route a stale claim to whichever
+surface owns it: the skill body, or the pull request that carries the table.
+
+---
+
+## What this pass does not do
+
+It does not judge whether the enforcement layer is well designed, and it does not
+propose refactors. Its output is limited to agreement and disagreement between two
+surfaces that are supposed to say the same thing.
+
+One exception is worth raising when it appears: a claim the skill states in prose
+that *could* be enforced but is not. That finding belongs to the channel test in
+pass 2 — propose the guard, because a guard removes the paragraph.


### PR DESCRIPTION
Draft. First version of a `/skill-review` skill — expect iteration.

## What it adds over the agent it wraps

`plugin-dev:skill-reviewer` already reviews structure, frontmatter, trigger
phrases, imperative voice, word count, and progressive-disclosure placement. Its
axis is **size and placement**, and for content that does not belong in SKILL.md
it has exactly one route: `references/`.

This skill delegates that pass to the agent and spends its own words on the
orthogonal question — **does this belong at all?** — supplying the routes the
agent does not have: the enforcement layer, the commit message, or out.

That division is the design decision worth questioning. The alternative was to
fork the agent's checklist and extend it, which would have duplicated a
third-party file that moves on its own schedule — the ownership failure this skill
itself tests for.

## The five belonging tests

| Test | Ask | Route on failure |
|---|---|---|
| Execution relevance | Does a model *executing* this skill act differently because of this sentence? | commit message |
| Ownership | Is this a fact about this skill's surface, or another tool's option space? | out |
| Channel | Is it already enforced somewhere read on demand (`--help`, validator, schema)? | enforcement layer |
| Salience | Does naming this in order to forbid it introduce it? | out, or the positive statement |
| Friction | Does an example make a high-impact path the frictionless one? | trim the example |

## Structure

```
skill-review/
  .claude-plugin/plugin.json
  skills/skill-review/
    SKILL.md                    688 words   — always-applicable core
    references/belonging.md    1160 words   — depth behind the five tests
    references/drift.md         775 words   — conditional pass (enforcement layer)
```

Progressive disclosure follows what actually branches: **whether the skill under
review ships an enforcement layer**. A pure-prose procedure skill has no script or
validator, so the drift pass does not apply to it and does not belong in the core.

## Where this draft falls short

Checked against its own criteria, honestly:

- **Ownership, self-inflicted.** SKILL.md itemises what `skill-reviewer` covers
  ("frontmatter, trigger phrases, imperative voice, word count, progressive
  disclosure"). That is another tool's surface recited here — the exact failure
  test 2 describes. It could reduce to "structure and triggering". Kept for now
  because the division of labour is the design idea and a reader needs to see
  which question is delegated; it is the first thing to cut on the next pass.
- **Execution relevance, one weak line.** "A skill bloats for several unrelated
  reasons at once, and a single word-count verdict cannot tell them apart" is
  closer to justification than instruction. It survives on the argument that it
  tells the reviewer the tests are non-overlapping and each must be applied.
- **Below the wrapped agent's own floor.** `skill-reviewer` wants a 1,000–3,000
  word body; this one is 688. Running the agent on this skill will flag that
  immediately. My read is that the floor assumes a skill carrying its own bulk,
  and 1,935 words sit in `references/` by design — but the tension is real and
  worth a decision rather than a silent exception.
- **Never executed.** The drift pass prescribes establishing claims by running
  rather than reading, and this skill has not itself been run against a real
  target. That is the largest gap in the draft. The obvious first target is one of
  the skills from the session that produced these tests.

## Origin

Distilled from a session porting a wrapper skill across two repos, where the
document re-bloated four times — each time passing the previous cleanup's
criterion and failing a new one. Trimming by size caught none of them. The drift
reference also records two ways a single-channel search wrongly concludes absence
(a value assigned inside a `case` block; a deprecated flag omitted from `--help`
but still parsed), both of which produced wrong conclusions before a calibrated
check settled them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
