### PR TITLE
feat(agent-device-preflight): attachment-prerequisite preflight plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -102,7 +102,7 @@
     {
       "name": "agent-device-preflight",
       "source": "./agent-device-preflight",
-      "description": "Resolve agent-device attachment prerequisites before `open` — signing team from the certificate OU, developer disk image mount, macOS DevToolsSecurity, stale daemon environment, and physical-vs-virtual device selection"
+      "description": "Resolve agent-device attachment prerequisites before `open` — device lock state, signing team from the certificate OU, developer-account device registration, developer disk image mount, macOS DevToolsSecurity, stale runner cache and daemon environment, and physical-vs-virtual device selection"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -98,6 +98,11 @@
       "name": "unfold",
       "source": "./unfold",
       "description": "Linear loop moment router — unfold the whole picture, next unblocked actions, runbook invariants, decision log, and roadmap from Linear; write only structure and decisions, never state"
+    },
+    {
+      "name": "agent-device-preflight",
+      "source": "./agent-device-preflight",
+      "description": "Resolve agent-device attachment prerequisites before `open` — signing team from the certificate OU, developer disk image mount, macOS DevToolsSecurity, stale daemon environment, and physical-vs-virtual device selection"
     }
   ]
 }

--- a/agent-device-preflight/.claude-plugin/plugin.json
+++ b/agent-device-preflight/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device-preflight",
   "description": "Preflight the local environment before agent-device attaches to a device: lock-state check, signing team derivation, device registration, DDI mount, DevToolsSecurity, runner cache and daemon env staleness, device selector resolution",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/agent-device-preflight/.claude-plugin/plugin.json
+++ b/agent-device-preflight/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device-preflight",
   "description": "Preflight the local environment before agent-device attaches to a device: lock-state check, signing team derivation, device registration, DDI mount, DevToolsSecurity, runner cache and daemon env staleness, device selector resolution",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/agent-device-preflight/.claude-plugin/plugin.json
+++ b/agent-device-preflight/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device-preflight",
   "description": "Preflight the local environment before agent-device attaches to a device: lock-state check, signing team derivation, device registration, DDI mount, DevToolsSecurity, runner cache and daemon env staleness, device selector resolution",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/agent-device-preflight/.claude-plugin/plugin.json
+++ b/agent-device-preflight/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "agent-device-preflight",
+  "description": "Preflight the local environment before agent-device attaches to a device: signing team derivation, DDI mount, DevToolsSecurity, daemon env freshness, device selector resolution",
+  "version": "0.1.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/agent-device-preflight/.claude-plugin/plugin.json
+++ b/agent-device-preflight/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device-preflight",
   "description": "Preflight the local environment before agent-device attaches to a device: lock-state check, signing team derivation, device registration, DDI mount, DevToolsSecurity, runner cache and daemon env staleness, device selector resolution",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/agent-device-preflight/.claude-plugin/plugin.json
+++ b/agent-device-preflight/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device-preflight",
   "description": "Preflight the local environment before agent-device attaches to a device: signing team derivation, DDI mount, DevToolsSecurity, daemon env freshness, device selector resolution",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/agent-device-preflight/.claude-plugin/plugin.json
+++ b/agent-device-preflight/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device-preflight",
-  "description": "Preflight the local environment before agent-device attaches to a device: signing team derivation, DDI mount, DevToolsSecurity, daemon env freshness, device selector resolution",
-  "version": "0.2.0",
+  "description": "Preflight the local environment before agent-device attaches to a device: lock-state check, signing team derivation, device registration, DDI mount, DevToolsSecurity, runner cache and daemon env staleness, device selector resolution",
+  "version": "0.3.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/agent-device-preflight/.claude-plugin/plugin.json
+++ b/agent-device-preflight/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device-preflight",
   "description": "Preflight the local environment before agent-device attaches to a device: lock-state check, signing team derivation, device registration, DDI mount, DevToolsSecurity, runner cache and daemon env staleness, device selector resolution",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/agent-device-preflight/.claude-plugin/plugin.json
+++ b/agent-device-preflight/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device-preflight",
   "description": "Preflight the local environment before agent-device attaches to a device: lock-state check, signing team derivation, device registration, DDI mount, DevToolsSecurity, runner cache and daemon env staleness, device selector resolution",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/agent-device-preflight/skills/agent-device-preflight/SKILL.md
+++ b/agent-device-preflight/skills/agent-device-preflight/SKILL.md
@@ -253,9 +253,11 @@ Two things to expect:
   still succeeded**; re-run the coverage query rather than re-reading the exit code.
 - With a concrete destination xcodebuild states the real problem plainly
   (`Device "X" isn't registered in your developer account`). That diagnostic never appears
-  through agent-device's generic-destination build. To get it *without* registering anything,
-  run the same command with `-allowProvisioningDeviceRegistration` removed —
-  `-allowProvisioningUpdates` alone does not register devices, so the diagnostic is free.
+  through agent-device's generic-destination build. To get it without spending a device slot,
+  run the same command with `-allowProvisioningDeviceRegistration` removed. That is cheaper,
+  not free: `-allowProvisioningUpdates` still creates and updates profiles, App IDs, and
+  certificates in the account, exactly as stated above. It stays under the same ask-first
+  gate — only the irreversible device slot is off the table.
 
 ### 7. Runner build cache is not device-aware
 
@@ -279,13 +281,22 @@ with**. Exporting a corrected `AGENT_DEVICE_IOS_TEAM_ID` into your shell does no
 already-running daemon: it keeps building with the stale value, and the identical error
 repeats as if the fix had not been applied.
 
-Confirm what the daemon actually used — the build command line is echoed in the runner log:
+Confirm what the daemon actually used. `agent-device` passes both the team and the runner
+bundle id to `xcodebuild` as build settings, and that command line is echoed in the runner log,
+so check for both — a daemon carrying the right team and a stale bundle id passes a team-only
+check and still builds the wrong runner:
 
 ```bash
-grep -o 'DEVELOPMENT_TEAM=[A-Z0-9]*' ~/.agent-device/sessions/<session>/runner.log | tail -1
+grep -oE '(DEVELOPMENT_TEAM|AGENT_DEVICE_IOS_RUNNER_APP_BUNDLE_ID)=[^ ]+' \
+  ~/.agent-device/sessions/<session>/runner.log | sort -u
 ```
 
-If it disagrees with your shell, restart the daemon:
+Two lines that both match your shell mean the daemon is current. **Anything else — one line,
+no lines, no log yet, or a value you do not recognise — means restart, not proceed.** A setting
+the daemon never received leaves nothing in the log to disagree with, so an empty result is the
+one outcome that reads like a pass and is not.
+
+To restart the daemon:
 
 ```bash
 agent-device daemon stop   # there is no `daemon start`; the next command respawns it

--- a/agent-device-preflight/skills/agent-device-preflight/SKILL.md
+++ b/agent-device-preflight/skills/agent-device-preflight/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: agent-device-preflight
+description: |
+  This skill should be used when the user asks to "connect my phone to agent-device",
+  "attach a device", "why can't agent-device see my iPhone", "agent-device doctor passes
+  but open fails", "developer disk image could not be mounted", "No Account for Team",
+  "xcodebuild build-for-testing failed", or is setting up agent-device against a physical
+  iOS device for the first time. Resolves the environment prerequisites that must hold
+  before `agent-device open` can attach; hands command-level work back to the CLI.
+  Pass the user's request verbatim — this skill reads a free-form request, not a subcommand.
+user_invocable: true
+context: fork
+model: sonnet
+---
+
+# agent-device Preflight
+
+Bring the local environment to the state `agent-device` needs, then get out of the way.
+
+## Scope Guard
+
+This skill covers **attachment prerequisites only** — the one-time environment setup that
+must hold before `agent-device open` can reach a device.
+
+It deliberately holds **no command knowledge**. Upstream ships its own router skill
+(`skills/agent-device/SKILL.md` in `callstack/agent-device`) whose stated position is
+"ask the CLI, don't hardcode": it gates on `agent-device >= 0.20.0` and delegates to
+`agent-device help <topic>`. Once preflight passes, defer there. Do not duplicate the
+command surface here — it moves faster than any static copy.
+
+Two reasons this layer exists rather than being covered by what already ships:
+
+- `agent-device doctor` does not check any of items 3–6 below. It passed clean on a
+  machine where `open` then failed three times in a row.
+- The MCP server does not expose the connection surface at all — `connect`, `disconnect`,
+  `connection`, `daemon`, `device`, `cdp`, `auth`, `proxy`, `react-devtools`, and `web`
+  are all `mcpExposed: false`. An MCP client cannot drive attachment; a shell must.
+
+## Preflight
+
+Run in order. Each check is read-only except where marked.
+
+### 1. CLI present and recent enough
+
+```bash
+agent-device --version   # must be >= 0.20.0
+```
+
+Not installed → `npm install -g agent-device@latest`. Requires Node 22.12+ (24+ for web).
+
+### 2. Device visible, and the selector you will actually pass
+
+```bash
+xcrun devicectl list devices
+```
+
+The default table shows an **Identifier** column. That is *not* what `--udid` takes.
+`agent-device` builds a device's id as `hardwareProperties.udid ?? identifier`
+(`packages/kernel/src/device.ts:238`), so on any device that reports a hardware UDID the
+selector is the UDID, not the Identifier shown on screen. Derive it:
+
+```bash
+xcrun devicectl list devices --json-output /tmp/dev.json >/dev/null
+python3 -c "
+import json
+for d in json.load(open('/tmp/dev.json'))['result']['devices']:
+    p, h = d['deviceProperties'], d['hardwareProperties']
+    c = d['connectionProperties']
+    print(p.get('name'), h.get('udid'), '| transport:', c.get('transportType'),
+          '| tunnel:', c.get('tunnelState'), '| devMode:', p.get('developerModeStatus'))
+"
+```
+
+**Always pass `--udid`.** Device resolution prefers *virtual* devices over physical ones
+(`packages/kernel/src/device.ts:240-298`), so on a machine with simulators installed a
+bare `--platform ios` silently targets a simulator instead of the phone.
+
+Also confirm from that output: `developerModeStatus: enabled` (enable on the device under
+Settings → Privacy & Security → Developer Mode) and a live `transportType`. Connect by
+cable for first setup — the alternative runner transport
+(`AGENT_DEVICE_IOS_RUNNER_ROUTE=usbmux`) is cable-only, and a locked phone wedges either
+transport. Keep the screen unlocked for the whole run.
+
+### 3. Developer disk image mounts
+
+```bash
+xcrun devicectl device info details --device <udid>
+```
+
+Success prints device details. Failure prints
+`The developer disk image could not be mounted on this device. (com.apple.dt.CoreDeviceError error 12040)`
+and nothing downstream will work — not `open`, not the runner install.
+
+If it fails while pairing, Developer Mode, cable, and network to Apple are all healthy:
+**open Xcode → Window → Devices and Simulators and select the device.** That window drives
+the device-preparation flow. (Observed: three consecutive CLI-only attempts failed, and the
+next attempt after selecting the device in Xcode succeeded. Asynchronous completion in the
+interval was not controlled for, so treat this as an effective step rather than an
+established mechanism.)
+
+Do **not** jump to "Xcode is too old for this iOS version" without evidence. The DDI's
+`ProductBuildVersion` is Xcode's own build number, not an iOS build number — the two are
+not on a comparable scale, and a version-mismatch reading built on comparing them is
+unfounded. Xcode 26.2 drove an iOS 26.5.2 device successfully.
+
+### 4. macOS developer tools authorized (undocumented upstream)
+
+```bash
+DevToolsSecurity -status        # read-only
+sudo DevToolsSecurity -enable   # WRITES: persistent system setting, needs the user's password
+```
+
+UI test runners start suspended until `testmanagerd` attaches. With this disabled the
+runner never wakes and `snapshot` fails with
+`Developer mode is disabled for Apple development tools`.
+
+This requirement appears **nowhere** in the upstream README or `website/docs/`, though the
+code checks it proactively (`src/platforms/apple/core/runner/runner-session.ts:620`).
+
+The `sudo` line changes machine state and requires a password — **ask the user to run it
+themselves; never run it unattended.** Reverse with `sudo DevToolsSecurity -disable`.
+
+### 5. Signing team ID — read the certificate's `OU`, not its `CN`
+
+```bash
+security find-identity -v -p codesigning
+security find-certificate -c "<identity CN>" -p | openssl x509 -noout -subject
+```
+
+The subject looks like:
+
+```
+UID=..., CN=Apple Development: Some Name (AAAAAAAAAA), OU=BBBBBBBBBB, O=..., C=US
+```
+
+`AAAAAAAAAA` in the `CN` parenthetical is the developer's individual id. **The team id is
+`OU`.** Passing the parenthetical yields
+`error: No Account for Team "AAAAAAAAAA"` plus `No profiles for 'com.callstack.agentdevice.runner' were found`,
+which reads like a provisioning problem and is not one.
+
+```bash
+export AGENT_DEVICE_IOS_TEAM_ID=<the OU value>
+```
+
+Cross-check against an installed profile, which also tells you whether the target device is
+already registered:
+
+```bash
+security cms -D -i ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*.mobileprovision \
+  > /tmp/prof.plist 2>/dev/null
+python3 -c "
+import plistlib
+d = plistlib.load(open('/tmp/prof.plist','rb'))
+print('TeamName:', d.get('TeamName'), '| TeamID:', d.get('TeamIdentifier'))
+print('AppIDName:', d.get('AppIDName'), '| expires:', d.get('ExpirationDate'))
+print('devices:', d.get('ProvisionedDevices'))
+"
+```
+
+A wildcard App ID with a ~1-year expiry indicates a paid account. A free Personal Team gets
+7-day profiles and no wildcard — there, set `AGENT_DEVICE_IOS_BUNDLE_ID` to a unique
+reverse-DNS value or the build fails with "bundle identifier is not available".
+
+### 6. Daemon environment freshness
+
+The daemon starts lazily on the first command and **captures the environment it was spawned
+with**. Exporting a corrected `AGENT_DEVICE_IOS_TEAM_ID` into your shell does nothing for an
+already-running daemon: it keeps building with the stale value, and the identical error
+repeats as if the fix had not been applied.
+
+Confirm what the daemon actually used — the build command line is echoed in the runner log:
+
+```bash
+grep -o 'DEVELOPMENT_TEAM=[A-Z0-9]*' ~/.agent-device/sessions/<session>/runner.log | tail -1
+```
+
+If it disagrees with your shell, restart the daemon:
+
+```bash
+agent-device daemon stop   # there is no `daemon start`; the next command respawns it
+```
+
+Same trap for every other `AGENT_DEVICE_*` variable.
+
+## Sandbox
+
+The daemon binds to localhost and fails with `listen EPERM` inside a sandbox. Any
+agent shell that sandboxes command execution must run agent-device work unsandboxed —
+including `doctor`, since it starts the daemon too.
+
+## Verify
+
+```bash
+export AGENT_DEVICE_IOS_TEAM_ID=<OU value>
+agent-device doctor --platform ios --udid <udid>
+agent-device open com.apple.Preferences --platform ios --udid <udid> --session preflight
+agent-device snapshot -i --session preflight
+agent-device close --session preflight
+```
+
+A first snapshot taking 20–30s is normal; the CLI warns about it itself. The first physical
+run builds and installs a signed XCTest runner
+(`AgentDeviceRunnerUITests-Runner`, bundle id `com.callstack.agentdevice.runner.uitests.xctrunner`)
+onto the device — tell the user before it happens, and note that removing it is a home-screen
+delete.
+
+Once this passes, hand off: `agent-device help workflow`.
+
+## Failure → cause
+
+| Symptom | Cause | Section |
+|---|---|---|
+| `CoreDeviceError 12040`, DDI could not be mounted | device preparation not driven | 3 |
+| `Developer mode is disabled for Apple development tools` | macOS `DevToolsSecurity` off | 4 |
+| `No Account for Team "..."` / `No profiles for ...were found` | team id read from `CN` instead of `OU` | 5 |
+| Same signing error after correcting the team id | daemon holding stale env | 6 |
+| Commands land on a simulator instead of the phone | `--udid` omitted; virtual devices win resolution | 2 |
+| `listen EPERM` | daemon started inside a sandbox | Sandbox |
+| `doctor` passes but `open` fails | `doctor` does not cover 3–6 | — |
+
+## Scope not covered
+
+Android (`--test-ime` on real hardware, snapshot-helper APK auto-install, `adb reverse` for
+Metro), web, the remote/cloud lease providers, `proxy`, and the degraded legacy-XCTest tier
+for older iPhones are all outside this preflight. Verified against physical iOS
+(CoreDevice tier) and the iOS simulator only.

--- a/agent-device-preflight/skills/agent-device-preflight/SKILL.md
+++ b/agent-device-preflight/skills/agent-device-preflight/SKILL.md
@@ -2,8 +2,9 @@
 name: agent-device-preflight
 description: |
   This skill should be used when the user asks to "connect my phone to agent-device",
-  "attach a device", "why can't agent-device see my iPhone", "agent-device doctor passes
-  but open fails", "developer disk image could not be mounted", "No Account for Team",
+  "attach a device", "why can't agent-device see my iPhone/iPad", "agent-device doctor
+  passes but open fails", "developer disk image could not be mounted", "No Account for
+  Team", "this provisioning profile cannot be installed on this device",
   "xcodebuild build-for-testing failed", or is setting up agent-device against a physical
   iOS device for the first time. Resolves the environment prerequisites that must hold
   before `agent-device open` can attach; hands command-level work back to the CLI.
@@ -28,13 +29,37 @@ It deliberately holds **no command knowledge**. Upstream ships its own router sk
 `agent-device help <topic>`. Once preflight passes, defer there. Do not duplicate the
 command surface here — it moves faster than any static copy.
 
-Two reasons this layer exists rather than being covered by what already ships:
+Three reasons this layer exists rather than being covered by what already ships:
 
-- `agent-device doctor` does not check any of items 3–6 below. It passed clean on a
-  machine where `open` then failed three times in a row.
+- `agent-device doctor` does not check items 3–7 below. It reported
+  `Doctor: pass` / `No blockers found` on two separate devices that could not in fact be
+  driven — once with Developer Mode disabled, once with the device absent from every
+  provisioning profile.
 - The MCP server does not expose the connection surface at all — `connect`, `disconnect`,
   `connection`, `daemon`, `device`, `cdp`, `auth`, `proxy`, `react-devtools`, and `web`
   are all `mcpExposed: false`. An MCP client cannot drive attachment; a shell must.
+- One failure in this set is reported with an actively misleading hint (see
+  **Reading failures** below). Following it wastes the session.
+
+## Reading failures
+
+Two rules before acting on any runner failure.
+
+**Read `runner.log`, not just the hint.** On a signing/install failure the released CLI
+can surface `The current screen is overwhelming the iOS accessibility capture (usually
+heavy or animating content)` and suggest changing screens. Observed: that hint appeared
+for a pure code-signing install failure; the screen was never the problem, and the exact
+same screen captured 49 nodes once signing was fixed. The real cause was in
+`~/.agent-device/sessions/<session>/runner.log`. Upstream has already corrected this on
+`main` — `runner-recycle-ledger.ts` now carries "a provisioning or code-signing error
+there means the runner cannot install on this device, and no retry will help", with a
+comment noting the old wording "sent people to change screens when the runner had in fact
+failed to install" — but the fix is not in the published 0.20.3.
+
+**A matching `version` field does not mean matching code.** `package.json` keeps the last
+released version until the next bump, so a `main` checkout and an installed npm build can
+both read `0.20.3` and differ. Verify behaviour against the installed
+`dist/`, not the repository, when the two could disagree.
 
 ## Preflight
 
@@ -66,19 +91,23 @@ import json
 for d in json.load(open('/tmp/dev.json'))['result']['devices']:
     p, h = d['deviceProperties'], d['hardwareProperties']
     c = d['connectionProperties']
-    print(p.get('name'), h.get('udid'), '| transport:', c.get('transportType'),
-          '| tunnel:', c.get('tunnelState'), '| devMode:', p.get('developerModeStatus'))
+    print(p.get('name'), h.get('udid'), '|', h.get('marketingName'),
+          '| transport:', c.get('transportType'), '| tunnel:', c.get('tunnelState'),
+          '| devMode:', p.get('developerModeStatus'))
 "
 ```
 
 **Always pass `--udid`.** Device resolution prefers *virtual* devices over physical ones
 (`packages/kernel/src/device.ts:240-298`), so on a machine with simulators installed a
-bare `--platform ios` silently targets a simulator instead of the phone.
+bare `--platform ios` silently targets a simulator instead of the real device. iPads
+resolve as `target=mobile`, same as iPhones.
 
-Also confirm from that output: `developerModeStatus: enabled` (enable on the device under
-Settings → Privacy & Security → Developer Mode) and a live `transportType`. Connect by
-cable for first setup — the alternative runner transport
-(`AGENT_DEVICE_IOS_RUNNER_ROUTE=usbmux`) is cable-only, and a locked phone wedges either
+Confirm `developerModeStatus: enabled` — **`doctor` does not check this**, and will report
+no blockers on a device with it disabled. Enable on the device: Settings → Privacy &
+Security → Developer Mode. The device reboots and asks once more after unlock.
+
+Connect by cable for first setup — the alternative runner transport
+(`AGENT_DEVICE_IOS_RUNNER_ROUTE=usbmux`) is cable-only, and a locked device wedges either
 transport. Keep the screen unlocked for the whole run.
 
 ### 3. Developer disk image mounts
@@ -96,12 +125,12 @@ If it fails while pairing, Developer Mode, cable, and network to Apple are all h
 the device-preparation flow. (Observed: three consecutive CLI-only attempts failed, and the
 next attempt after selecting the device in Xcode succeeded. Asynchronous completion in the
 interval was not controlled for, so treat this as an effective step rather than an
-established mechanism.)
+established mechanism. A second device connected by cable from the start never hit this.)
 
 Do **not** jump to "Xcode is too old for this iOS version" without evidence. The DDI's
 `ProductBuildVersion` is Xcode's own build number, not an iOS build number — the two are
 not on a comparable scale, and a version-mismatch reading built on comparing them is
-unfounded. Xcode 26.2 drove an iOS 26.5.2 device successfully.
+unfounded. Xcode 26.2 drove iOS 26.5.2 and iPadOS 26.5 devices successfully.
 
 ### 4. macOS developer tools authorized (undocumented upstream)
 
@@ -142,26 +171,92 @@ which reads like a provisioning problem and is not one.
 export AGENT_DEVICE_IOS_TEAM_ID=<the OU value>
 ```
 
-Cross-check against an installed profile, which also tells you whether the target device is
-already registered:
+Do not infer "no Apple account is signed in" from
+`defaults read com.apple.dt.Xcode IDEProvisioningTeams` returning *does not exist* —
+Xcode 26 does not populate that legacy key even with an account present. Check
+Xcode → Settings → Accounts instead.
+
+### 6. Target device is covered by a provisioning profile
+
+**agent-device will not register a device for you.** It builds the runner with
+`-destination generic/platform=iOS` — no target device — so automatic signing has nothing
+to register, silently picks whatever profile exists, and the mismatch does not surface
+until install:
+
+```
+Failed to install embedded profile for com.callstack.agentdevice.runner.uitests.xctrunner
+: 0xe8008012 (This provisioning profile cannot be installed on this device.)
+```
+
+Check before running anything:
 
 ```bash
-security cms -D -i ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*.mobileprovision \
-  > /tmp/prof.plist 2>/dev/null
+UDID=<target udid>
+for f in ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*.mobileprovision; do
+  security cms -D -i "$f" > /tmp/p.plist 2>/dev/null && python3 -c "
+import plistlib
+d = plistlib.load(open('/tmp/p.plist','rb'))
+devs = d.get('ProvisionedDevices') or []
+print(d.get('Name'), '| devices:', len(devs), '| covers target:', '$UDID' in devs)
+"
+done
+```
+
+If nothing covers it, register from the CLI — a **concrete** destination plus both
+provisioning flags. `-allowProvisioningUpdates` alone is not enough; it creates and
+updates profiles but does not register devices:
+
+```bash
+xcodebuild build-for-testing \
+  -project "$(npm root -g)/agent-device/dist/apple/runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj" \
+  -scheme AgentDeviceRunner \
+  -destination "platform=iOS,id=$UDID" \
+  -derivedDataPath /tmp/ad-register-dd \
+  -allowProvisioningUpdates -allowProvisioningDeviceRegistration \
+  CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=<OU value>
+```
+
+**This writes to the Apple Developer account** — it consumes one of the 100 annual device
+slots for that device type, and registrations are not freely removable until membership
+renewal. Tell the user before running it.
+
+Two things to expect:
+
+- The build may end with
+  `error: Build input file cannot be found: '...<uuid>.mobileprovision'`. That is a race —
+  the newly issued profile replaced the one the build had already resolved. **Registration
+  still succeeded**; re-check the profile as above rather than re-reading the exit code.
+- With a concrete destination xcodebuild states the real problem plainly
+  (`Device "X" isn't registered in your developer account`). That diagnostic never appears
+  through agent-device's generic-destination build. Use this command as a diagnostic even
+  when you do not intend to register.
+
+### 7. Runner build cache is not device-aware
+
+The derived-data cache key covers the team id but **not the target device or the profile
+identity**, so a runner signed against one device's profile is reused verbatim for another.
+After fixing anything signing-related — team id, device registration, profile refresh —
+clear the cache or the old artifact is silently reused:
+
+```bash
+ls ~/.agent-device/apple-runner/derived/ios-device/          # cache-<hash> dirs
+mv ~/.agent-device/apple-runner/derived/ios-device/cache-<hash> /tmp/   # reversible
+```
+
+Confirm what a built runner is actually signed for:
+
+```bash
+APP=$(find ~/.agent-device/apple-runner/derived/ios-device \
+        -name "AgentDeviceRunnerUITests-Runner.app" -maxdepth 5 | head -1)
+security cms -D -i "$APP/embedded.mobileprovision" > /tmp/emb.plist
 python3 -c "
 import plistlib
-d = plistlib.load(open('/tmp/prof.plist','rb'))
-print('TeamName:', d.get('TeamName'), '| TeamID:', d.get('TeamIdentifier'))
-print('AppIDName:', d.get('AppIDName'), '| expires:', d.get('ExpirationDate'))
-print('devices:', d.get('ProvisionedDevices'))
+d = plistlib.load(open('/tmp/emb.plist','rb'))
+print('UUID:', d.get('UUID'), '| devices:', d.get('ProvisionedDevices'))
 "
 ```
 
-A wildcard App ID with a ~1-year expiry indicates a paid account. A free Personal Team gets
-7-day profiles and no wildcard — there, set `AGENT_DEVICE_IOS_BUNDLE_ID` to a unique
-reverse-DNS value or the build fails with "bundle identifier is not available".
-
-### 6. Daemon environment freshness
+### 8. Daemon environment freshness
 
 The daemon starts lazily on the first command and **captures the environment it was spawned
 with**. Exporting a corrected `AGENT_DEVICE_IOS_TEAM_ID` into your shell does nothing for an
@@ -198,11 +293,14 @@ agent-device snapshot -i --session preflight
 agent-device close --session preflight
 ```
 
+`doctor` passing proves less than it looks — it does not cover items 3–7. The snapshot is
+the real gate.
+
 A first snapshot taking 20–30s is normal; the CLI warns about it itself. The first physical
 run builds and installs a signed XCTest runner
 (`AgentDeviceRunnerUITests-Runner`, bundle id `com.callstack.agentdevice.runner.uitests.xctrunner`)
-onto the device — tell the user before it happens, and note that removing it is a home-screen
-delete.
+onto the device — tell the user before it happens, and note that removing it is a
+home-screen delete.
 
 Once this passes, hand off: `agent-device help workflow`.
 
@@ -213,14 +311,19 @@ Once this passes, hand off: `agent-device help workflow`.
 | `CoreDeviceError 12040`, DDI could not be mounted | device preparation not driven | 3 |
 | `Developer mode is disabled for Apple development tools` | macOS `DevToolsSecurity` off | 4 |
 | `No Account for Team "..."` / `No profiles for ...were found` | team id read from `CN` instead of `OU` | 5 |
-| Same signing error after correcting the team id | daemon holding stale env | 6 |
-| Commands land on a simulator instead of the phone | `--udid` omitted; virtual devices win resolution | 2 |
+| `0xe8008012 This provisioning profile cannot be installed on this device` | target device not in any profile | 6 |
+| Hint blames a heavy or animating screen | misleading in 0.20.3 — read `runner.log`; usually 6 | Reading failures |
+| Signing fix applied but the same error repeats | stale runner cache, or daemon holding stale env | 7, 8 |
+| Commands land on a simulator instead of the real device | `--udid` omitted; virtual devices win resolution | 2 |
 | `listen EPERM` | daemon started inside a sandbox | Sandbox |
-| `doctor` passes but `open` fails | `doctor` does not cover 3–6 | — |
+| `doctor` passes but `open`/`snapshot` fails | `doctor` does not cover 3–7 | — |
 
 ## Scope not covered
 
 Android (`--test-ime` on real hardware, snapshot-helper APK auto-install, `adb reverse` for
 Metro), web, the remote/cloud lease providers, `proxy`, and the degraded legacy-XCTest tier
-for older iPhones are all outside this preflight. Verified against physical iOS
-(CoreDevice tier) and the iOS simulator only.
+for older devices are all outside this preflight.
+
+Verified end to end (open → snapshot → press → screenshot → close) against a physical
+iPhone and a physical iPad, both CoreDevice tier, plus the iOS simulator. iPad split-view
+captures correctly, sidebar and detail pane both present in the accessibility tree.

--- a/agent-device-preflight/skills/agent-device-preflight/SKILL.md
+++ b/agent-device-preflight/skills/agent-device-preflight/SKILL.md
@@ -340,8 +340,8 @@ Once this passes, hand off: `agent-device help workflow`.
 
 ## Failure → cause
 
-Each row is the cause measured for that symptom in the sessions this file was written from,
-not the only cause the symptom can have. Where a row names more than one, work them in order.
+Each row names the cause this file has evidence for, not the only cause the symptom can have.
+Where a row names more than one, work them in order.
 
 | Symptom | Cause | Section |
 |---|---|---|

--- a/agent-device-preflight/skills/agent-device-preflight/SKILL.md
+++ b/agent-device-preflight/skills/agent-device-preflight/SKILL.md
@@ -287,9 +287,15 @@ so check for both — a daemon carrying the right team and a stale bundle id pas
 check and still builds the wrong runner:
 
 ```bash
-grep -oE '(DEVELOPMENT_TEAM|AGENT_DEVICE_IOS_RUNNER_APP_BUNDLE_ID)=[^ ]+' \
-  ~/.agent-device/sessions/<session>/runner.log | sort -u
+grep 'build-for-testing' ~/.agent-device/sessions/<session>/runner.log | tail -1 \
+  | grep -oE '(DEVELOPMENT_TEAM|AGENT_DEVICE_IOS_RUNNER_APP_BUNDLE_ID)=[^ ]+'
 ```
+
+The log is appended to rather than truncated per build, so it holds every value this session
+has ever built with — including the ones from before you corrected the environment. Read only
+the last `build-for-testing` line: scanning the whole file returns those stale values alongside
+the corrected ones, and a build that succeeded after the restart would still read as a
+mismatch.
 
 Two lines that both match your shell mean the daemon is current. **Anything else — one line,
 no lines, no log yet, or a value you do not recognise — means restart, not proceed.** A setting
@@ -334,12 +340,16 @@ Once this passes, hand off: `agent-device help workflow`.
 
 ## Failure → cause
 
+Each row is the cause measured for that symptom in the sessions this file was written from,
+not the only cause the symptom can have. Where a row names more than one, work them in order.
+
 | Symptom | Cause | Section |
 |---|---|---|
 | `Daemon request timed out` on `snapshot`, after `open` reported success | device is locked | 2b |
 | `CoreDeviceError 12040`, DDI could not be mounted | device preparation not driven | 3 |
 | `Developer mode is disabled for Apple development tools` | macOS `DevToolsSecurity` off | 4 |
-| `No Account for Team "..."` / `No profiles for ...were found` | team id read from `CN` instead of `OU` | 5 |
+| `No Account for Team "..."` | team id read from `CN` instead of `OU` | 5 |
+| `No profiles for ...were found` | wrong team id, or no profile Xcode can auto-select for this App ID and device; with both already correct, name the profile in `AGENT_DEVICE_IOS_PROVISIONING_PROFILE` (a profile name or specifier, not a path) | 5, 6 |
 | `0xe8008012 This provisioning profile cannot be installed on this device` | target device not in any profile | 6 |
 | Hint blames a heavy or animating screen | misleading in 0.20.3 — read `runner.log`; usually 6 | Reading failures |
 | Signing fix applied but the same error repeats | stale runner cache, or daemon holding stale env | 7, 8 |

--- a/agent-device-preflight/skills/agent-device-preflight/SKILL.md
+++ b/agent-device-preflight/skills/agent-device-preflight/SKILL.md
@@ -216,19 +216,33 @@ updates profiles but does not register devices:
 for that device type, and registrations are not freely removable until membership renewal.
 Ask the user before running it and wait for their answer — do not run it on your own initiative.
 
-Resolve the runner project from the binary you validated in item 1, not from `npm root -g` —
-the install may not be npm's, and a pnpm, Volta, or per-project install would send the build
-at a different source tree or none at all.
+Two things this command has to be told, because neither reaches it on its own.
+
+Resolve the runner project from the binary you validated in item 1 rather than from
+`npm root -g`, which assumes npm was the installer — then confirm the project is actually
+there before building. If that check fails, this install is laid out differently and you
+locate `AgentDeviceRunner.xcodeproj` inside the installed package yourself; do not build
+against a guess.
+
+Pass the bundle id as a build setting too. `AGENT_DEVICE_IOS_BUNDLE_ID` is read by
+`agent-device`, not by `xcodebuild` — the packaged project carries its own default
+(`AGENT_DEVICE_IOS_RUNNER_APP_BUNDLE_ID = com.callstack.agentdevice.runner`), so a raw build
+would register and sign the callstack id while every actual run uses yours. The test id
+derives from it inside the project, so setting the one setting covers both.
 
 ```bash
 AD_ROOT=$(dirname "$(dirname "$(readlink -f "$(command -v agent-device)")")")
+PROJ="$AD_ROOT/dist/apple/runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj"
+[ -d "$PROJ" ] || echo "not at $PROJ — find it inside the installed package before continuing"
+
 xcodebuild build-for-testing \
-  -project "$AD_ROOT/dist/apple/runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj" \
+  -project "$PROJ" \
   -scheme AgentDeviceRunner \
   -destination "platform=iOS,id=<target udid>" \
   -derivedDataPath /tmp/ad-register-dd \
   -allowProvisioningUpdates -allowProvisioningDeviceRegistration \
-  CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=<OU value>
+  CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=<OU value> \
+  AGENT_DEVICE_IOS_RUNNER_APP_BUNDLE_ID=<the AGENT_DEVICE_IOS_BUNDLE_ID value>
 ```
 
 Two things to expect:

--- a/agent-device-preflight/skills/agent-device-preflight/SKILL.md
+++ b/agent-device-preflight/skills/agent-device-preflight/SKILL.md
@@ -175,9 +175,18 @@ UID=..., CN=Apple Development: Some Name (AAAAAAAAAA), OU=BBBBBBBBBB, O=..., C=U
 `error: No Account for Team "AAAAAAAAAA"` plus `No profiles for 'com.callstack.agentdevice.runner' were found`,
 which reads like a provisioning problem and is not one.
 
+Set the bundle id too. `agent-device help physical-device` asks for both of these and only
+these, and for a bundle id **you** own — the shared default belongs to callstack's team, and
+your team may not be allowed to sign it:
+
 ```bash
 export AGENT_DEVICE_IOS_TEAM_ID=<the OU value>
+export AGENT_DEVICE_IOS_BUNDLE_ID=com.yourname.agentdevice.runner
 ```
+
+Both messages above, and the install failure in item 6, carry whichever bundle id is in
+effect — the callstack default while `AGENT_DEVICE_IOS_BUNDLE_ID` is unset, your own id once
+it is set.
 
 Do not infer "no Apple account is signed in" from
 `defaults read com.apple.dt.Xcode IDEProvisioningTeams` returning *does not exist* —
@@ -207,9 +216,14 @@ updates profiles but does not register devices:
 for that device type, and registrations are not freely removable until membership renewal.
 Ask the user before running it and wait for their answer — do not run it on your own initiative.
 
+Resolve the runner project from the binary you validated in item 1, not from `npm root -g` —
+the install may not be npm's, and a pnpm, Volta, or per-project install would send the build
+at a different source tree or none at all.
+
 ```bash
+AD_ROOT=$(dirname "$(dirname "$(readlink -f "$(command -v agent-device)")")")
 xcodebuild build-for-testing \
-  -project "$(npm root -g)/agent-device/dist/apple/runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj" \
+  -project "$AD_ROOT/dist/apple/runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj" \
   -scheme AgentDeviceRunner \
   -destination "platform=iOS,id=<target udid>" \
   -derivedDataPath /tmp/ad-register-dd \
@@ -275,12 +289,13 @@ including `doctor`, since it starts the daemon too.
 
 A first snapshot taking 20–30s is normal; the CLI warns about it itself. The first physical
 run builds and installs a signed XCTest runner
-(`AgentDeviceRunnerUITests-Runner`, bundle id `com.callstack.agentdevice.runner.uitests.xctrunner`)
+(`AgentDeviceRunnerUITests-Runner`, bundle id `<AGENT_DEVICE_IOS_BUNDLE_ID>.uitests.xctrunner`)
 onto the device — tell the user before you run this, and note that removing it is a
 home-screen delete.
 
 ```bash
 export AGENT_DEVICE_IOS_TEAM_ID=<OU value>
+export AGENT_DEVICE_IOS_BUNDLE_ID=com.yourname.agentdevice.runner
 agent-device doctor --platform ios --udid <udid>
 agent-device open com.apple.Preferences --platform ios --udid <udid> --session preflight
 agent-device snapshot -i --session preflight

--- a/agent-device-preflight/skills/agent-device-preflight/SKILL.md
+++ b/agent-device-preflight/skills/agent-device-preflight/SKILL.md
@@ -107,8 +107,38 @@ no blockers on a device with it disabled. Enable on the device: Settings → Pri
 Security → Developer Mode. The device reboots and asks once more after unlock.
 
 Connect by cable for first setup — the alternative runner transport
-(`AGENT_DEVICE_IOS_RUNNER_ROUTE=usbmux`) is cable-only, and a locked device wedges either
-transport. Keep the screen unlocked for the whole run.
+(`AGENT_DEVICE_IOS_RUNNER_ROUTE=usbmux`) is cable-only.
+
+### 2b. Device is unlocked — check it, do not assume it
+
+A locked device cannot be driven, and **`open` does not tell you.** Measured on one device,
+same session, same command, only the lock state changed:
+
+| device state | `passcodeRequired` | `open` | `snapshot` |
+|---|---|---|---|
+| locked (screen off, face away) | `true` | reports `Opened: ...` | `Daemon request timed out` |
+| unlocked | `false` | reports `Opened: ...` | 49 nodes |
+
+So `open` succeeding proves nothing about controllability, and the first real symptom is a
+timeout several steps later. Check the lock state directly instead:
+
+```bash
+xcrun devicectl device info lockState --device <udid>
+# passcodeRequired: true  -> currently LOCKED, control will time out
+# passcodeRequired: false -> currently unlocked
+```
+
+`passcodeRequired` is a live lock readout, not the static "is a passcode configured"
+setting. Do not confuse it with `unlockedSinceBoot`, which stays `true` after the first
+unlock and says nothing about the present moment.
+
+Recovery needs no daemon restart: unlocking the device and re-running the same command in
+the same session succeeds.
+
+Because a Face ID device unlocks the instant its owner looks at it, "the screen was off"
+and "the device was locked" are easy to conflate while sitting next to it. Remove the
+variable for the whole run rather than watching it — on the device, Settings → Display &
+Brightness → Auto-Lock → Never, restored afterwards.
 
 ### 3. Developer disk image mounts
 
@@ -308,6 +338,7 @@ Once this passes, hand off: `agent-device help workflow`.
 
 | Symptom | Cause | Section |
 |---|---|---|
+| `Daemon request timed out` on `snapshot`, after `open` reported success | device is locked | 2b |
 | `CoreDeviceError 12040`, DDI could not be mounted | device preparation not driven | 3 |
 | `Developer mode is disabled for Apple development tools` | macOS `DevToolsSecurity` off | 4 |
 | `No Account for Team "..."` / `No profiles for ...were found` | team id read from `CN` instead of `OU` | 5 |

--- a/agent-device-preflight/skills/agent-device-preflight/SKILL.md
+++ b/agent-device-preflight/skills/agent-device-preflight/SKILL.md
@@ -2,16 +2,17 @@
 name: agent-device-preflight
 description: |
   This skill should be used when the user asks to "connect my phone to agent-device",
-  "attach a device", "why can't agent-device see my iPhone/iPad", "agent-device doctor
-  passes but open fails", "developer disk image could not be mounted", "No Account for
-  Team", "this provisioning profile cannot be installed on this device",
-  "xcodebuild build-for-testing failed", or is setting up agent-device against a physical
-  iOS device for the first time. Resolves the environment prerequisites that must hold
-  before `agent-device open` can attach; hands command-level work back to the CLI.
-  Pass the user's request verbatim — this skill reads a free-form request, not a subcommand.
+  "attach a device to agent-device", "why can't agent-device see my iPhone/iPad",
+  "agent-device doctor passes but open fails", "developer disk image could not be
+  mounted", "No Account for Team", "this provisioning profile cannot be installed on
+  this device", "xcodebuild build-for-testing failed", "agent-device snapshot times
+  out", "Daemon request timed out", "agent-device is targeting the simulator instead of
+  my phone", "the same signing error repeats after I fixed it", or is setting up
+  agent-device against a physical iOS device for the first time. Resolves the
+  environment prerequisites that must hold before `agent-device open` can attach; hands
+  command-level work back to the CLI. Pass the user's request verbatim — this skill
+  reads a free-form request, not a subcommand.
 user_invocable: true
-context: fork
-model: sonnet
 ---
 
 # agent-device Preflight
@@ -23,21 +24,14 @@ Bring the local environment to the state `agent-device` needs, then get out of t
 This skill covers **attachment prerequisites only** — the one-time environment setup that
 must hold before `agent-device open` can reach a device.
 
-It deliberately holds **no command knowledge**. Upstream ships its own router skill
-(`skills/agent-device/SKILL.md` in `callstack/agent-device`) whose stated position is
-"ask the CLI, don't hardcode": it gates on `agent-device >= 0.20.0` and delegates to
-`agent-device help <topic>`. Once preflight passes, defer there. Do not duplicate the
-command surface here — it moves faster than any static copy.
+It deliberately holds **no command knowledge**. Once preflight passes, defer to
+`agent-device help <topic>`. Do not duplicate the command surface here — it moves faster
+than any static copy.
 
 Three reasons this layer exists rather than being covered by what already ships:
 
-- `agent-device doctor` does not check items 3–7 below. It reported
-  `Doctor: pass` / `No blockers found` on two separate devices that could not in fact be
-  driven — once with Developer Mode disabled, once with the device absent from every
-  provisioning profile.
-- The MCP server does not expose the connection surface at all — `connect`, `disconnect`,
-  `connection`, `daemon`, `device`, `cdp`, `auth`, `proxy`, `react-devtools`, and `web`
-  are all `mcpExposed: false`. An MCP client cannot drive attachment; a shell must.
+- `agent-device doctor` covers none of the checks below except the CLI's own presence (item 1).
+- The MCP server does not expose the connection surface, so a shell must drive attachment.
 - One failure in this set is reported with an actively misleading hint (see
   **Reading failures** below). Following it wastes the session.
 
@@ -50,11 +44,8 @@ can surface `The current screen is overwhelming the iOS accessibility capture (u
 heavy or animating content)` and suggest changing screens. Observed: that hint appeared
 for a pure code-signing install failure; the screen was never the problem, and the exact
 same screen captured 49 nodes once signing was fixed. The real cause was in
-`~/.agent-device/sessions/<session>/runner.log`. Upstream has already corrected this on
-`main` — `runner-recycle-ledger.ts` now carries "a provisioning or code-signing error
-there means the runner cannot install on this device, and no retry will help", with a
-comment noting the old wording "sent people to change screens when the runner had in fact
-failed to install" — but the fix is not in the published 0.20.3.
+`~/.agent-device/sessions/<session>/runner.log`. The released 0.20.3 still surfaces this
+misleading hint.
 
 **A matching `version` field does not mean matching code.** `package.json` keeps the last
 released version until the next bump, so a `main` checkout and an installed npm build can
@@ -71,7 +62,10 @@ Run in order. Each check is read-only except where marked.
 agent-device --version   # must be >= 0.20.0
 ```
 
-Not installed → `npm install -g agent-device@latest`. Requires Node 22.12+ (24+ for web).
+Missing or older than 0.20.0 → **stop.** Do not run `npm install -g agent-device@latest` or
+`npx -y agent-device@latest` autonomously, and do not put a version or upgrade command in a
+plan — upstream's own skill forbids both. Ask the user to upgrade their trusted install, or to
+approve an exact-version command they run themselves. Requires Node 22.12+ (24+ for web).
 
 ### 2. Device visible, and the selector you will actually pass
 
@@ -79,28 +73,13 @@ Not installed → `npm install -g agent-device@latest`. Requires Node 22.12+ (24
 xcrun devicectl list devices
 ```
 
-The default table shows an **Identifier** column. That is *not* what `--udid` takes.
-`agent-device` builds a device's id as `hardwareProperties.udid ?? identifier`
-(`packages/kernel/src/device.ts:238`), so on any device that reports a hardware UDID the
-selector is the UDID, not the Identifier shown on screen. Derive it:
+The default table shows an **Identifier** column. That is *not* what `--udid` takes. On
+any device that reports a hardware UDID, the selector is that UDID, not the Identifier
+shown on screen. Derive it with the query in `references/device-and-signing-queries.md`.
 
-```bash
-xcrun devicectl list devices --json-output /tmp/dev.json >/dev/null
-python3 -c "
-import json
-for d in json.load(open('/tmp/dev.json'))['result']['devices']:
-    p, h = d['deviceProperties'], d['hardwareProperties']
-    c = d['connectionProperties']
-    print(p.get('name'), h.get('udid'), '|', h.get('marketingName'),
-          '| transport:', c.get('transportType'), '| tunnel:', c.get('tunnelState'),
-          '| devMode:', p.get('developerModeStatus'))
-"
-```
-
-**Always pass `--udid`.** Device resolution prefers *virtual* devices over physical ones
-(`packages/kernel/src/device.ts:240-298`), so on a machine with simulators installed a
-bare `--platform ios` silently targets a simulator instead of the real device. iPads
-resolve as `target=mobile`, same as iPhones.
+**Always pass `--udid`.** Device resolution prefers *virtual* devices over physical ones,
+so on a machine with simulators installed a bare `--platform ios` silently targets a
+simulator instead of the real device. iPads resolve as `target=mobile`, same as iPhones.
 
 Confirm `developerModeStatus: enabled` — **`doctor` does not check this**, and will report
 no blockers on a device with it disabled. Enable on the device: Settings → Privacy &
@@ -111,16 +90,9 @@ Connect by cable for first setup — the alternative runner transport
 
 ### 2b. Device is unlocked — check it, do not assume it
 
-A locked device cannot be driven, and **`open` does not tell you.** Measured on one device,
-same session, same command, only the lock state changed:
-
-| device state | `passcodeRequired` | `open` | `snapshot` |
-|---|---|---|---|
-| locked (screen off, face away) | `true` | reports `Opened: ...` | `Daemon request timed out` |
-| unlocked | `false` | reports `Opened: ...` | 49 nodes |
-
-So `open` succeeding proves nothing about controllability, and the first real symptom is a
-timeout several steps later. Check the lock state directly instead:
+A locked device cannot be driven, and **`open` does not tell you.** `open` succeeding
+proves nothing about controllability, and the first real symptom is a timeout several
+steps later. Check the lock state directly instead:
 
 ```bash
 xcrun devicectl device info lockState --device <udid>
@@ -152,17 +124,18 @@ and nothing downstream will work — not `open`, not the runner install.
 
 If it fails while pairing, Developer Mode, cable, and network to Apple are all healthy:
 **open Xcode → Window → Devices and Simulators and select the device.** That window drives
-the device-preparation flow. (Observed: three consecutive CLI-only attempts failed, and the
-next attempt after selecting the device in Xcode succeeded. Asynchronous completion in the
-interval was not controlled for, so treat this as an effective step rather than an
-established mechanism. A second device connected by cable from the start never hit this.)
+the device-preparation flow. Treat this as an effective step rather than an established
+mechanism.
 
 Do **not** jump to "Xcode is too old for this iOS version" without evidence. The DDI's
 `ProductBuildVersion` is Xcode's own build number, not an iOS build number — the two are
 not on a comparable scale, and a version-mismatch reading built on comparing them is
-unfounded. Xcode 26.2 drove iOS 26.5.2 and iPadOS 26.5 devices successfully.
+unfounded.
 
 ### 4. macOS developer tools authorized (undocumented upstream)
+
+The `sudo` line changes machine state and requires a password — **ask the user to run it
+themselves; never run it unattended.** Reverse with `sudo DevToolsSecurity -disable`.
 
 ```bash
 DevToolsSecurity -status        # read-only
@@ -173,18 +146,23 @@ UI test runners start suspended until `testmanagerd` attaches. With this disable
 runner never wakes and `snapshot` fails with
 `Developer mode is disabled for Apple development tools`.
 
-This requirement appears **nowhere** in the upstream README or `website/docs/`, though the
-code checks it proactively (`src/platforms/apple/core/runner/runner-session.ts:620`).
-
-The `sudo` line changes machine state and requires a password — **ask the user to run it
-themselves; never run it unattended.** Reverse with `sudo DevToolsSecurity -disable`.
-
 ### 5. Signing team ID — read the certificate's `OU`, not its `CN`
 
 ```bash
 security find-identity -v -p codesigning
-security find-certificate -c "<identity CN>" -p | openssl x509 -noout -subject
+# Note the 40-hex hash of the identity you will actually sign with.
+# `find-certificate -c` matches the CN as a substring and returns only the first hit, so
+# select by that hash instead — two teams give one person two certs with the same CN.
+security find-certificate -a -c "<identity CN>" -p \
+  | awk '/BEGIN CERT/{n++} n{print > ("/tmp/ad-cert-" n ".pem")}'
+for f in /tmp/ad-cert-*.pem; do
+  openssl x509 -in "$f" -noout -fingerprint -sha1 -subject
+done
+rm -f /tmp/ad-cert-*.pem
 ```
+
+Match the fingerprint to the identity hash above, then read the `OU` off *that* certificate's
+subject.
 
 The subject looks like:
 
@@ -218,48 +196,38 @@ Failed to install embedded profile for com.callstack.agentdevice.runner.uitests.
 : 0xe8008012 (This provisioning profile cannot be installed on this device.)
 ```
 
-Check before running anything:
-
-```bash
-UDID=<target udid>
-for f in ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*.mobileprovision; do
-  security cms -D -i "$f" > /tmp/p.plist 2>/dev/null && python3 -c "
-import plistlib
-d = plistlib.load(open('/tmp/p.plist','rb'))
-devs = d.get('ProvisionedDevices') or []
-print(d.get('Name'), '| devices:', len(devs), '| covers target:', '$UDID' in devs)
-"
-done
-```
+Check coverage before running anything, with the query in
+`references/device-and-signing-queries.md`.
 
 If nothing covers it, register from the CLI — a **concrete** destination plus both
 provisioning flags. `-allowProvisioningUpdates` alone is not enough; it creates and
 updates profiles but does not register devices:
 
+**This writes to the Apple Developer account.** It consumes one of the 100 annual device slots
+for that device type, and registrations are not freely removable until membership renewal.
+Ask the user before running it and wait for their answer — do not run it on your own initiative.
+
 ```bash
 xcodebuild build-for-testing \
   -project "$(npm root -g)/agent-device/dist/apple/runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj" \
   -scheme AgentDeviceRunner \
-  -destination "platform=iOS,id=$UDID" \
+  -destination "platform=iOS,id=<target udid>" \
   -derivedDataPath /tmp/ad-register-dd \
   -allowProvisioningUpdates -allowProvisioningDeviceRegistration \
   CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=<OU value>
 ```
-
-**This writes to the Apple Developer account** — it consumes one of the 100 annual device
-slots for that device type, and registrations are not freely removable until membership
-renewal. Tell the user before running it.
 
 Two things to expect:
 
 - The build may end with
   `error: Build input file cannot be found: '...<uuid>.mobileprovision'`. That is a race —
   the newly issued profile replaced the one the build had already resolved. **Registration
-  still succeeded**; re-check the profile as above rather than re-reading the exit code.
+  still succeeded**; re-run the coverage query rather than re-reading the exit code.
 - With a concrete destination xcodebuild states the real problem plainly
   (`Device "X" isn't registered in your developer account`). That diagnostic never appears
-  through agent-device's generic-destination build. Use this command as a diagnostic even
-  when you do not intend to register.
+  through agent-device's generic-destination build. To get it *without* registering anything,
+  run the same command with `-allowProvisioningDeviceRegistration` removed —
+  `-allowProvisioningUpdates` alone does not register devices, so the diagnostic is free.
 
 ### 7. Runner build cache is not device-aware
 
@@ -273,18 +241,8 @@ ls ~/.agent-device/apple-runner/derived/ios-device/          # cache-<hash> dirs
 mv ~/.agent-device/apple-runner/derived/ios-device/cache-<hash> /tmp/   # reversible
 ```
 
-Confirm what a built runner is actually signed for:
-
-```bash
-APP=$(find ~/.agent-device/apple-runner/derived/ios-device \
-        -name "AgentDeviceRunnerUITests-Runner.app" -maxdepth 5 | head -1)
-security cms -D -i "$APP/embedded.mobileprovision" > /tmp/emb.plist
-python3 -c "
-import plistlib
-d = plistlib.load(open('/tmp/emb.plist','rb'))
-print('UUID:', d.get('UUID'), '| devices:', d.get('ProvisionedDevices'))
-"
-```
+Confirm what a built runner is actually signed for with the query in
+`references/device-and-signing-queries.md`.
 
 ### 8. Daemon environment freshness
 
@@ -315,6 +273,12 @@ including `doctor`, since it starts the daemon too.
 
 ## Verify
 
+A first snapshot taking 20–30s is normal; the CLI warns about it itself. The first physical
+run builds and installs a signed XCTest runner
+(`AgentDeviceRunnerUITests-Runner`, bundle id `com.callstack.agentdevice.runner.uitests.xctrunner`)
+onto the device — tell the user before you run this, and note that removing it is a
+home-screen delete.
+
 ```bash
 export AGENT_DEVICE_IOS_TEAM_ID=<OU value>
 agent-device doctor --platform ios --udid <udid>
@@ -323,14 +287,8 @@ agent-device snapshot -i --session preflight
 agent-device close --session preflight
 ```
 
-`doctor` passing proves less than it looks — it does not cover items 3–7. The snapshot is
+`doctor` passing proves less than it looks — it covers none of items 2 through 8. The snapshot is
 the real gate.
-
-A first snapshot taking 20–30s is normal; the CLI warns about it itself. The first physical
-run builds and installs a signed XCTest runner
-(`AgentDeviceRunnerUITests-Runner`, bundle id `com.callstack.agentdevice.runner.uitests.xctrunner`)
-onto the device — tell the user before it happens, and note that removing it is a
-home-screen delete.
 
 Once this passes, hand off: `agent-device help workflow`.
 
@@ -347,7 +305,7 @@ Once this passes, hand off: `agent-device help workflow`.
 | Signing fix applied but the same error repeats | stale runner cache, or daemon holding stale env | 7, 8 |
 | Commands land on a simulator instead of the real device | `--udid` omitted; virtual devices win resolution | 2 |
 | `listen EPERM` | daemon started inside a sandbox | Sandbox |
-| `doctor` passes but `open`/`snapshot` fails | `doctor` does not cover 3–7 | — |
+| `doctor` passes but `open`/`snapshot` fails | `doctor` covers only item 1 | — |
 
 ## Scope not covered
 
@@ -355,6 +313,5 @@ Android (`--test-ime` on real hardware, snapshot-helper APK auto-install, `adb r
 Metro), web, the remote/cloud lease providers, `proxy`, and the degraded legacy-XCTest tier
 for older devices are all outside this preflight.
 
-Verified end to end (open → snapshot → press → screenshot → close) against a physical
-iPhone and a physical iPad, both CoreDevice tier, plus the iOS simulator. iPad split-view
-captures correctly, sidebar and detail pane both present in the accessibility tree.
+This preflight is verified against physical iOS devices (iPhone and iPad, CoreDevice tier)
+and the iOS simulator.

--- a/agent-device-preflight/skills/agent-device-preflight/references/device-and-signing-queries.md
+++ b/agent-device-preflight/skills/agent-device-preflight/references/device-and-signing-queries.md
@@ -1,0 +1,64 @@
+# Device and Signing Queries
+
+Read-only queries the preflight steps call for.
+
+## Deriving the device UDID
+
+Run this to get the selector `--udid` actually takes, rather than the Identifier column
+`xcrun devicectl list devices` prints on screen.
+
+```bash
+xcrun devicectl list devices --json-output /tmp/dev.json >/dev/null
+python3 -c "
+import json
+for d in json.load(open('/tmp/dev.json'))['result']['devices']:
+    p, h = d['deviceProperties'], d['hardwareProperties']
+    c = d['connectionProperties']
+    print(p.get('name'), h.get('udid'), '|', h.get('marketingName'),
+          '| transport:', c.get('transportType'), '| tunnel:', c.get('tunnelState'),
+          '| devMode:', p.get('developerModeStatus'))
+"
+```
+
+## Checking provisioning-profile coverage
+
+Run this before registering a device, to check whether an existing profile already covers
+it for the target team.
+
+```bash
+UDID=<target udid>
+TEAM=<the OU value from step 5>
+for f in ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*.mobileprovision; do
+  security cms -D -i "$f" > /tmp/p.plist 2>/dev/null && python3 -c "
+import plistlib
+d = plistlib.load(open('/tmp/p.plist','rb'))
+devs = d.get('ProvisionedDevices') or []
+team = (d.get('TeamIdentifier') or [None])[0]
+print(d.get('Name'), '| team:', team, '| devices:', len(devs),
+      '| covers target:', '$UDID' in devs and team == '$TEAM')
+"
+done
+```
+
+A profile that lists the device but reports a different `team` does not help you: coverage is
+per team. Read `covers target` as false unless both columns agree.
+
+## Confirming what a built runner is signed for
+
+Run this after a cache clear or a signing change, to confirm which device and team a built
+runner is actually signed for.
+
+```bash
+# There is one of these per cache dir — inspect every one, not the first found.
+find ~/.agent-device/apple-runner/derived/ios-device \
+     -name "AgentDeviceRunnerUITests-Runner.app" -maxdepth 5 | while read -r APP; do
+  security cms -D -i "$APP/embedded.mobileprovision" > /tmp/emb.plist 2>/dev/null || continue
+  python3 -c "
+import plistlib, sys
+d = plistlib.load(open('/tmp/emb.plist','rb'))
+print('$APP')
+print('  UUID:', d.get('UUID'), '| team:', (d.get('TeamIdentifier') or [None])[0],
+      '| devices:', d.get('ProvisionedDevices'))
+"
+done
+```

--- a/agent-device-preflight/skills/agent-device-preflight/references/device-and-signing-queries.md
+++ b/agent-device-preflight/skills/agent-device-preflight/references/device-and-signing-queries.md
@@ -22,26 +22,36 @@ for d in json.load(open('/tmp/dev.json'))['result']['devices']:
 
 ## Checking provisioning-profile coverage
 
-Run this before registering a device, to check whether an existing profile already covers
-it for the target team.
+Run this before registering a device, to check whether an existing profile already covers it —
+for the target team, and for both App IDs the runner needs.
 
 ```bash
 UDID=<target udid>
 TEAM=<the OU value from step 5>
+BUNDLE=<the AGENT_DEVICE_IOS_BUNDLE_ID value from step 5>
 for f in ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*.mobileprovision; do
   security cms -D -i "$f" > /tmp/p.plist 2>/dev/null && python3 -c "
-import plistlib
+import plistlib, fnmatch
 d = plistlib.load(open('/tmp/p.plist','rb'))
 devs = d.get('ProvisionedDevices') or []
 team = (d.get('TeamIdentifier') or [None])[0]
-print(d.get('Name'), '| team:', team, '| devices:', len(devs),
-      '| covers target:', '$UDID' in devs and team == '$TEAM')
+appid = (d.get('Entitlements') or {}).get('application-identifier') or ''
+def ok(w): return '$UDID' in devs and team == '$TEAM' and fnmatch.fnmatch(w, appid)
+print(d.get('Name'), '| team:', team, '| app id:', appid, '| devices:', len(devs),
+      '| runner:', ok('$TEAM.$BUNDLE'), '| uitests:', ok('$TEAM.$BUNDLE.uitests'))
 "
 done
 ```
 
-A profile that lists the device but reports a different `team` does not help you: coverage is
-per team. Read `covers target` as false unless both columns agree.
+Three things have to line up, and the device UDID alone is none of them. A profile that lists
+the device but reports a different `team` does not help you — coverage is per team. A same-team
+profile issued for an unrelated App ID does not help either, which is why the `app id` column
+is printed: it is the pattern the runner's identifier has to match.
+
+You need **both** the `runner` and `uitests` columns true, across the profiles you have. One
+wildcard profile (`app id` ending in `.*`) satisfies both at once; an explicit profile names a
+single App ID, so two of them are needed between them. Nothing covering both means the
+registration step below is still owed.
 
 ## Confirming what a built runner is signed for
 


### PR DESCRIPTION
## What

A preflight-only plugin for [`agent-device`](https://github.com/callstack/agent-device): the environment prerequisites that must hold before `agent-device open` can reach a physical iOS device. It holds **no command knowledge** — once preflight passes it hands off to `agent-device help <topic>`.

## Why a separate layer

Three surfaces each decline to cover this, for their own reasons:

| Surface | Why it doesn't cover attachment setup |
|---|---|
| Upstream's own skill (`skills/agent-device/SKILL.md`) | Pure router — version-gates, then delegates to `agent-device help`. Deliberately holds no setup knowledge. |
| The MCP server | `connect`, `disconnect`, `connection`, `daemon`, `device`, `cdp`, `auth`, `proxy`, `react-devtools`, `web` are all `mcpExposed: false`. An MCP client cannot drive attachment at all. |
| `agent-device doctor` | Covers only the skill's item 1 (CLI presence and version). It reported `Doctor: pass` / `No blockers found` on two separate devices that could not in fact be driven — once with Developer Mode disabled, once with the device absent from every provisioning profile. |

## Evidence base

End-to-end attach — `open` → `snapshot` → `press --settle` → `screenshot` → `close` — verified against a physical iPhone and a physical iPad, both CoreDevice tier, plus the iOS simulator, on agent-device 0.20.3. The iPad's split view captured correctly, with sidebar and detail pane both present in the accessibility tree.

Prerequisites hit along the way that are **undocumented upstream**:

1. **`sudo DevToolsSecurity -enable`** — appears nowhere in the upstream README or `website/docs/`, yet the code checks it proactively (`src/platforms/apple/core/runner/runner-session.ts:620`). Without it the UI test runner stays suspended forever.
2. **Select the device once in Xcode → Devices and Simulators** to drive device preparation past `CoreDeviceError 12040`.
3. **The signing team id is the certificate's `OU`, not the `CN` parenthetical.** Passing the parenthetical yields `No Account for Team "..."`, which reads like a provisioning failure and is not one.
4. **The daemon captures its environment at spawn** — correcting `AGENT_DEVICE_IOS_TEAM_ID` in the shell does nothing until `agent-device daemon stop`. The runner log is appended to across builds, so confirming what the daemon actually used means reading its *last* `build-for-testing` invocation, not the whole file.

**Device lock state, measured on one device in one session with only the lock changed.** Locked (screen off, face away): `passcodeRequired` true, `open` reports `Opened: ...`, `snapshot` fails with `Daemon request timed out`. Unlocked: `passcodeRequired` false, `open` reports `Opened: ...`, `snapshot` returns 49 nodes. So `open` succeeding proves nothing about controllability, and the first real symptom arrives several steps later. Recovery needed no daemon restart. `passcodeRequired` is a live readout and is not `unlockedSinceBoot`, which stays true after the first unlock and says nothing about the present moment.

Plus two device-selection traps, both confirmed in upstream source:

- `--udid` takes the **hardware UDID**, not the Identifier `devicectl` prints by default (`packages/kernel/src/device.ts:238`).
- Resolution **prefers virtual devices**, so omitting `--udid` silently targets a simulator (`packages/kernel/src/device.ts:240-298`).

## Rejected alternatives

- **CLI wrapper skill** — duplicates upstream's router and rots against CLI updates.
- **MCP-based plugin** — the connection commands are hidden from MCP by design, so the attach half is unreachable.
- **Upstream contribution instead** — still open, and arguably the better end state for the undocumented items above. Merge timing is out of our hands and the certificate-OU derivation is environment-specific. Not mutually exclusive with this plugin.

## Privacy

No hardware UDID, team id, or device name is committed. This repo is public, so every machine-specific value is written as a derivation command rather than a literal.

## Scope limits (stated in the skill itself)

Verified against physical iOS (CoreDevice tier) and the iOS simulator only. **Android, web, remote/cloud lease providers, `proxy`, and the degraded legacy-XCTest tier are untested.** Android in particular has its own documented friction (`--test-ime` opt-in on real hardware, snapshot-helper APK auto-install, `adb reverse` for Metro) that this preflight does not address.

## One claim deliberately softened

The Xcode → Devices and Simulators step is recorded as an effective step, not an established mechanism: three consecutive CLI-only attempts failed and the next attempt after selecting the device in Xcode succeeded, but asynchronous completion in the interval was not controlled for. The skill says so in place, and also warns against the version-mismatch misreading it replaced — the DDI's `ProductBuildVersion` is Xcode's own build number, not an iOS build number, so comparing the two is unfounded (Xcode 26.2 drove an iOS 26.5.2 device successfully). A second device connected by cable from the start never hit this step at all.

## Review loop — five rounds

Reviewed by `codex` (gpt-5.6-sol) as the review source, five rounds, each finding verified against first-party evidence before any edit landed. Commits `04333ed` → `9d0a1af` → `9de6546` → `d65bf46` → `44ed1b4`; each commit message carries its round's findings, the reading behind them, and what would break that reading.

**Zero recurrence across all five rounds** — no defect returned on a clause after its fix landed. The recurring reading instead was that this file was written from observed sessions and stated each observation as though it held always: a step it never reconciled against `agent-device help physical-device`, a symptom mapped to a single cause, a log grep assuming a single build.

### The one design decision constituted during review

The skill originally declared `context: fork` (with `model: sonnet`), which meant it ran in a separate agent context that cannot pause for user input mid-run — so its own authorization clauses ("ask the user before running this", "tell the user first") could not reach anyone until the run had already ended. Two workarounds were available: the sibling pattern at `cdp-attach/skills/cdp-attach/SKILL.md:80` (return the proposed command as the final result and take no action in that run), and a `PreToolUse` command-matching hook on the pattern at `cdp-attach/hooks/hooks.json`.

Both were rejected in favour of removing the fork, in the author's words:

> fork 밖으로. 이 스킬은 굳이 포크로 할 필요 없음

So the skill runs inline in the main conversation and its gates fire directly, with no workaround. `model: sonnet` went with it: every skill in this repo that sets `model:` also sets `context: fork`, and selecting a model for a context that no longer exists is meaningless.

### Residual — knowingly left open

Two prerequisites stated in `agent-device help physical-device` remain unreconciled, recorded rather than silently dropped:

- the profile/team must allow `<AGENT_DEVICE_IOS_BUNDLE_ID>.uitests` as well as the bundle id itself — the skill's reference query checks both App IDs, but the requirement is never stated in prose;
- `AGENT_DEVICE_IOS_SIGNING_IDENTITY` is optional and should be omitted unless xcodebuild asks for a specific identity.

Each would enter on the strength of the CLI's documentation rather than a run observed here, which is a weaker footing than every other claim in the file currently stands on. A third item from the same list (`AGENT_DEVICE_IOS_PROVISIONING_PROFILE` taking a name or specifier, not a path) *was* taken in round 5, because a verified defect in the skill's own failure table required it.

The loop was stopped at a pre-declared boundary — five rounds, with the last round's verdict still `needs-attention` — not at an `approve` from the source.
