### PR TITLE
Add Android to agent-device-preflight, split per platform

### DIFF
--- a/agent-device-preflight/.claude-plugin/plugin.json
+++ b/agent-device-preflight/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device-preflight",
-  "description": "Preflight the local environment before agent-device attaches to a device: lock-state check, signing team derivation, device registration, DDI mount, DevToolsSecurity, runner cache and daemon env staleness, device selector resolution",
-  "version": "0.4.6",
+  "description": "Preflight the local environment before agent-device attaches to a physical iOS or Android device: device selector resolution, lock-state check, adb authorization, signing team derivation, device registration, DDI mount, DevToolsSecurity, helper install, runner cache and daemon env staleness",
+  "version": "0.5.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/agent-device-preflight/.claude-plugin/plugin.json
+++ b/agent-device-preflight/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device-preflight",
   "description": "Preflight the local environment before agent-device attaches to a device: lock-state check, signing team derivation, device registration, DDI mount, DevToolsSecurity, runner cache and daemon env staleness, device selector resolution",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/agent-device-preflight/skills/agent-device-preflight/SKILL.md
+++ b/agent-device-preflight/skills/agent-device-preflight/SKILL.md
@@ -2,16 +2,17 @@
 name: agent-device-preflight
 description: |
   This skill should be used when the user asks to "connect my phone to agent-device",
-  "attach a device to agent-device", "why can't agent-device see my iPhone/iPad",
-  "agent-device doctor passes but open fails", "developer disk image could not be
-  mounted", "No Account for Team", "this provisioning profile cannot be installed on
-  this device", "xcodebuild build-for-testing failed", "agent-device snapshot times
-  out", "Daemon request timed out", "agent-device is targeting the simulator instead of
-  my phone", "the same signing error repeats after I fixed it", or is setting up
-  agent-device against a physical iOS device for the first time. Resolves the
-  environment prerequisites that must hold before `agent-device open` can attach; hands
-  command-level work back to the CLI. Pass the user's request verbatim — this skill
-  reads a free-form request, not a subcommand.
+  "attach a device to agent-device", "why can't agent-device see my iPhone/iPad", "why
+  can't agent-device see my Pixel/Android phone", "agent-device doctor passes but open
+  fails", "developer disk image could not be mounted", "No Account for Team", "this
+  provisioning profile cannot be installed on this device", "xcodebuild
+  build-for-testing failed", "No Android devices found", "adb says unauthorized",
+  "agent-device snapshot times out", "Daemon request timed out", "agent-device is
+  targeting the simulator instead of my phone", "the same signing error repeats after I
+  fixed it", or is setting up agent-device against a physical iOS or Android device for
+  the first time. Resolves the environment prerequisites that must hold before
+  `agent-device open` can attach; hands command-level work back to the CLI. Pass the
+  user's request verbatim — this skill reads a free-form request, not a subcommand.
 user_invocable: true
 ---
 
@@ -21,42 +22,43 @@ Bring the local environment to the state `agent-device` needs, then get out of t
 
 ## Scope Guard
 
-This skill covers **attachment prerequisites only** — the one-time environment setup that
-must hold before `agent-device open` can reach a device.
+This skill covers **attachment prerequisites only** — what must hold before `agent-device open`
+can reach a device. Some of it is one-time setup (toolchain, signing, developer mode); the rest
+is per-run state that goes stale on its own — lock state, session identity, ownership claims,
+and the daemon's captured environment.
 
-It deliberately holds **no command knowledge**. Once preflight passes, defer to
+It deliberately holds **no post-attachment command catalog**. The few commands here exist to
+establish or inspect the preconditions themselves. Once preflight passes, defer to
 `agent-device help <topic>`. Do not duplicate the command surface here — it moves faster
 than any static copy.
 
 Three reasons this layer exists rather than being covered by what already ships:
 
-- `agent-device doctor` covers none of the checks below except the CLI's own presence (item 1).
+- `agent-device doctor` covers almost none of the platform checks — on iOS it reaches only
+  the CLI's own presence.
 - The MCP server does not expose the connection surface, so a shell must drive attachment.
-- One failure in this set is reported with an actively misleading hint (see
-  **Reading failures** below). Following it wastes the session.
+- Failures in this set are reported with actively misleading text on both platforms. iOS
+  blames the screen for a signing failure; Android reports "no devices found" for a
+  device that is connected and listed. Following either wastes the session.
 
-## Reading failures
+## Platform
 
-Two rules before acting on any runner failure.
+Run the shared checks below, then read **exactly one** platform file:
 
-**Read `runner.log`, not just the hint.** On a signing/install failure the released CLI
-can surface `The current screen is overwhelming the iOS accessibility capture (usually
-heavy or animating content)` and suggest changing screens. Observed: that hint appeared
-for a pure code-signing install failure; the screen was never the problem, and the exact
-same screen captured 49 nodes once signing was fixed. The real cause was in
-`~/.agent-device/sessions/<session>/runner.log`. The released 0.20.3 still surfaces this
-misleading hint.
+| Target | Read |
+|---|---|
+| Physical iPhone or iPad | `references/ios-preflight.md` |
+| Physical Android device | `references/android-preflight.md` |
 
-**A matching `version` field does not mean matching code.** `package.json` keeps the last
-released version until the next bump, so a `main` checkout and an installed npm build can
-both read `0.20.3` and differ. Verify behaviour against the installed
-`dist/`, not the repository, when the two could disagree.
+Read only the one you need, and do not carry conclusions across. The two platforms
+disagree at nearly every corresponding step — which selector works, whether signing
+exists at all, how a locked device announces itself, what a slow first snapshot means.
+Applying an iOS habit on Android (or the reverse) produces failures whose error text
+points somewhere else entirely.
 
-## Preflight
+## Shared checks
 
-Run in order. Each check is read-only except where marked.
-
-### 1. CLI present and recent enough
+### CLI present and recent enough
 
 ```bash
 agent-device --version   # must be >= 0.20.0
@@ -67,306 +69,66 @@ Missing or older than 0.20.0 → **stop.** Do not run `npm install -g agent-devi
 plan — upstream's own skill forbids both. Ask the user to upgrade their trusted install, or to
 approve an exact-version command they run themselves. Requires Node 22.12+ (24+ for web).
 
-### 2. Device visible, and the selector you will actually pass
+### A matching `version` field does not mean matching code
+
+`package.json` keeps the last released version until the next bump, so a `main` checkout and
+an installed npm build can both read `0.20.3` and differ. Verify behaviour against the
+installed `dist/`, not the repository, when the two could disagree.
+
+### Sessions are named from the working directory
+
+With no `--session`, the default session name derives from a hash of the current directory
+(`cwd:<hash>:default`). The same command run from a different directory therefore targets a
+*different* session, and `doctor` will say so:
+
+```
+- session: No active session named cwd:<hash>:default. Doctor will use device inventory only.
+```
+
+Pass `--session <name>` explicitly for any multi-step run, so the session does not move when
+the shell does.
+
+Device ownership claims can also outlive their owner:
 
 ```bash
-xcrun devicectl list devices
+agent-device device status            # summarises; hides stale entries
+agent-device device status --stale    # shows them, e.g. owner-process-dead
 ```
 
-The default table shows an **Identifier** column. That is *not* what `--udid` takes. On
-any device that reports a hardware UDID, the selector is that UDID, not the Identifier
-shown on screen. Derive it with the query in `references/device-and-signing-queries.md`.
+A dead-owner claim from an earlier session lingers in this state. It is advisory, so it does
+not block on its own — but read it before concluding that something else is holding the device.
 
-**Always pass `--udid`.** Device resolution prefers *virtual* devices over physical ones,
-so on a machine with simulators installed a bare `--platform ios` silently targets a
-simulator instead of the real device. iPads resolve as `target=mobile`, same as iPhones.
+### The daemon captures the environment it was spawned with
 
-Confirm `developerModeStatus: enabled` — **`doctor` does not check this**, and will report
-no blockers on a device with it disabled. Enable on the device: Settings → Privacy &
-Security → Developer Mode. The device reboots and asks once more after unlock.
-
-Connect by cable for first setup — the alternative runner transport
-(`AGENT_DEVICE_IOS_RUNNER_ROUTE=usbmux`) is cable-only.
-
-### 2b. Device is unlocked — check it, do not assume it
-
-A locked device cannot be driven, and **`open` does not tell you.** `open` succeeding
-proves nothing about controllability, and the first real symptom is a timeout several
-steps later. Check the lock state directly instead:
-
-```bash
-xcrun devicectl device info lockState --device <udid>
-# passcodeRequired: true  -> currently LOCKED, control will time out
-# passcodeRequired: false -> currently unlocked
-```
-
-`passcodeRequired` is a live lock readout, not the static "is a passcode configured"
-setting. Do not confuse it with `unlockedSinceBoot`, which stays `true` after the first
-unlock and says nothing about the present moment.
-
-Recovery needs no daemon restart: unlocking the device and re-running the same command in
-the same session succeeds.
-
-Because a Face ID device unlocks the instant its owner looks at it, "the screen was off"
-and "the device was locked" are easy to conflate while sitting next to it. Remove the
-variable for the whole run rather than watching it — on the device, Settings → Display &
-Brightness → Auto-Lock → Never, restored afterwards.
-
-### 3. Developer disk image mounts
-
-```bash
-xcrun devicectl device info details --device <udid>
-```
-
-Success prints device details. Failure prints
-`The developer disk image could not be mounted on this device. (com.apple.dt.CoreDeviceError error 12040)`
-and nothing downstream will work — not `open`, not the runner install.
-
-If it fails while pairing, Developer Mode, cable, and network to Apple are all healthy:
-**open Xcode → Window → Devices and Simulators and select the device.** That window drives
-the device-preparation flow. Treat this as an effective step rather than an established
-mechanism.
-
-Do **not** jump to "Xcode is too old for this iOS version" without evidence. The DDI's
-`ProductBuildVersion` is Xcode's own build number, not an iOS build number — the two are
-not on a comparable scale, and a version-mismatch reading built on comparing them is
-unfounded.
-
-### 4. macOS developer tools authorized (undocumented upstream)
-
-The `sudo` line changes machine state and requires a password — **ask the user to run it
-themselves; never run it unattended.** Reverse with `sudo DevToolsSecurity -disable`.
-
-```bash
-DevToolsSecurity -status        # read-only
-sudo DevToolsSecurity -enable   # WRITES: persistent system setting, needs the user's password
-```
-
-UI test runners start suspended until `testmanagerd` attaches. With this disabled the
-runner never wakes and `snapshot` fails with
-`Developer mode is disabled for Apple development tools`.
-
-### 5. Signing team ID — read the certificate's `OU`, not its `CN`
-
-```bash
-security find-identity -v -p codesigning
-# Note the 40-hex hash of the identity you will actually sign with.
-# `find-certificate -c` matches the CN as a substring and returns only the first hit, so
-# select by that hash instead — two teams give one person two certs with the same CN.
-security find-certificate -a -c "<identity CN>" -p \
-  | awk '/BEGIN CERT/{n++} n{print > ("/tmp/ad-cert-" n ".pem")}'
-for f in /tmp/ad-cert-*.pem; do
-  openssl x509 -in "$f" -noout -fingerprint -sha1 -subject
-done
-rm -f /tmp/ad-cert-*.pem
-```
-
-Match the fingerprint to the identity hash above, then read the `OU` off *that* certificate's
-subject.
-
-The subject looks like:
-
-```
-UID=..., CN=Apple Development: Some Name (AAAAAAAAAA), OU=BBBBBBBBBB, O=..., C=US
-```
-
-`AAAAAAAAAA` in the `CN` parenthetical is the developer's individual id. **The team id is
-`OU`.** Passing the parenthetical yields
-`error: No Account for Team "AAAAAAAAAA"` plus `No profiles for 'com.callstack.agentdevice.runner' were found`,
-which reads like a provisioning problem and is not one.
-
-Set the bundle id too. `agent-device help physical-device` asks for both of these and only
-these, and for a bundle id **you** own — the shared default belongs to callstack's team, and
-your team may not be allowed to sign it:
-
-```bash
-export AGENT_DEVICE_IOS_TEAM_ID=<the OU value>
-export AGENT_DEVICE_IOS_BUNDLE_ID=com.yourname.agentdevice.runner
-```
-
-Both messages above, and the install failure in item 6, carry whichever bundle id is in
-effect — the callstack default while `AGENT_DEVICE_IOS_BUNDLE_ID` is unset, your own id once
-it is set.
-
-Do not infer "no Apple account is signed in" from
-`defaults read com.apple.dt.Xcode IDEProvisioningTeams` returning *does not exist* —
-Xcode 26 does not populate that legacy key even with an account present. Check
-Xcode → Settings → Accounts instead.
-
-### 6. Target device is covered by a provisioning profile
-
-**agent-device will not register a device for you.** It builds the runner with
-`-destination generic/platform=iOS` — no target device — so automatic signing has nothing
-to register, silently picks whatever profile exists, and the mismatch does not surface
-until install:
-
-```
-Failed to install embedded profile for com.callstack.agentdevice.runner.uitests.xctrunner
-: 0xe8008012 (This provisioning profile cannot be installed on this device.)
-```
-
-Check coverage before running anything, with the query in
-`references/device-and-signing-queries.md`.
-
-If nothing covers it, register from the CLI — a **concrete** destination plus both
-provisioning flags. `-allowProvisioningUpdates` alone is not enough; it creates and
-updates profiles but does not register devices:
-
-**This writes to the Apple Developer account.** It consumes one of the 100 annual device slots
-for that device type, and registrations are not freely removable until membership renewal.
-Ask the user before running it and wait for their answer — do not run it on your own initiative.
-
-Two things this command has to be told, because neither reaches it on its own.
-
-Resolve the runner project from the binary you validated in item 1 rather than from
-`npm root -g`, which assumes npm was the installer — then confirm the project is actually
-there before building. If that check fails, this install is laid out differently and you
-locate `AgentDeviceRunner.xcodeproj` inside the installed package yourself; do not build
-against a guess.
-
-Pass the bundle id as a build setting too. `AGENT_DEVICE_IOS_BUNDLE_ID` is read by
-`agent-device`, not by `xcodebuild` — the packaged project carries its own default
-(`AGENT_DEVICE_IOS_RUNNER_APP_BUNDLE_ID = com.callstack.agentdevice.runner`), so a raw build
-would register and sign the callstack id while every actual run uses yours. The test id
-derives from it inside the project, so setting the one setting covers both.
-
-```bash
-AD_ROOT=$(dirname "$(dirname "$(readlink -f "$(command -v agent-device)")")")
-PROJ="$AD_ROOT/dist/apple/runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj"
-[ -d "$PROJ" ] || echo "not at $PROJ — find it inside the installed package before continuing"
-
-xcodebuild build-for-testing \
-  -project "$PROJ" \
-  -scheme AgentDeviceRunner \
-  -destination "platform=iOS,id=<target udid>" \
-  -derivedDataPath /tmp/ad-register-dd \
-  -allowProvisioningUpdates -allowProvisioningDeviceRegistration \
-  CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=<OU value> \
-  AGENT_DEVICE_IOS_RUNNER_APP_BUNDLE_ID=<the AGENT_DEVICE_IOS_BUNDLE_ID value>
-```
-
-Two things to expect:
-
-- The build may end with
-  `error: Build input file cannot be found: '...<uuid>.mobileprovision'`. That is a race —
-  the newly issued profile replaced the one the build had already resolved. **Registration
-  still succeeded**; re-run the coverage query rather than re-reading the exit code.
-- With a concrete destination xcodebuild states the real problem plainly
-  (`Device "X" isn't registered in your developer account`). That diagnostic never appears
-  through agent-device's generic-destination build. To get it without spending a device slot,
-  run the same command with `-allowProvisioningDeviceRegistration` removed. That is cheaper,
-  not free: `-allowProvisioningUpdates` still creates and updates profiles, App IDs, and
-  certificates in the account, exactly as stated above. It stays under the same ask-first
-  gate — only the irreversible device slot is off the table.
-
-### 7. Runner build cache is not device-aware
-
-The derived-data cache key covers the team id but **not the target device or the profile
-identity**, so a runner signed against one device's profile is reused verbatim for another.
-After fixing anything signing-related — team id, device registration, profile refresh —
-clear the cache or the old artifact is silently reused:
-
-```bash
-ls ~/.agent-device/apple-runner/derived/ios-device/          # cache-<hash> dirs
-mv ~/.agent-device/apple-runner/derived/ios-device/cache-<hash> /tmp/   # reversible
-```
-
-Confirm what a built runner is actually signed for with the query in
-`references/device-and-signing-queries.md`.
-
-### 8. Daemon environment freshness
-
-The daemon starts lazily on the first command and **captures the environment it was spawned
-with**. Exporting a corrected `AGENT_DEVICE_IOS_TEAM_ID` into your shell does nothing for an
-already-running daemon: it keeps building with the stale value, and the identical error
-repeats as if the fix had not been applied.
-
-Confirm what the daemon actually used. `agent-device` passes both the team and the runner
-bundle id to `xcodebuild` as build settings, and that command line is echoed in the runner log,
-so check for both — a daemon carrying the right team and a stale bundle id passes a team-only
-check and still builds the wrong runner:
-
-```bash
-grep 'build-for-testing' ~/.agent-device/sessions/<session>/runner.log | tail -1 \
-  | grep -oE '(DEVELOPMENT_TEAM|AGENT_DEVICE_IOS_RUNNER_APP_BUNDLE_ID)=[^ ]+'
-```
-
-The log is appended to rather than truncated per build, so it holds every value this session
-has ever built with — including the ones from before you corrected the environment. Read only
-the last `build-for-testing` line: scanning the whole file returns those stale values alongside
-the corrected ones, and a build that succeeded after the restart would still read as a
-mismatch.
-
-Two lines that both match your shell mean the daemon is current. **Anything else — one line,
-no lines, no log yet, or a value you do not recognise — means restart, not proceed.** A setting
-the daemon never received leaves nothing in the log to disagree with, so an empty result is the
-one outcome that reads like a pass and is not.
-
-To restart the daemon:
+The daemon starts lazily on the first command and keeps the environment it was spawned with.
+Exporting a corrected `AGENT_DEVICE_*` value into your shell does nothing for an
+already-running daemon.
 
 ```bash
 agent-device daemon stop   # there is no `daemon start`; the next command respawns it
 ```
 
-Same trap for every other `AGENT_DEVICE_*` variable.
+`references/ios-preflight.md` item 7 covers which variables this actually bites on there, and
+how to confirm what the daemon used. Android sets none of the `AGENT_DEVICE_*` variables this
+matters for, so its file carries no counterpart.
 
-## Sandbox
+### Sandbox
 
 The daemon binds to localhost, and in one sandboxed agent shell that failed with
 `listen EPERM`. Because `doctor` starts the daemon too, the failure strands everything
 downstream of it.
 
-It is not a property of every sandbox. A later session ran `devices`, `doctor`, `open`,
-`snapshot`, and `close` entirely inside a sandboxed agent shell, and the daemon started
-and stayed up throughout. So treat `listen EPERM` as the signal to re-run that shell
-unsandboxed, rather than moving all agent-device work out of the sandbox pre-emptively.
+It is not a property of every sandbox — a full run has since gone through one untouched. So
+treat `listen EPERM` as the signal to re-run that shell unsandboxed, rather than moving all
+agent-device work out of the sandbox pre-emptively.
 
-## Verify
+## Handoff
 
-A first snapshot taking 20–30s is normal; the CLI warns about it itself. The first physical
-run builds and installs a signed XCTest runner
-(`AgentDeviceRunnerUITests-Runner`, bundle id `<AGENT_DEVICE_IOS_BUNDLE_ID>.uitests.xctrunner`)
-onto the device — tell the user before you run this, and note that removing it is a
-home-screen delete.
-
-```bash
-export AGENT_DEVICE_IOS_TEAM_ID=<OU value>
-export AGENT_DEVICE_IOS_BUNDLE_ID=com.yourname.agentdevice.runner
-agent-device doctor --platform ios --udid <udid>
-agent-device open com.apple.Preferences --platform ios --udid <udid> --session preflight
-agent-device snapshot -i --session preflight
-agent-device close --session preflight
-```
-
-`doctor` passing proves less than it looks — it covers none of items 2 through 8. The snapshot is
-the real gate.
-
-Once this passes, hand off: `agent-device help workflow`.
-
-## Failure → cause
-
-Each row names the cause this file has evidence for, not the only cause the symptom can have.
-Where a row names more than one, work them in order.
-
-| Symptom | Cause | Section |
-|---|---|---|
-| `Daemon request timed out` on `snapshot`, after `open` reported success | device is locked | 2b |
-| `CoreDeviceError 12040`, DDI could not be mounted | device preparation not driven | 3 |
-| `Developer mode is disabled for Apple development tools` | macOS `DevToolsSecurity` off | 4 |
-| `No Account for Team "..."` | team id read from `CN` instead of `OU` | 5 |
-| `No profiles for ...were found` | wrong team id, or no profile Xcode can auto-select for this App ID and device; with both already correct, name the profile in `AGENT_DEVICE_IOS_PROVISIONING_PROFILE` (a profile name or specifier, not a path) | 5, 6 |
-| `0xe8008012 This provisioning profile cannot be installed on this device` | target device not in any profile | 6 |
-| Hint blames a heavy or animating screen | misleading in 0.20.3 — read `runner.log`; usually 6 | Reading failures |
-| Signing fix applied but the same error repeats | stale runner cache, or daemon holding stale env | 7, 8 |
-| Commands land on a simulator instead of the real device | `--udid` omitted; virtual devices win resolution | 2 |
-| `listen EPERM` | daemon started inside a sandbox | Sandbox |
-| `doctor` passes but `open`/`snapshot` fails | `doctor` covers only item 1 | — |
+Each platform file contains a Verify step. The snapshot is the real gate — `doctor` passing
+proves considerably less. Once it passes, hand off: `agent-device help workflow`.
 
 ## Scope not covered
 
-Android (`--test-ime` on real hardware, snapshot-helper APK auto-install, `adb reverse` for
-Metro), web, the remote/cloud lease providers, `proxy`, and the degraded legacy-XCTest tier
-for older devices are all outside this preflight.
-
-This preflight is verified against physical iOS devices (iPhone and iPad, CoreDevice tier)
-and the iOS simulator.
+Web, the remote/cloud lease providers, and `proxy` are outside this preflight on every
+platform. Platform-specific exclusions are named in each platform file, alongside the
+verification domain that file's evidence actually ranged over.

--- a/agent-device-preflight/skills/agent-device-preflight/SKILL.md
+++ b/agent-device-preflight/skills/agent-device-preflight/SKILL.md
@@ -312,9 +312,14 @@ Same trap for every other `AGENT_DEVICE_*` variable.
 
 ## Sandbox
 
-The daemon binds to localhost and fails with `listen EPERM` inside a sandbox. Any
-agent shell that sandboxes command execution must run agent-device work unsandboxed —
-including `doctor`, since it starts the daemon too.
+The daemon binds to localhost, and in one sandboxed agent shell that failed with
+`listen EPERM`. Because `doctor` starts the daemon too, the failure strands everything
+downstream of it.
+
+It is not a property of every sandbox. A later session ran `devices`, `doctor`, `open`,
+`snapshot`, and `close` entirely inside a sandboxed agent shell, and the daemon started
+and stayed up throughout. So treat `listen EPERM` as the signal to re-run that shell
+unsandboxed, rather than moving all agent-device work out of the sandbox pre-emptively.
 
 ## Verify
 

--- a/agent-device-preflight/skills/agent-device-preflight/references/android-preflight.md
+++ b/agent-device-preflight/skills/agent-device-preflight/references/android-preflight.md
@@ -1,0 +1,219 @@
+# Android Preflight
+
+Attachment prerequisites for a physical Android device.
+
+Read `SKILL.md` first. The CLI-version check, the sandbox note, session naming, stale
+device claims, and the daemon restart all live there and are not repeated here.
+
+**If you came from `ios-preflight.md`, read item 3 before you run anything.** Every item
+below that has an iOS counterpart inverts it — which selector works, whether signing is
+needed, how a locked device announces itself, and what a slow-snapshot warning means.
+Carrying an iOS habit across is the fastest way to lose a session here.
+
+## 1. Toolchain — `adb` on `PATH`, and nothing else
+
+No Android Studio and no full SDK. `platform-tools` is an SDK component, but it is the only
+one needed, and it can be installed on its own.
+
+Check before installing anything:
+
+```bash
+adb version
+```
+
+If that answers, this item is done — skip the install. If `adb` is not found, the smallest
+thing that satisfies the requirement is:
+
+```bash
+brew install --cask android-platform-tools   # WRITES: links adb, fastboot et al. into PATH
+```
+
+**Ask the user before running it and wait for their answer.** It needs no password and is
+reversible (`brew uninstall --cask android-platform-tools`), so this is a lighter gate than
+the iOS `sudo` and device-registration steps — but it still installs software on their
+machine, and choosing a package manager is theirs to make.
+
+The CLI resolves adb two ways and the second one is enough. `dist/src/manifest.js` looks
+under `ANDROID_HOME` / `ANDROID_SDK_ROOT` for `platform-tools`, and otherwise falls back to
+`adb` on `PATH`. With no SDK present at all, `doctor` reports
+
+```
+- toolchain: Android toolchain: Android Debug Bridge version 1.0.41; ANDROID_HOME unset.
+```
+
+and still passes. **`ANDROID_HOME unset` is a note, not a blocker** — do not go install an
+SDK because you saw it.
+
+## 2. USB debugging, and the authorization handshake
+
+On the device: Developer options → USB debugging. Then connect by cable and accept the
+on-device prompt ("Allow USB debugging?"), with "Always allow from this computer" checked.
+
+```bash
+adb devices -l
+```
+
+Declining that prompt — or never seeing it — does not produce an empty list. It produces:
+
+```
+<adb-serial>   unauthorized   usb:34603008X   transport_id:1
+```
+
+**Read the `usb:` and `transport_id:` fields before suspecting hardware.** Their presence
+means the transport is already working and only the authorization is outstanding; the cable,
+the port, and the USB-debugging toggle are all accounted for. `unauthorized` is a pending
+handshake, not a connection problem.
+
+The prompt only renders on an unlocked screen. A device plugged in while locked sits at
+`unauthorized` with no dialog to accept. Unlock, then re-plug.
+
+## 3. The selector is the display name, not the id — the inverse of iOS
+
+```bash
+agent-device devices --platform android --json
+```
+
+```json
+{ "platform": "android", "id": "<adb-serial>", "name": "Pixel 7", ... }
+```
+
+`id` is the adb serial. **`--device` rejects it and accepts `name`.** Verified on both
+`doctor` and `open`:
+
+| Passed | Result |
+|---|---|
+| `--device "Pixel 7"` | works |
+| `--device` omitted | works |
+| `--device <adb serial>` | fails |
+| `--udid <adb serial>` | fails |
+
+The failure is reported as:
+
+```
+⨯ device: No Android devices found.
+  run: agent-device devices --platform android
+```
+
+Both halves mislead. It reads as *no device is present* when one is connected and
+authorized, and the command it prescribes as the remedy is the one that disproves it —
+run it and the device is listed. Nothing about the message points at the selector, which
+is the actual cause.
+
+This is where an iOS reader lands hardest. `ios-preflight.md` item 1 says **always pass
+`--udid`**, because on iOS the on-screen Identifier is not the selector and omitting the
+flag silently targets a simulator. Both halves of that habit fail here: the serial-shaped
+id is the wrong thing to pass, and omitting the selector is fine.
+
+## 4. Device is unlocked — read it, do not assume it
+
+```bash
+adb shell dumpsys power | grep mWakefulness=
+adb shell dumpsys window | grep mDreamingLockscreen
+```
+
+On a working run:
+
+```
+mWakefulness=Awake
+mShowingDream=false mDreamingLockscreen=false
+```
+
+Unlike iOS — where a locked device lets `open` report success and only surfaces as a
+timeout several steps later — Android names the problem at the first command that needs
+the device. That makes the readout above a confirmation step rather than the diagnosis of
+an otherwise-silent failure.
+
+## 5. The snapshot helper is installed on the device
+
+A plain `snapshot` installs one package:
+
+```
+com.callstack.agentdevice.snapshothelper
+```
+
+`com.callstack.agentdevice.imehelper` did **not** appear after `open` + `snapshot` + `close`.
+That is the whole observation — the ordinary path did not install it. Why it did not, and
+what would, is untested here; `--test-ime` was never run (see *Scope not covered*). Both APKs
+ship inside the installed CLI at `android/{snapshot-helper,ime-helper}/dist/`.
+
+Tell the user before the first run — this puts an app on their device. Removal:
+
+```bash
+adb shell pm list packages | grep agentdevice
+adb uninstall com.callstack.agentdevice.snapshothelper
+```
+
+**No signing setup exists on Android.** callstack's own package ids are installed as-is.
+There is no counterpart to `AGENT_DEVICE_IOS_BUNDLE_ID`, no team id to derive, and no
+provisioning profile to cover the device — items 4 and 5 of the iOS preflight have no
+Android analogue at all.
+
+## 6. The first-snapshot slowness warning is noise
+
+A 2.1-second capture still printed:
+
+```
+Warning: android snapshots are slow in this run: p95 1925ms over 1 captures.
+Possible causes: device load, app or dev server stuck, helper fallback, or stale daemon.
+```
+
+A p95 over one sample is not a p95. On the first capture of a session there is no
+distribution to take a percentile of, so the warning fires on a healthy run and its list of
+"possible causes" sends you looking for a problem that is not there.
+
+Inverted from iOS again: there a first snapshot genuinely takes 20–30s and the CLI
+pre-announces it. Here the capture is roughly ten times faster and the CLI complains anyway.
+
+## 7. Choose the verification target deliberately
+
+`agent-device open com.android.settings` resumes the Settings screen that was last viewed
+rather than opening the root list, so the starting state is not deterministic between runs.
+
+In this session it resumed the device-information page, and the snapshot captured the
+device's IMEI, IP addresses, Wi-Fi MAC address, and Bluetooth address. **Snapshot output is
+transcript-visible**, so a verification target should be chosen for content that is not
+identifying — `com.android.settings` is not the neutral choice its iOS counterpart
+(`com.apple.Preferences`) is.
+
+## Verify
+
+```bash
+agent-device doctor --platform android --device "<display name>"
+agent-device open <package> --platform android --device "<display name>" --session preflight
+agent-device snapshot -i --session preflight
+agent-device close --session preflight
+```
+
+The snapshot is the gate. `doctor` passing tells you the device resolved and adb answered;
+it does not tell you the helper installed or that the accessibility capture works.
+
+Once this passes, hand off: `agent-device help workflow`.
+
+## Failure → cause
+
+Each row names the cause this file has evidence for, not the only cause the symptom can have.
+
+| Symptom | Cause | Section |
+|---|---|---|
+| `adb devices -l` reports `unauthorized`, with `usb:` and `transport_id:` present | RSA prompt never accepted; screen was locked when plugged in | 2 |
+| `⨯ device: No Android devices found.` while `agent-device devices --platform android` lists the device | adb serial passed as the selector — pass the display name | 3 |
+| `⨯ device: No Android devices found.` and `adb devices` is also empty | not connected, or USB debugging off | 1, 2 |
+| `p95 ... over 1 captures` on the first snapshot | statistic over a single sample; not a signal | 6 |
+| Snapshot contains IMEI / MAC / IP | Settings resumed a device-information page | 7 |
+| `ANDROID_HOME unset` in `doctor` output | a note; adb on `PATH` already satisfies the toolchain | 1 |
+
+## Scope not covered
+
+Named rather than guessed at — none of these were exercised:
+
+- **Emulator / AVD.** No emulator was installed, so the iOS hazard where virtual devices
+  win device resolution is **untested** on Android. Do not assume it does or does not apply.
+- **`--test-ime`** and the IME helper install path.
+- **React Native / Expo Metro reachability** (`adb reverse`).
+- **Whether the beta OS build affects any of the above** — see the verification domain below.
+
+## Verification domain
+
+Verified against a Pixel 7 (`panther_beta`) on Android 17 / API 37, with agent-device 0.20.3
+and adb 37.0.1, through `devices`, `doctor`, `open`, `snapshot`, and `close`. One device, one
+OS build, one CLI version — nothing here is claimed beyond that.

--- a/agent-device-preflight/skills/agent-device-preflight/references/ios-device-and-signing-queries.md
+++ b/agent-device-preflight/skills/agent-device-preflight/references/ios-device-and-signing-queries.md
@@ -1,6 +1,8 @@
 # Device and Signing Queries
 
-Read-only queries the preflight steps call for.
+Queries the iOS preflight steps call for. None of them changes the device, the Apple Developer
+account, or any project state — but they do write and remove fixed `/tmp` paths, so they are
+read-only with respect to what you are diagnosing, not to the filesystem.
 
 ## Deriving the device UDID
 
@@ -27,8 +29,8 @@ for the target team, and for both App IDs the runner needs.
 
 ```bash
 UDID=<target udid>
-TEAM=<the OU value from step 5>
-BUNDLE=<the AGENT_DEVICE_IOS_BUNDLE_ID value from step 5>
+TEAM=<the OU value from ios-preflight.md item 4>
+BUNDLE=<the AGENT_DEVICE_IOS_BUNDLE_ID value from ios-preflight.md item 4>
 for f in ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*.mobileprovision; do
   security cms -D -i "$f" > /tmp/p.plist 2>/dev/null && python3 -c "
 import plistlib, fnmatch
@@ -50,8 +52,8 @@ is printed: it is the pattern the runner's identifier has to match.
 
 You need **both** the `runner` and `uitests` columns true, across the profiles you have. One
 wildcard profile (`app id` ending in `.*`) satisfies both at once; an explicit profile names a
-single App ID, so two of them are needed between them. Nothing covering both means the
-registration step below is still owed.
+single App ID, so two of them are needed between them. Nothing covering both means the device
+registration in `ios-preflight.md` item 5 is still owed — it is not in this file.
 
 ## Confirming what a built runner is signed for
 

--- a/agent-device-preflight/skills/agent-device-preflight/references/ios-preflight.md
+++ b/agent-device-preflight/skills/agent-device-preflight/references/ios-preflight.md
@@ -1,0 +1,304 @@
+# iOS Preflight
+
+Attachment prerequisites for a physical iOS device. The simulator is not a target for this
+preflight — it appears only as the thing that silently wins device resolution (item 1), and as
+the secondary surface some of this file's evidence came from (see *Verification domain*).
+
+Read `SKILL.md` first. The CLI-version check, the sandbox note, session naming, stale
+device claims, and the daemon restart all live there and are not repeated here.
+
+Run the items below in order. Each check is read-only except where marked.
+
+## Reading failures
+
+**Read `runner.log`, not just the hint.** On a signing/install failure the released CLI can
+surface `The current screen is overwhelming the iOS accessibility capture (usually heavy or
+animating content)` and suggest changing screens. Observed: that hint appeared for a pure
+code-signing install failure; the screen was never the problem, and the exact same screen
+captured 49 nodes once signing was fixed. The real cause was in
+`~/.agent-device/sessions/<session>/runner.log`. The released 0.20.3 still surfaces this
+misleading hint.
+
+## 1. Device visible, and the selector you will actually pass
+
+```bash
+xcrun devicectl list devices
+```
+
+The default table shows an **Identifier** column. That is *not* what `--udid` takes. On any
+device that reports a hardware UDID, the selector is that UDID, not the Identifier shown on
+screen. Derive it with the query in `references/ios-device-and-signing-queries.md`.
+
+**Always pass `--udid`.** Device resolution prefers *virtual* devices over physical ones, so
+on a machine with simulators installed a bare `--platform ios` silently targets a simulator
+instead of the real device. iPads resolve as `target=mobile`, same as iPhones.
+
+Confirm `developerModeStatus: enabled` — **`doctor` does not check this**, and will report no
+blockers on a device with it disabled. **WRITES — device setting:** enable on the device at
+Settings → Privacy & Security → Developer Mode. The device reboots and asks once more after
+unlock, so do this with the user's knowledge rather than mid-run.
+
+Connect by cable for first setup — the alternative runner transport
+(`AGENT_DEVICE_IOS_RUNNER_ROUTE=usbmux`) is cable-only.
+
+## 1b. Device is unlocked — check it, do not assume it
+
+A locked device cannot be driven, and **`open` does not tell you.** `open` succeeding proves
+nothing about controllability, and the first real symptom is a timeout several steps later.
+Check the lock state directly instead:
+
+```bash
+xcrun devicectl device info lockState --device <udid>
+# passcodeRequired: true  -> currently LOCKED, control will time out
+# passcodeRequired: false -> currently unlocked
+```
+
+`passcodeRequired` is a live lock readout, not the static "is a passcode configured" setting.
+Do not confuse it with `unlockedSinceBoot`, which stays `true` after the first unlock and says
+nothing about the present moment.
+
+Recovery needs no daemon restart: unlocking the device and re-running the same command in the
+same session succeeds.
+
+Because a Face ID device unlocks the instant its owner looks at it, "the screen was off" and
+"the device was locked" are easy to conflate while sitting next to it. Remove the variable for
+the whole run rather than watching it — **WRITES — device setting:** on the device, Settings →
+Display & Brightness → Auto-Lock → Never. Restore the previous value afterwards; it is the
+user's device and this one does not revert on its own.
+
+## 2. Developer disk image mounts
+
+```bash
+xcrun devicectl device info details --device <udid>
+```
+
+Success prints device details. Failure prints
+`The developer disk image could not be mounted on this device. (com.apple.dt.CoreDeviceError error 12040)`
+and nothing downstream will work — not `open`, not the runner install.
+
+If it fails while pairing, Developer Mode, cable, and network to Apple are all healthy:
+**open Xcode → Window → Devices and Simulators and select the device.** That window drives the
+device-preparation flow. Treat this as an effective step rather than an established mechanism.
+
+Do **not** jump to "Xcode is too old for this iOS version" without evidence. The DDI's
+`ProductBuildVersion` is Xcode's own build number, not an iOS build number — the two are not on
+a comparable scale, and a version-mismatch reading built on comparing them is unfounded.
+
+## 3. macOS developer tools authorized (undocumented upstream)
+
+The `sudo` line changes machine state and requires a password — **ask the user to run it
+themselves; never run it unattended.** Reverse with `sudo DevToolsSecurity -disable`.
+
+```bash
+DevToolsSecurity -status        # read-only
+sudo DevToolsSecurity -enable   # WRITES: persistent system setting, needs the user's password
+```
+
+UI test runners start suspended until `testmanagerd` attaches. With this disabled the runner
+never wakes and `snapshot` fails with `Developer mode is disabled for Apple development tools`.
+
+## 4. Signing team ID — read the certificate's `OU`, not its `CN`
+
+```bash
+security find-identity -v -p codesigning
+# Note the 40-hex hash of the identity you will actually sign with.
+# `find-certificate -c` matches the CN as a substring and returns only the first hit, so
+# select by that hash instead — two teams give one person two certs with the same CN.
+security find-certificate -a -c "<identity CN>" -p \
+  | awk '/BEGIN CERT/{n++} n{print > ("/tmp/ad-cert-" n ".pem")}'
+for f in /tmp/ad-cert-*.pem; do
+  openssl x509 -in "$f" -noout -fingerprint -sha1 -subject
+done
+rm -f /tmp/ad-cert-*.pem
+```
+
+Match the fingerprint to the identity hash above, then read the `OU` off *that* certificate's
+subject.
+
+The subject looks like:
+
+```
+UID=..., CN=Apple Development: Some Name (AAAAAAAAAA), OU=BBBBBBBBBB, O=..., C=US
+```
+
+`AAAAAAAAAA` in the `CN` parenthetical is the developer's individual id. **The team id is
+`OU`.** Passing the parenthetical yields
+`error: No Account for Team "AAAAAAAAAA"` plus `No profiles for 'com.callstack.agentdevice.runner' were found`,
+which reads like a provisioning problem and is not one.
+
+Set the bundle id too. `agent-device help physical-device` asks for both of these and only
+these, and for a bundle id **you** own — the shared default belongs to callstack's team, and
+your team may not be allowed to sign it:
+
+```bash
+export AGENT_DEVICE_IOS_TEAM_ID=<the OU value>
+export AGENT_DEVICE_IOS_BUNDLE_ID=com.yourname.agentdevice.runner
+```
+
+Both messages above, and the install failure in item 5, carry whichever bundle id is in effect
+— the callstack default while `AGENT_DEVICE_IOS_BUNDLE_ID` is unset, your own id once it is set.
+
+Do not infer "no Apple account is signed in" from
+`defaults read com.apple.dt.Xcode IDEProvisioningTeams` returning *does not exist* — Xcode 26
+does not populate that legacy key even with an account present. Check Xcode → Settings →
+Accounts instead.
+
+## 5. Target device is covered by a provisioning profile
+
+**agent-device will not register a device for you.** It builds the runner with
+`-destination generic/platform=iOS` — no target device — so automatic signing has nothing to
+register, silently picks whatever profile exists, and the mismatch does not surface until
+install:
+
+```
+Failed to install embedded profile for com.callstack.agentdevice.runner.uitests.xctrunner
+: 0xe8008012 (This provisioning profile cannot be installed on this device.)
+```
+
+Check coverage before running anything, with the query in
+`references/ios-device-and-signing-queries.md`.
+
+If nothing covers it, register from the CLI — a **concrete** destination plus both provisioning
+flags. `-allowProvisioningUpdates` alone is not enough; it creates and updates profiles but does
+not register devices:
+
+**This writes to the Apple Developer account.** It consumes one of the 100 annual device slots
+for that device type, and registrations are not freely removable until membership renewal. Ask
+the user before running it and wait for their answer — do not run it on your own initiative.
+
+Two things this command has to be told, because neither reaches it on its own.
+
+Resolve the runner project from the binary you validated in the CLI check rather than from
+`npm root -g`, which assumes npm was the installer — then confirm the project is actually there
+before building. If that check fails, this install is laid out differently and you locate
+`AgentDeviceRunner.xcodeproj` inside the installed package yourself; do not build against a guess.
+
+Pass the bundle id as a build setting too. `AGENT_DEVICE_IOS_BUNDLE_ID` is read by
+`agent-device`, not by `xcodebuild` — the packaged project carries its own default
+(`AGENT_DEVICE_IOS_RUNNER_APP_BUNDLE_ID = com.callstack.agentdevice.runner`), so a raw build
+would register and sign the callstack id while every actual run uses yours. The test id derives
+from it inside the project, so setting the one setting covers both.
+
+```bash
+AD_ROOT=$(dirname "$(dirname "$(readlink -f "$(command -v agent-device)")")")
+PROJ="$AD_ROOT/dist/apple/runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj"
+[ -d "$PROJ" ] || echo "not at $PROJ — find it inside the installed package before continuing"
+
+xcodebuild build-for-testing \
+  -project "$PROJ" \
+  -scheme AgentDeviceRunner \
+  -destination "platform=iOS,id=<target udid>" \
+  -derivedDataPath /tmp/ad-register-dd \
+  -allowProvisioningUpdates -allowProvisioningDeviceRegistration \
+  CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=<OU value> \
+  AGENT_DEVICE_IOS_RUNNER_APP_BUNDLE_ID=<the AGENT_DEVICE_IOS_BUNDLE_ID value>
+```
+
+Two things to expect:
+
+- The build may end with
+  `error: Build input file cannot be found: '...<uuid>.mobileprovision'`. That is a race — the
+  newly issued profile replaced the one the build had already resolved. **Registration still
+  succeeded**; re-run the coverage query rather than re-reading the exit code.
+- With a concrete destination xcodebuild states the real problem plainly
+  (`Device "X" isn't registered in your developer account`). That diagnostic never appears
+  through agent-device's generic-destination build. To get it without spending a device slot,
+  run the same command with `-allowProvisioningDeviceRegistration` removed. That is cheaper, not
+  free: `-allowProvisioningUpdates` still creates and updates profiles, App IDs, and certificates
+  in the account, exactly as stated above. It stays under the same ask-first gate — only the
+  irreversible device slot is off the table.
+
+## 6. Runner build cache is not device-aware
+
+The derived-data cache key covers the team id but **not the target device or the profile
+identity**, so a runner signed against one device's profile is reused verbatim for another.
+After fixing anything signing-related — team id, device registration, profile refresh — clear
+the cache or the old artifact is silently reused:
+
+```bash
+ls ~/.agent-device/apple-runner/derived/ios-device/          # cache-<hash> dirs
+mv ~/.agent-device/apple-runner/derived/ios-device/cache-<hash> /tmp/   # reversible
+```
+
+Confirm what a built runner is actually signed for with the query in
+`references/ios-device-and-signing-queries.md`.
+
+## 7. Daemon carries stale signing environment
+
+`SKILL.md` covers the general fact — the daemon captures the environment it was spawned with,
+and `agent-device daemon stop` is the restart. This item is what that costs you on iOS:
+exporting a corrected `AGENT_DEVICE_IOS_TEAM_ID` into your shell does nothing for an
+already-running daemon. It keeps building with the stale value, and the identical error repeats
+as if the fix had not been applied.
+
+Confirm what the daemon actually used. `agent-device` passes both the team and the runner bundle
+id to `xcodebuild` as build settings, and that command line is echoed in the runner log, so check
+for both — a daemon carrying the right team and a stale bundle id passes a team-only check and
+still builds the wrong runner:
+
+```bash
+grep 'build-for-testing' ~/.agent-device/sessions/<session>/runner.log | tail -1 \
+  | grep -oE '(DEVELOPMENT_TEAM|AGENT_DEVICE_IOS_RUNNER_APP_BUNDLE_ID)=[^ ]+'
+```
+
+The log is appended to rather than truncated per build, so it holds every value this session has
+ever built with — including the ones from before you corrected the environment. Read only the
+last `build-for-testing` line: scanning the whole file returns those stale values alongside the
+corrected ones, and a build that succeeded after the restart would still read as a mismatch.
+
+Two lines that both match your shell mean the daemon is current. **Anything else — one line, no
+lines, no log yet, or a value you do not recognise — means restart, not proceed.** A setting the
+daemon never received leaves nothing in the log to disagree with, so an empty result is the one
+outcome that reads like a pass and is not.
+
+Same trap for every other `AGENT_DEVICE_*` variable.
+
+## Verify
+
+A first snapshot taking 20–30s is normal; the CLI warns about it itself. The first physical run
+builds and installs a signed XCTest runner
+(`AgentDeviceRunnerUITests-Runner`, bundle id `<AGENT_DEVICE_IOS_BUNDLE_ID>.uitests.xctrunner`)
+onto the device — tell the user before you run this, and note that removing it is a home-screen
+delete.
+
+```bash
+export AGENT_DEVICE_IOS_TEAM_ID=<OU value>
+export AGENT_DEVICE_IOS_BUNDLE_ID=com.yourname.agentdevice.runner
+agent-device doctor --platform ios --udid <udid>
+agent-device open com.apple.Preferences --platform ios --udid <udid> --session preflight
+agent-device snapshot -i --session preflight
+agent-device close --session preflight
+```
+
+`doctor` passing proves less than it looks — it covers none of items 1 through 7. The snapshot is
+the real gate.
+
+Once this passes, hand off: `agent-device help workflow`.
+
+## Failure → cause
+
+Each row names the cause this file has evidence for, not the only cause the symptom can have.
+Where a row names more than one, work them in order.
+
+| Symptom | Cause | Section |
+|---|---|---|
+| `Daemon request timed out` on `snapshot`, after `open` reported success | device is locked | 1b |
+| `CoreDeviceError 12040`, DDI could not be mounted | device preparation not driven | 2 |
+| `Developer mode is disabled for Apple development tools` | macOS `DevToolsSecurity` off | 3 |
+| `No Account for Team "..."` | team id read from `CN` instead of `OU` | 4 |
+| `No profiles for ...were found` | wrong team id, or no profile Xcode can auto-select for this App ID and device; with both already correct, name the profile in `AGENT_DEVICE_IOS_PROVISIONING_PROFILE` (a profile name or specifier, not a path) | 4, 5 |
+| `0xe8008012 This provisioning profile cannot be installed on this device` | target device not in any profile | 5 |
+| Hint blames a heavy or animating screen | misleading in 0.20.3 — read `runner.log`; usually 5 | Reading failures |
+| Signing fix applied but the same error repeats | stale runner cache, or daemon holding stale env | 6, 7 |
+| Commands land on a simulator instead of the real device | `--udid` omitted; virtual devices win resolution | 1 |
+| `listen EPERM` | daemon started inside a sandbox | `SKILL.md` § Sandbox |
+| `doctor` passes but `open`/`snapshot` fails | `doctor` covers only the CLI check | — |
+
+## Scope not covered
+
+Web, the remote/cloud lease providers, `proxy`, and the degraded legacy-XCTest tier for older
+devices are all outside this preflight.
+
+## Verification domain
+
+Verified against physical iOS devices (iPhone and iPad, CoreDevice tier) and the iOS simulator.


### PR DESCRIPTION
Adds Android to `agent-device-preflight`, written from an actual physical-device
session on a Pixel 7 rather than from upstream docs — upstream's entire Android
guidance is two lines.

## Headline finding: the selector inverts

On iOS the rule is **always pass `--udid`**, because the on-screen Identifier is not
the selector and omitting the flag silently targets a simulator.

On Android that habit fails twice over. `agent-device devices --platform android --json`
returns `{"id": "<adb serial>", "name": "Pixel 7"}` — and `--device` **rejects the `id`
and accepts the `name`**:

| Passed | Result |
|---|---|
| `--device "Pixel 7"` | works |
| `--device` omitted | works |
| `--device <adb serial>` | fails |
| `--udid <adb serial>` | fails |

The failure is reported as `⨯ device: No Android devices found.` followed by
`run: agent-device devices --platform android` — which reads as "no device present"
and prescribes the one command that disproves it. Verified on both `doctor` and `open`.

That inversion is why the split below routes to **exactly one** platform file rather
than presenting both.

## Structure

SKILL.md carried the whole iOS preflight inline (368 lines) and named Android as out of
scope. Adding Android inline would have pushed one always-loaded file past 500 lines.

```
SKILL.md (131)                      routing + what both platforms share
references/ios-preflight.md (300)   items 2–8, signing, iOS failure table
references/ios-device-and-signing-queries.md   (git mv, unchanged)
references/android-preflight.md (204)          new
```

SKILL.md keeps the CLI version check, session naming (the default session name derives
from a cwd hash), stale device claims, daemon environment capture, and the sandbox note.

## Commits

- `c63adfb` — narrows the Sandbox claim. It asserted that *any* sandboxing agent shell
  must run all agent-device work unsandboxed; this session ran `devices`, `doctor`,
  `open`, `snapshot`, and `close` inside a sandboxed shell with the daemon up throughout.
  `listen EPERM` stays as a real observation, now scoped to where it was seen.
- `dfa44c9` — the split and the Android reference.

## Other Android findings

- adb on `PATH` is the entire toolchain requirement — no Android Studio, no SDK.
  `ANDROID_HOME unset` is a `doctor` note, not a blocker.
- `unauthorized` in `adb devices -l` still shows `usb:` and `transport_id:`, which is
  what separates a pending RSA handshake from a cable/port problem.
- A plain `snapshot` installs only `com.callstack.agentdevice.snapshothelper`; the IME
  helper is gated behind `--test-ime`. No signing setup exists on Android at all.
- The first-capture slowness warning computes a p95 over one sample and fires on a
  healthy 2.1s run.
- `open com.android.settings` resumes the last-viewed Settings screen — in this run the
  device-information page, so the snapshot pulled IMEI, MAC, and IP into the transcript.
  Not the neutral verification target its iOS counterpart is.

## Not covered

Emulator/AVD, `--test-ime`, and Metro `adb reverse` are **named as untested**, not written
from documentation. In particular the iOS hazard where virtual devices win device
resolution is unverified on Android — no emulator was installed. Each platform file now
closes with the verification domain its evidence actually ranged over; the Android one is
one device (Pixel 7, `panther_beta`, Android 17 / API 37), agent-device 0.20.3, adb 37.0.1.
