### PR TITLE
restore(google): bring back veo skill, re-authed to Gemini API key

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "google",
       "source": "./google",
-      "description": "Google Gemini video understanding"
+      "description": "Google Gemini video understanding, Veo video generation"
     },
     {
       "name": "claude-code-internals",

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding, Veo video generation",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding, Veo video generation",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
-  "description": "Google Gemini video understanding",
-  "version": "2.0.1",
+  "description": "Google Gemini video understanding, Veo video generation",
+  "version": "2.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding, Veo video generation",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding, Veo video generation",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding, Veo video generation",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/.claude-plugin/plugin.json
+++ b/google/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "google",
   "description": "Google Gemini video understanding, Veo video generation",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/google/skills/veo/SKILL.md
+++ b/google/skills/veo/SKILL.md
@@ -9,23 +9,19 @@ description: |
 
   Not the default for a plain "generate a video" / "make a video from this
   photo" request with no Veo-specific control named — prefer Gemini Omni
-  Flash for that (Google's current default for video generation: better
-  coherence, multi-input reasoning, character consistency, multi-turn
-  editing). Reach for this skill only when the task specifically needs
-  Veo's own controls.
+  Flash for that. Reach for this skill only when the task specifically
+  needs Veo's own controls.
 context: fork
 model: sonnet
 ---
 
 # Veo Video Generation
 
-Generate video with Google Veo 3.1 via the Gemini API, with cinematography
+Generate video with Google Veo via the Gemini API, with cinematography
 control and synchronized audio.
 
-Not the default video-generation route: a plain "generate a video of X" is
-Gemini Omni Flash's job, which leads on coherence, multi-input reasoning,
-character consistency, and multi-turn editing. Come here for Veo's own
-controls.
+Not the default video-generation route — a plain "generate a video of X"
+goes to Gemini Omni Flash. Come here for Veo's own controls.
 
 ```bash
 export GEMINI_API_KEY="your-api-key"
@@ -33,7 +29,6 @@ SCRIPT="${CLAUDE_PLUGIN_ROOT}/skills/veo/scripts/generate_video.py"
 
 uv run "$SCRIPT" "A neon hologram of a cat driving at top speed"
 uv run "$SCRIPT" "Slow dolly shot, cinematic lighting" --image photo.jpg
-uv run "$SCRIPT" "Zoom out to reveal the skyline" --model veo-3.1-fast-generate-preview --duration 4 --resolution 720p
 ```
 
 The path goes through `CLAUDE_PLUGIN_ROOT` because this runs with the
@@ -41,7 +36,12 @@ user's project as the working directory, not this one. A bare relative
 path does not resolve.
 
 The script declares its own dependency inline (PEP 723), so `uv run`
-resolves it; there is no install step. `--help` carries the current flags.
+resolves it; there is no install step.
+
+`--help` is the list of model variants, durations, and resolutions the
+script accepts. It is generated from the code, so it is current in a way
+this page cannot be — read it before choosing flags, and do not take a
+variant name from prose anywhere.
 
 The script covers text-to-video and image-to-video, and nothing else.
 Video extension, first/last-frame transitions, and ingredients-to-video
@@ -51,35 +51,34 @@ prompt text to adapt in place, in
 [references/api-examples.md](references/api-examples.md) and
 [references/prompting-guide.md](references/prompting-guide.md).
 
-## Choosing a Veo variant
+## Variant, duration, resolution — read the model table, not this page
 
-| Model | Use when |
-|---|---|
-| `veo-3.1-generate-preview` | Best fidelity, production/hero shots |
-| `veo-3.1-fast-generate-preview` | Faster iteration, drafts |
-| `veo-3.1-lite-generate-preview` | Cheapest, quick previews, high volume |
+Three things about a Veo generation are decided together, and all three
+move with each Veo release. No figures are given here on purpose; what
+follows is what to look up and where.
 
-Lite is not just a cheaper tier of the same thing — it takes no video input
-and no reference images, so video extension and ingredients-to-video are off
-the table there. All three are preview models.
+**The variants are not one model at several prices.** They differ in
+which *inputs* they accept, so a workflow needing a source video or
+reference images can be unavailable on a cheaper rung whatever its price
+per second. Check the accepted inputs before designing around a variant,
+not after.
 
-Price scales per second of output, and resolution is the lever that moves it
-(720p, or 1080p and 4k at 8 seconds). Audio is not a second lever on this
-model line — Veo 3.1 always generates it. Check
-[Google's Vertex AI generative-AI pricing page](https://cloud.google.com/vertex-ai/generative-ai/pricing)
-for the current per-second figures before a spend decision — a number
-copied here would go stale silently.
+**Duration and resolution are not independent.** The higher resolutions
+are offered at a restricted set of clip lengths, so shortening a clip can
+force the resolution down in the same command. The script rejects an
+invalid pair locally, naming both flags, instead of letting the request go
+out and come back rejected — so the error message, not this page, is where
+the current rule reaches you.
 
-## Duration
+**Audio is not reliably a lever.** Whether it can be switched off at all,
+and whether switching it off changes the price, differs by model line —
+look it up in the same table before planning a silent render or budgeting
+around one.
 
-Supported single-generation durations are **4, 6, or 8 seconds** —
-anything else is rejected by the API. `--duration` defaults to 8.
-
-Duration and resolution are coupled: **1080p and 4k are 8 seconds only**, so
-a 4- or 6-second clip has to be 720p. The script's `--resolution` defaults to
-1080p, which means shortening a clip means dropping the resolution in the
-same command. It rejects the invalid pair locally rather than letting the API
-reject it after the request is already out.
+All three live in one place: the model table on
+[the Veo API page](https://ai.google.dev/gemini-api/docs/video), with
+per-second figures on
+[the Gemini API pricing page](https://ai.google.dev/gemini-api/docs/pricing).
 
 ## The Prompting Formula
 
@@ -100,23 +99,19 @@ color film, slightly grainy.
 For detailed cinematography language (camera movements, composition, lens
 techniques), see [references/prompting-guide.md](references/prompting-guide.md).
 
-## Audio Direction
+## Audio
 
-Audio is always on for Veo 3.1 and cannot be switched off. Veo builds the
-soundtrack from text instructions in the same prompt — there is no separate
-audio parameter, only the prompt.
-
-- **Dialogue** — quotation marks: `A woman says, "We have to leave now."`
-- **Sound effects** — described explicitly: `SFX: thunder cracks in the distance`
-- **Ambient noise** — background soundscape: `Ambient noise: the quiet hum of a starship bridge`
+Veo builds the soundtrack from the prompt text. There is no audio
+parameter to reach for — dialogue, effects, and ambience are written into
+the same string as the picture, and the idioms for each are in
+[references/prompting-guide.md](references/prompting-guide.md).
 
 ## Watermarking
 
-Google DeepMind documents that Veo output carries an invisible SynthID
-watermark — invisible does not mean absent. Whether API output *also*
-carries a visible watermark, the way some consumer surfaces (the Gemini
-app, Flow) do, is **not verified here** — check a generated clip rather
-than assuming either way.
+Veo output is watermarked. Whether a given clip carries a *visible* mark
+on top of the invisible one varies by surface and by release, and it is
+not something to assume in either direction — generate one clip and look
+at it before promising a client an unmarked render.
 
 ## Resources
 

--- a/google/skills/veo/SKILL.md
+++ b/google/skills/veo/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: veo
+description: |
+  This skill should be used when the user specifically asks for Veo, or
+  names a Veo-specific control: "generate video with Veo", "extend this
+  video" / "video-to-video", "first and last frame transition", "ingredients
+  to video" / "consistent characters across shots", or integrating with an
+  existing Veo pipeline.
+
+  Not the default for a plain "generate a video" / "make a video from this
+  photo" request with no Veo-specific control named — prefer Gemini Omni
+  Flash for that (Google's current default for video generation: better
+  coherence, multi-input reasoning, character consistency, multi-turn
+  editing). Reach for this skill only when the task specifically needs
+  Veo's own controls.
+context: fork
+model: sonnet
+---
+
+# Veo Video Generation
+
+Generate video with Google Veo 3.1 via the Gemini API. Supports
+text-to-video, image-to-video, video extension, and multi-shot workflows
+with cinematography control and synchronized audio.
+
+**This is not the default video-generation route.** Google's current
+guidance is to reach for Gemini Omni Flash first — it gives better video
+coherence, reasons over text/image/audio/video together, keeps characters
+consistent, and supports multi-turn conversational editing via the
+Interactions API. Come here specifically for Veo's own controls: scene
+extension, last-frame control, or integrating with an existing Veo
+pipeline. If the request is a plain "generate a video of X," that is
+Omni Flash's job, not this skill's.
+
+```bash
+export GEMINI_API_KEY="your-api-key"
+SCRIPT="${CLAUDE_PLUGIN_ROOT}/skills/veo/scripts/generate_video.py"
+
+uv run "$SCRIPT" "A neon hologram of a cat driving at top speed"
+uv run "$SCRIPT" "Slow dolly shot, cinematic lighting" --image photo.jpg
+uv run "$SCRIPT" "Zoom out to reveal the skyline" --model veo-3.1-fast-generate-preview --duration 4
+```
+
+The path goes through `CLAUDE_PLUGIN_ROOT` because this runs with the
+user's project as the working directory, not this one. A bare relative
+path does not resolve.
+
+The script declares its own dependency inline (PEP 723), so `uv run`
+resolves it; there is no install step. `--help` carries the current flags.
+
+The script covers text-to-video and image-to-video. Video extension,
+first/last-frame transitions, and ingredients-to-video (reference images)
+take more inputs than a CLI comfortably carries — see
+[references/api-examples.md](references/api-examples.md) for worked code
+to adapt directly.
+
+## Choosing a Veo variant
+
+| Model | Use when |
+|---|---|
+| `veo-3.1-generate-preview` | Best fidelity, production/hero shots |
+| `veo-3.1-fast-generate-preview` | Faster iteration, drafts |
+| `veo-3.1-lite-generate-preview` | Cheapest, quick previews, high volume |
+
+Price scales per second of output, and the same two levers move it for
+every variant: resolution (720p/1080p/4k) and whether audio is generated
+alongside the video (video+audio costs more than video-only). Check
+[Google's Vertex AI generative-AI pricing page](https://cloud.google.com/vertex-ai/generative-ai/pricing)
+for the current per-second figures before a spend decision — a number
+copied here would go stale silently.
+
+## Duration
+
+Supported single-generation durations are **4, 6, or 8 seconds** —
+anything else is rejected by the API. `--duration` defaults to 8.
+
+## The Prompting Formula
+
+For consistent, high-quality results, structure prompts using:
+
+**[Cinematography] + [Subject] + [Action] + [Context] + [Style & Ambiance]**
+
+### Example
+
+```
+Medium shot, a tired corporate worker, rubbing his temples in exhaustion,
+in front of a bulky 1980s computer in a cluttered office late at night.
+The scene is lit by the harsh fluorescent overhead lights and the green
+glow of the monochrome monitor. Retro aesthetic, shot as if on 1980s
+color film, slightly grainy.
+```
+
+For detailed cinematography language (camera movements, composition, lens
+techniques), see [references/prompting-guide.md](references/prompting-guide.md).
+
+## Audio Direction
+
+Veo 3.1 generates complete soundtracks based on text instructions in the
+same prompt — there is no separate audio parameter.
+
+- **Dialogue** — quotation marks: `A woman says, "We have to leave now."`
+- **Sound effects** — described explicitly: `SFX: thunder cracks in the distance`
+- **Ambient noise** — background soundscape: `Ambient noise: the quiet hum of a starship bridge`
+
+## Advanced Workflows
+
+For complex projects requiring precise control, combine Veo with an image
+model (e.g. Gemini's image generation) to prepare inputs, then feed them
+to Veo:
+
+- **First and Last Frame** — controlled transition between two specific
+  viewpoints (`last_frame` in the generation config).
+- **Ingredients to Video** — consistent characters/objects across shots via
+  `reference_images` in the generation config.
+- **Timestamp Prompting** — direct a multi-shot sequence with precise
+  timing inside a single generation, via the prompt text alone.
+
+See [references/prompting-guide.md](references/prompting-guide.md) for
+workflow instructions and [references/api-examples.md](references/api-examples.md)
+for the code.
+
+## Watermarking
+
+Google DeepMind documents that Veo output carries an invisible SynthID
+watermark — invisible does not mean absent, and it is meant to be
+machine-detectable rather than seen. Whether API output additionally
+carries a *visible* watermark, the way some consumer surfaces (the Gemini
+app, Flow) do, is **not verified here** — do not assume API output is
+visibly watermark-free, and do not assume it is watermarked, without
+checking a generated clip directly.
+
+## Resources
+
+- [Veo API Reference](https://ai.google.dev/gemini-api/docs/video)
+- [Google GenAI Python SDK](https://github.com/googleapis/python-genai)

--- a/google/skills/veo/SKILL.md
+++ b/google/skills/veo/SKILL.md
@@ -76,7 +76,7 @@ look it up in the same table before planning a silent render or budgeting
 around one.
 
 All three live in one place: the model table on
-[the Veo API page](https://ai.google.dev/gemini-api/docs/video), with
+[the Veo API page](https://ai.google.dev/gemini-api/docs/veo), with
 per-second figures on
 [the Gemini API pricing page](https://ai.google.dev/gemini-api/docs/pricing).
 
@@ -115,5 +115,5 @@ at it before promising a client an unmarked render.
 
 ## Resources
 
-- [Veo API Reference](https://ai.google.dev/gemini-api/docs/video)
+- [Veo API Reference](https://ai.google.dev/gemini-api/docs/veo)
 - [Google GenAI Python SDK](https://github.com/googleapis/python-genai)

--- a/google/skills/veo/SKILL.md
+++ b/google/skills/veo/SKILL.md
@@ -19,18 +19,13 @@ model: sonnet
 
 # Veo Video Generation
 
-Generate video with Google Veo 3.1 via the Gemini API. Supports
-text-to-video, image-to-video, video extension, and multi-shot workflows
-with cinematography control and synchronized audio.
+Generate video with Google Veo 3.1 via the Gemini API, with cinematography
+control and synchronized audio.
 
-**This is not the default video-generation route.** Google's current
-guidance is to reach for Gemini Omni Flash first — it gives better video
-coherence, reasons over text/image/audio/video together, keeps characters
-consistent, and supports multi-turn conversational editing via the
-Interactions API. Come here specifically for Veo's own controls: scene
-extension, last-frame control, or integrating with an existing Veo
-pipeline. If the request is a plain "generate a video of X," that is
-Omni Flash's job, not this skill's.
+Not the default video-generation route: a plain "generate a video of X" is
+Gemini Omni Flash's job, which leads on coherence, multi-input reasoning,
+character consistency, and multi-turn editing. Come here for Veo's own
+controls.
 
 ```bash
 export GEMINI_API_KEY="your-api-key"
@@ -48,11 +43,13 @@ path does not resolve.
 The script declares its own dependency inline (PEP 723), so `uv run`
 resolves it; there is no install step. `--help` carries the current flags.
 
-The script covers text-to-video and image-to-video. Video extension,
-first/last-frame transitions, and ingredients-to-video (reference images)
-take more inputs than a CLI comfortably carries — see
-[references/api-examples.md](references/api-examples.md) for worked code
-to adapt directly.
+The script covers text-to-video and image-to-video, and nothing else.
+Video extension, first/last-frame transitions, and ingredients-to-video
+take more inputs than a CLI comfortably carries; timestamp prompting takes
+no parameter at all. None of the four are commands — they are code and
+prompt text to adapt in place, in
+[references/api-examples.md](references/api-examples.md) and
+[references/prompting-guide.md](references/prompting-guide.md).
 
 ## Choosing a Veo variant
 
@@ -63,8 +60,8 @@ to adapt directly.
 | `veo-3.1-lite-generate-preview` | Cheapest, quick previews, high volume |
 
 Price scales per second of output, and the same two levers move it for
-every variant: resolution (720p/1080p/4k) and whether audio is generated
-alongside the video (video+audio costs more than video-only). Check
+every variant: resolution, and whether audio is generated alongside the
+video (video+audio costs more than video-only). Check
 [Google's Vertex AI generative-AI pricing page](https://cloud.google.com/vertex-ai/generative-ai/pricing)
 for the current per-second figures before a spend decision — a number
 copied here would go stale silently.
@@ -102,32 +99,13 @@ same prompt — there is no separate audio parameter.
 - **Sound effects** — described explicitly: `SFX: thunder cracks in the distance`
 - **Ambient noise** — background soundscape: `Ambient noise: the quiet hum of a starship bridge`
 
-## Advanced Workflows
-
-For complex projects requiring precise control, combine Veo with an image
-model (e.g. Gemini's image generation) to prepare inputs, then feed them
-to Veo:
-
-- **First and Last Frame** — controlled transition between two specific
-  viewpoints (`last_frame` in the generation config).
-- **Ingredients to Video** — consistent characters/objects across shots via
-  `reference_images` in the generation config.
-- **Timestamp Prompting** — direct a multi-shot sequence with precise
-  timing inside a single generation, via the prompt text alone.
-
-See [references/prompting-guide.md](references/prompting-guide.md) for
-workflow instructions and [references/api-examples.md](references/api-examples.md)
-for the code.
-
 ## Watermarking
 
 Google DeepMind documents that Veo output carries an invisible SynthID
-watermark — invisible does not mean absent, and it is meant to be
-machine-detectable rather than seen. Whether API output additionally
-carries a *visible* watermark, the way some consumer surfaces (the Gemini
-app, Flow) do, is **not verified here** — do not assume API output is
-visibly watermark-free, and do not assume it is watermarked, without
-checking a generated clip directly.
+watermark — invisible does not mean absent. Whether API output *also*
+carries a visible watermark, the way some consumer surfaces (the Gemini
+app, Flow) do, is **not verified here** — check a generated clip rather
+than assuming either way.
 
 ## Resources
 

--- a/google/skills/veo/SKILL.md
+++ b/google/skills/veo/SKILL.md
@@ -33,7 +33,7 @@ SCRIPT="${CLAUDE_PLUGIN_ROOT}/skills/veo/scripts/generate_video.py"
 
 uv run "$SCRIPT" "A neon hologram of a cat driving at top speed"
 uv run "$SCRIPT" "Slow dolly shot, cinematic lighting" --image photo.jpg
-uv run "$SCRIPT" "Zoom out to reveal the skyline" --model veo-3.1-fast-generate-preview --duration 4
+uv run "$SCRIPT" "Zoom out to reveal the skyline" --model veo-3.1-fast-generate-preview --duration 4 --resolution 720p
 ```
 
 The path goes through `CLAUDE_PLUGIN_ROOT` because this runs with the
@@ -59,9 +59,13 @@ prompt text to adapt in place, in
 | `veo-3.1-fast-generate-preview` | Faster iteration, drafts |
 | `veo-3.1-lite-generate-preview` | Cheapest, quick previews, high volume |
 
-Price scales per second of output, and the same two levers move it for
-every variant: resolution, and whether audio is generated alongside the
-video (video+audio costs more than video-only). Check
+Lite is not just a cheaper tier of the same thing — it takes no video input
+and no reference images, so video extension and ingredients-to-video are off
+the table there. All three are preview models.
+
+Price scales per second of output, and resolution is the lever that moves it
+(720p, or 1080p and 4k at 8 seconds). Audio is not a second lever on this
+model line — Veo 3.1 always generates it. Check
 [Google's Vertex AI generative-AI pricing page](https://cloud.google.com/vertex-ai/generative-ai/pricing)
 for the current per-second figures before a spend decision — a number
 copied here would go stale silently.
@@ -70,6 +74,12 @@ copied here would go stale silently.
 
 Supported single-generation durations are **4, 6, or 8 seconds** —
 anything else is rejected by the API. `--duration` defaults to 8.
+
+Duration and resolution are coupled: **1080p and 4k are 8 seconds only**, so
+a 4- or 6-second clip has to be 720p. The script's `--resolution` defaults to
+1080p, which means shortening a clip means dropping the resolution in the
+same command. It rejects the invalid pair locally rather than letting the API
+reject it after the request is already out.
 
 ## The Prompting Formula
 
@@ -92,8 +102,9 @@ techniques), see [references/prompting-guide.md](references/prompting-guide.md).
 
 ## Audio Direction
 
-Veo 3.1 generates complete soundtracks based on text instructions in the
-same prompt — there is no separate audio parameter.
+Audio is always on for Veo 3.1 and cannot be switched off. Veo builds the
+soundtrack from text instructions in the same prompt — there is no separate
+audio parameter, only the prompt.
 
 - **Dialogue** — quotation marks: `A woman says, "We have to leave now."`
 - **Sound effects** — described explicitly: `SFX: thunder cracks in the distance`

--- a/google/skills/veo/references/api-examples.md
+++ b/google/skills/veo/references/api-examples.md
@@ -72,7 +72,7 @@ Vertex AI concept and does not apply here.
 Extension constrains the output — resolution in particular may be pinned
 regardless of what you asked for — and the cheaper variants may not accept
 video input at all. Both are in the model table on
-[the Veo API page](https://ai.google.dev/gemini-api/docs/video); check it
+[the Veo API page](https://ai.google.dev/gemini-api/docs/veo); check it
 before building a pipeline on an extension step.
 
 ```python
@@ -132,12 +132,12 @@ constraints are silent until the call is rejected. They bound three things
 at once — which other inputs may accompany them, how long the clip may be,
 and which variants accept them at all — and the counts move between
 releases. The model table on
-[the Veo API page](https://ai.google.dev/gemini-api/docs/video) carries the
+[the Veo API page](https://ai.google.dev/gemini-api/docs/veo) carries the
 current set; read it before assuming a reference-image run can also carry a
 start frame, or run at the length you had in mind.
 
 ## Resources
 
-- [Veo API Reference](https://ai.google.dev/gemini-api/docs/video)
+- [Veo API Reference](https://ai.google.dev/gemini-api/docs/veo)
 - [Prompting Guide](./prompting-guide.md)
 - [Google GenAI Python SDK](https://github.com/googleapis/python-genai)

--- a/google/skills/veo/references/api-examples.md
+++ b/google/skills/veo/references/api-examples.md
@@ -1,49 +1,31 @@
-# Veo 3.1 API Examples
+# Veo 3.1 — the API shapes the CLI does not carry
 
-Complete examples for using Google Veo 3.1 via the Gemini API Python SDK.
-The [scripts/generate_video.py](../scripts/generate_video.py) script covers
-text-to-video and image-to-video from the command line; the workflows below
-(video extension, first/last frame, ingredients, timestamp prompting) are
-not scripted — copy and adapt the code directly.
+[scripts/generate_video.py](../scripts/generate_video.py) covers text-to-video
+and image-to-video, so neither is repeated here. What follows is the four
+workflows the script deliberately leaves out, each shown only by the part
+that differs — copy the config field into the shared skeleton below.
 
-## Setup
+Timestamp prompting is absent from this file on purpose: it takes no special
+parameter, so it is prompt craft, not an API shape — see
+[prompting-guide.md](./prompting-guide.md).
 
-### Installation
+## The skeleton
 
-```bash
-uv pip install google-genai
-```
-
-### Authentication
-
-```bash
-export GEMINI_API_KEY="your-api-key"
-```
-
-### Client Initialization
+Declare the dependency the way the script does — a PEP 723 header plus
+`uv run`, so there is no install step; copy the header from
+[scripts/generate_video.py](../scripts/generate_video.py).
 
 ```python
+import os, time
 from google import genai
 from google.genai import types
-import time
-import os
 
 client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
-```
 
-These examples use `source=types.GenerateVideosSource(...)` rather than
-passing `prompt=`/`image=`/`video=` directly to `generate_videos()`,
-because the direct kwargs are deprecated in favor of `source`.
-
-## Text-to-Video Generation
-
-```python
 operation = client.models.generate_videos(
-    model='veo-3.1-generate-preview',
-    source=types.GenerateVideosSource(
-        prompt='A neon hologram of a cat driving at top speed',
-    ),
-    config=types.GenerateVideosConfig(
+    model="veo-3.1-generate-preview",
+    source=types.GenerateVideosSource(prompt=prompt),   # ← varies
+    config=types.GenerateVideosConfig(                  # ← varies
         number_of_videos=1,
         duration_seconds=8,
     ),
@@ -54,319 +36,74 @@ while not operation.done:
     operation = client.operations.get(operation)
 
 if operation.error:
-    raise Exception(f"Video generation failed: {operation.error}")
+    raise RuntimeError(operation.error)
+if not operation.response or not operation.response.generated_videos:
+    raise RuntimeError(f"No video in response: {operation.response}")
 
 video = operation.response.generated_videos[0].video
-with open('output.mp4', 'wb') as f:
-    f.write(video.video_bytes)
+if not video.video_bytes and video.uri:
+    client.files.download(file=video)   # sets video.video_bytes in place
+open("output.mp4", "wb").write(video.video_bytes)
 ```
 
-### Advanced Text-to-Video with Audio
+Inputs go through `source=types.GenerateVideosSource(...)`, not the
+`prompt=`/`image=`/`video=` kwargs on `generate_videos()` — those are
+deprecated in favor of `source`.
+
+Check `operation.error`, then `operation.response`, then
+`operation.response.generated_videos`, in that order, before touching the
+result; the earlier one being fine does not imply the later one exists.
+
+`enhance_prompt` defaults to `True` and cannot be set to `False` on Veo 3.1 —
+omit it rather than pass it explicitly.
+
+## Video extension ("video-to-video")
+
+The Gemini API path takes the source video as inline bytes. A `gs://` URI is a
+Vertex AI concept and does not apply here.
 
 ```python
-prompt = '''
-Medium shot of a detective in a noir film office. He looks directly at
-the camera and says, "I've been expecting you." SFX: the creak of a
-leather chair. Ambient noise: rain pattering against the window.
-Moody lighting with venetian blind shadows, cinematic, 1940s film noir style.
-'''
-
-operation = client.models.generate_videos(
-    model='veo-3.1-generate-preview',
-    source=types.GenerateVideosSource(prompt=prompt),
-    config=types.GenerateVideosConfig(
-        number_of_videos=1,
-        duration_seconds=6,
-        aspect_ratio='16:9',
-        resolution='1080p',
+source=types.GenerateVideosSource(
+    prompt="Transform into a cyberpunk style with neon lights",
+    video=types.Video(
+        video_bytes=open("local/path/video.mp4", "rb").read(),
+        mime_type="video/mp4",
     ),
 )
-
-while not operation.done:
-    time.sleep(20)
-    operation = client.operations.get(operation)
-
-if operation.error:
-    raise Exception(f"Video generation failed: {operation.error}")
-
-video = operation.response.generated_videos[0].video
 ```
 
-## Image-to-Video Animation
+## First and last frame
+
+The start image goes on the source, the end image on the config.
 
 ```python
-with open("path/to/your/image.png", 'rb') as f:
-    image_data = f.read()
-
-image = types.Image(
-    image_bytes=image_data,
-    mime_type='image/png'  # or 'image/jpeg' for JPEG files
+source=types.GenerateVideosSource(prompt=prompt, image=start_image)
+config=types.GenerateVideosConfig(
+    number_of_videos=1,
+    duration_seconds=6,
+    last_frame=end_image,
 )
-
-operation = client.models.generate_videos(
-    model='veo-3.1-generate-preview',
-    source=types.GenerateVideosSource(
-        prompt='Night sky with twinkling stars',  # optional alongside an image
-        image=image,
-    ),
-    config=types.GenerateVideosConfig(
-        number_of_videos=1,
-        duration_seconds=8,
-    ),
-)
-
-while not operation.done:
-    time.sleep(20)
-    operation = client.operations.get(operation)
-
-if operation.error:
-    raise Exception(f"Video generation failed: {operation.error}")
-
-video = operation.response.generated_videos[0].video
 ```
 
-### Image-to-Video with Detailed Cinematography
+where each frame is `types.Image(image_bytes=..., mime_type="image/png")`.
+
+## Ingredients to video (consistent characters/objects)
+
+Reference images ride on the config, not the source; the prompt then refers to
+them ("Using the provided character and office setting, ...").
 
 ```python
-with open("portrait.jpg", 'rb') as f:
-    image_data = f.read()
-
-image = types.Image(image_bytes=image_data, mime_type='image/jpeg')
-
-prompt = '''
-Slow dolly shot moving closer to the subject. Shallow depth of field,
-cinematic lighting with soft bokeh in the background. The subject
-slowly turns their head to look at the camera with a slight smile.
-'''
-
-operation = client.models.generate_videos(
-    model='veo-3.1-generate-preview',
-    source=types.GenerateVideosSource(prompt=prompt, image=image),
-    config=types.GenerateVideosConfig(
-        number_of_videos=1,
-        duration_seconds=4,
-        aspect_ratio='9:16',  # Vertical format
-        resolution='1080p',
-    ),
+config=types.GenerateVideosConfig(
+    number_of_videos=1,
+    duration_seconds=6,
+    reference_images=[character_ref, location_ref],
 )
-
-while not operation.done:
-    time.sleep(20)
-    operation = client.operations.get(operation)
-
-video = operation.response.generated_videos[0].video
-with open('portrait_animation.mp4', 'wb') as f:
-    f.write(video.video_bytes)
 ```
 
-## Video Extension ("Video-to-Video")
-
-Extend or transform existing video content. The Gemini API path takes the
-video as inline bytes (`video_bytes`); a `gs://` URI is a Vertex AI
-concept and does not apply here.
-
-```python
-with open("local/path/video.mp4", 'rb') as f:
-    video_data = f.read()
-
-video_input = types.Video(video_bytes=video_data, mime_type='video/mp4')
-
-operation = client.models.generate_videos(
-    model='veo-3.1-generate-preview',
-    source=types.GenerateVideosSource(
-        prompt='Transform into a cyberpunk style with neon lights',
-        video=video_input,
-    ),
-    config=types.GenerateVideosConfig(
-        number_of_videos=1,
-        duration_seconds=8,
-    ),
-)
-
-while not operation.done:
-    time.sleep(20)
-    operation = client.operations.get(operation)
-
-if operation.error:
-    raise Exception(f"Video generation failed: {operation.error}")
-
-video = operation.response.generated_videos[0].video
-```
-
-## Advanced Features
-
-### First and Last Frame (Seamless Transitions)
-
-```python
-with open("start_frame.png", 'rb') as f:
-    start_image = types.Image(image_bytes=f.read(), mime_type='image/png')
-
-with open("end_frame.png", 'rb') as f:
-    end_image = types.Image(image_bytes=f.read(), mime_type='image/png')
-
-prompt = '''
-The camera performs a smooth 180-degree arc shot, starting with the
-front-facing view and circling around to the back view. Natural camera
-movement, cinematic.
-'''
-
-operation = client.models.generate_videos(
-    model='veo-3.1-generate-preview',
-    source=types.GenerateVideosSource(prompt=prompt, image=start_image),
-    config=types.GenerateVideosConfig(
-        number_of_videos=1,
-        duration_seconds=6,
-        last_frame=end_image,
-    ),
-)
-
-while not operation.done:
-    time.sleep(20)
-    operation = client.operations.get(operation)
-
-video = operation.response.generated_videos[0].video
-```
-
-### Ingredients to Video (Consistent Characters/Objects)
-
-The SDK's own field documentation for `reference_images` describes it in
-terms of Veo 2 ("Veo 2 supports up to 3 asset images or 1 style image");
-whether this feature is fully supported on the veo-3.1 model line is
-**not verified** here — check the API's response if it matters for the task.
-
-```python
-with open("character_reference.png", 'rb') as f:
-    character_ref = types.Image(image_bytes=f.read(), mime_type='image/png')
-
-with open("office_reference.png", 'rb') as f:
-    location_ref = types.Image(image_bytes=f.read(), mime_type='image/png')
-
-prompt = '''
-Using the provided character and office setting, create a medium shot
-of the character sitting at the desk, typing on a computer. They pause,
-look up thoughtfully, and say "I think I've found something." Natural
-office lighting, realistic.
-'''
-
-operation = client.models.generate_videos(
-    model='veo-3.1-generate-preview',
-    source=types.GenerateVideosSource(prompt=prompt),
-    config=types.GenerateVideosConfig(
-        number_of_videos=1,
-        duration_seconds=6,
-        reference_images=[character_ref, location_ref],
-    ),
-)
-
-while not operation.done:
-    time.sleep(20)
-    operation = client.operations.get(operation)
-
-video = operation.response.generated_videos[0].video
-```
-
-### Timestamp Prompting
-
-Direct a multi-shot sequence with precise timing inside a single
-generation — no special parameter, just structured prompt text.
-
-```python
-prompt = '''
-[00:00-00:02] Wide shot of a coffee shop exterior on a rainy morning.
-Soft natural lighting, people with umbrellas passing by. SFX: rain and
-distant traffic.
-
-[00:02-00:04] Medium shot inside the coffee shop. A barista pours latte
-art into a white cup. Close-up on the swirling milk pattern. SFX: the
-hiss of the espresso machine, quiet jazz music.
-
-[00:04-00:06] Over-the-shoulder shot of a customer at a window seat,
-typing on a laptop while occasionally sipping coffee. They gaze out at
-the rain thoughtfully. Cozy, warm interior lighting.
-'''
-
-operation = client.models.generate_videos(
-    model='veo-3.1-generate-preview',
-    source=types.GenerateVideosSource(prompt=prompt),
-    config=types.GenerateVideosConfig(
-        number_of_videos=1,
-        duration_seconds=6,
-        aspect_ratio='16:9',
-        resolution='1080p',
-    ),
-)
-
-while not operation.done:
-    time.sleep(20)
-    operation = client.operations.get(operation)
-
-video = operation.response.generated_videos[0].video
-with open('coffee_shop_sequence.mp4', 'wb') as f:
-    f.write(video.video_bytes)
-```
-
-## Error Handling
-
-```python
-def generate_video_safe(prompt: str, **config_kwargs):
-    """Generate video with error handling and retry logic."""
-    max_retries = 3
-    retry_count = 0
-
-    while retry_count < max_retries:
-        try:
-            operation = client.models.generate_videos(
-                model='veo-3.1-generate-preview',
-                source=types.GenerateVideosSource(prompt=prompt),
-                config=types.GenerateVideosConfig(**config_kwargs),
-            )
-
-            timeout = 300  # 5 minutes
-            elapsed = 0
-            while not operation.done and elapsed < timeout:
-                time.sleep(20)
-                elapsed += 20
-                operation = client.operations.get(operation)
-
-            if not operation.done:
-                raise TimeoutError(f"Operation timed out after {timeout}s")
-            if operation.error:
-                raise Exception(f"Generation failed: {operation.error}")
-            if not operation.response:
-                raise Exception(f"No response received. Operation metadata: {operation.metadata}")
-            if not operation.response.generated_videos:
-                raise Exception(f"No videos generated. Response: {operation.response}")
-
-            return operation.response.generated_videos[0].video
-
-        except Exception as e:
-            retry_count += 1
-            if retry_count >= max_retries:
-                raise Exception(f"Failed after {max_retries} retries: {e}")
-            print(f"Retry {retry_count}/{max_retries} after error: {e}")
-            time.sleep(10 * retry_count)  # Exponential backoff
-
-# Usage
-try:
-    video = generate_video_safe(
-        "A serene mountain landscape at sunset",
-        number_of_videos=1,
-        duration_seconds=8,
-        aspect_ratio='16:9',
-    )
-except Exception as e:
-    print(f"Video generation failed: {e}")
-```
-
-## Best Practices
-
-1. `enhance_prompt` defaults to `True` and cannot be set to `False` on Veo 3.1 — omit it rather than pass it explicitly.
-2. Poll every 20 seconds; generation typically takes 2-5 minutes.
-3. Check `operation.error`, then `operation.response`, then `operation.response.generated_videos`, in that order, before touching the result.
-4. Use reference images for character consistency across shots (see the verification note above).
-5. Specify resolution and aspect ratio explicitly for production use.
-6. Include SFX and ambient noise in prompts for rich audio generation.
-7. Prefer PNG (lossless) for image inputs when maximum quality matters; JPEG is acceptable but may introduce compression artifacts.
+The SDK's own field documentation for `reference_images` describes it in terms
+of Veo 2 ("Veo 2 supports up to 3 asset images or 1 style image"); whether the
+feature is fully supported on the veo-3.1 line is **not verified** here —
+check the API's response if it matters for the task.
 
 ## Resources
 

--- a/google/skills/veo/references/api-examples.md
+++ b/google/skills/veo/references/api-examples.md
@@ -1,4 +1,4 @@
-# Veo 3.1 — the API shapes the CLI does not carry
+# Veo — the API shapes the CLI does not carry
 
 [scripts/generate_video.py](../scripts/generate_video.py) covers text-to-video
 and image-to-video, so neither is repeated here. What follows is the four
@@ -24,7 +24,7 @@ client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
 prompt = "A neon hologram of a cat driving at top speed"
 
 operation = client.models.generate_videos(
-    model="veo-3.1-generate-preview",
+    model=MODEL,                                        # see below
     source=types.GenerateVideosSource(prompt=prompt),   # ← varies
     config=types.GenerateVideosConfig(                  # ← varies
         number_of_videos=1,
@@ -48,24 +48,32 @@ with open("output.mp4", "wb") as f:
     f.write(video.video_bytes)
 ```
 
+`MODEL` is a variant name, and the live list is
+`MODEL_CHOICES` in [scripts/generate_video.py](../scripts/generate_video.py)
+— or `--help`, which prints it. Do not copy a variant name out of prose.
+
 Inputs go through `source=types.GenerateVideosSource(...)`, not the
-`prompt=`/`image=`/`video=` kwargs on `generate_videos()` — those are
-deprecated in favor of `source`.
+`prompt=`/`image=`/`video=` kwargs on `generate_videos()`.
 
 Check `operation.error`, then `operation.response`, then
 `operation.response.generated_videos`, in that order, before touching the
 result; the earlier one being fine does not imply the later one exists.
 
-`enhance_prompt` defaults to `True` and cannot be set to `False` on Veo 3.1 —
-omit it rather than pass it explicitly.
+For any config field's accepted values and defaults, read the annotations
+on `types.GenerateVideosConfig` — `python -c "from google.genai import
+types; help(types.GenerateVideosConfig)"` — rather than a value written
+down here. The SDK ships with the model line; this page does not.
 
 ## Video extension ("video-to-video")
 
 The Gemini API path takes the source video as inline bytes. A `gs://` URI is a
 Vertex AI concept and does not apply here.
 
-Output is 720p when extending, whatever `resolution` says, and
-`veo-3.1-lite-generate-preview` does not accept video input at all.
+Extension constrains the output — resolution in particular may be pinned
+regardless of what you asked for — and the cheaper variants may not accept
+video input at all. Both are in the model table on
+[the Veo API page](https://ai.google.dev/gemini-api/docs/video); check it
+before building a pipeline on an extension step.
 
 ```python
 source=types.GenerateVideosSource(
@@ -119,16 +127,14 @@ config=types.GenerateVideosConfig(
 )
 ```
 
-Three constraints come with it, and the first two are silent until the API
-rejects the call:
-
-- Reference images do not combine with `image`, `video`, or `last_frame` —
-  the prompt is the only other input.
-- Duration is forced to 8 seconds.
-- `veo-3.1-lite-generate-preview` does not accept reference images at all;
-  use the full or fast variant.
-
-Up to three images, per the Veo 3.1 model table.
+Reference images are the most constrained input on the API, and the
+constraints are silent until the call is rejected. They bound three things
+at once — which other inputs may accompany them, how long the clip may be,
+and which variants accept them at all — and the counts move between
+releases. The model table on
+[the Veo API page](https://ai.google.dev/gemini-api/docs/video) carries the
+current set; read it before assuming a reference-image run can also carry a
+start frame, or run at the length you had in mind.
 
 ## Resources
 

--- a/google/skills/veo/references/api-examples.md
+++ b/google/skills/veo/references/api-examples.md
@@ -21,6 +21,7 @@ from google import genai
 from google.genai import types
 
 client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
+prompt = "A neon hologram of a cat driving at top speed"
 
 operation = client.models.generate_videos(
     model="veo-3.1-generate-preview",
@@ -43,7 +44,8 @@ if not operation.response or not operation.response.generated_videos:
 video = operation.response.generated_videos[0].video
 if not video.video_bytes and video.uri:
     client.files.download(file=video)   # sets video.video_bytes in place
-open("output.mp4", "wb").write(video.video_bytes)
+with open("output.mp4", "wb") as f:
+    f.write(video.video_bytes)
 ```
 
 Inputs go through `source=types.GenerateVideosSource(...)`, not the
@@ -62,6 +64,9 @@ omit it rather than pass it explicitly.
 The Gemini API path takes the source video as inline bytes. A `gs://` URI is a
 Vertex AI concept and does not apply here.
 
+Output is 720p when extending, whatever `resolution` says, and
+`veo-3.1-lite-generate-preview` does not accept video input at all.
+
 ```python
 source=types.GenerateVideosSource(
     prompt="Transform into a cyberpunk style with neon lights",
@@ -74,7 +79,8 @@ source=types.GenerateVideosSource(
 
 ## First and last frame
 
-The start image goes on the source, the end image on the config.
+The start image goes on the source, the end image on the config. `last_frame`
+only works alongside `image` — an end frame with no start frame is rejected.
 
 ```python
 source=types.GenerateVideosSource(prompt=prompt, image=start_image)
@@ -92,18 +98,37 @@ where each frame is `types.Image(image_bytes=..., mime_type="image/png")`.
 Reference images ride on the config, not the source; the prompt then refers to
 them ("Using the provided character and office setting, ...").
 
+Each one is a `VideoGenerationReferenceImage`, not a bare `Image` — the wrapper
+exists to carry `reference_type`, which decides whether the picture supplies
+content or style.
+
 ```python
 config=types.GenerateVideosConfig(
     number_of_videos=1,
-    duration_seconds=6,
-    reference_images=[character_ref, location_ref],
+    duration_seconds=8,
+    reference_images=[
+        types.VideoGenerationReferenceImage(
+            image=character_ref,
+            reference_type=types.VideoGenerationReferenceType.ASSET,
+        ),
+        types.VideoGenerationReferenceImage(
+            image=location_ref,
+            reference_type=types.VideoGenerationReferenceType.STYLE,
+        ),
+    ],
 )
 ```
 
-The SDK's own field documentation for `reference_images` describes it in terms
-of Veo 2 ("Veo 2 supports up to 3 asset images or 1 style image"); whether the
-feature is fully supported on the veo-3.1 line is **not verified** here —
-check the API's response if it matters for the task.
+Three constraints come with it, and the first two are silent until the API
+rejects the call:
+
+- Reference images do not combine with `image`, `video`, or `last_frame` —
+  the prompt is the only other input.
+- Duration is forced to 8 seconds.
+- `veo-3.1-lite-generate-preview` does not accept reference images at all;
+  use the full or fast variant.
+
+Up to three images, per the Veo 3.1 model table.
 
 ## Resources
 

--- a/google/skills/veo/references/api-examples.md
+++ b/google/skills/veo/references/api-examples.md
@@ -1,0 +1,375 @@
+# Veo 3.1 API Examples
+
+Complete examples for using Google Veo 3.1 via the Gemini API Python SDK.
+The [scripts/generate_video.py](../scripts/generate_video.py) script covers
+text-to-video and image-to-video from the command line; the workflows below
+(video extension, first/last frame, ingredients, timestamp prompting) are
+not scripted — copy and adapt the code directly.
+
+## Setup
+
+### Installation
+
+```bash
+uv pip install google-genai
+```
+
+### Authentication
+
+```bash
+export GEMINI_API_KEY="your-api-key"
+```
+
+### Client Initialization
+
+```python
+from google import genai
+from google.genai import types
+import time
+import os
+
+client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
+```
+
+These examples use `source=types.GenerateVideosSource(...)` rather than
+passing `prompt=`/`image=`/`video=` directly to `generate_videos()`,
+because the direct kwargs are deprecated in favor of `source`.
+
+## Text-to-Video Generation
+
+```python
+operation = client.models.generate_videos(
+    model='veo-3.1-generate-preview',
+    source=types.GenerateVideosSource(
+        prompt='A neon hologram of a cat driving at top speed',
+    ),
+    config=types.GenerateVideosConfig(
+        number_of_videos=1,
+        duration_seconds=8,
+    ),
+)
+
+while not operation.done:
+    time.sleep(20)
+    operation = client.operations.get(operation)
+
+if operation.error:
+    raise Exception(f"Video generation failed: {operation.error}")
+
+video = operation.response.generated_videos[0].video
+with open('output.mp4', 'wb') as f:
+    f.write(video.video_bytes)
+```
+
+### Advanced Text-to-Video with Audio
+
+```python
+prompt = '''
+Medium shot of a detective in a noir film office. He looks directly at
+the camera and says, "I've been expecting you." SFX: the creak of a
+leather chair. Ambient noise: rain pattering against the window.
+Moody lighting with venetian blind shadows, cinematic, 1940s film noir style.
+'''
+
+operation = client.models.generate_videos(
+    model='veo-3.1-generate-preview',
+    source=types.GenerateVideosSource(prompt=prompt),
+    config=types.GenerateVideosConfig(
+        number_of_videos=1,
+        duration_seconds=6,
+        aspect_ratio='16:9',
+        resolution='1080p',
+    ),
+)
+
+while not operation.done:
+    time.sleep(20)
+    operation = client.operations.get(operation)
+
+if operation.error:
+    raise Exception(f"Video generation failed: {operation.error}")
+
+video = operation.response.generated_videos[0].video
+```
+
+## Image-to-Video Animation
+
+```python
+with open("path/to/your/image.png", 'rb') as f:
+    image_data = f.read()
+
+image = types.Image(
+    image_bytes=image_data,
+    mime_type='image/png'  # or 'image/jpeg' for JPEG files
+)
+
+operation = client.models.generate_videos(
+    model='veo-3.1-generate-preview',
+    source=types.GenerateVideosSource(
+        prompt='Night sky with twinkling stars',  # optional alongside an image
+        image=image,
+    ),
+    config=types.GenerateVideosConfig(
+        number_of_videos=1,
+        duration_seconds=8,
+    ),
+)
+
+while not operation.done:
+    time.sleep(20)
+    operation = client.operations.get(operation)
+
+if operation.error:
+    raise Exception(f"Video generation failed: {operation.error}")
+
+video = operation.response.generated_videos[0].video
+```
+
+### Image-to-Video with Detailed Cinematography
+
+```python
+with open("portrait.jpg", 'rb') as f:
+    image_data = f.read()
+
+image = types.Image(image_bytes=image_data, mime_type='image/jpeg')
+
+prompt = '''
+Slow dolly shot moving closer to the subject. Shallow depth of field,
+cinematic lighting with soft bokeh in the background. The subject
+slowly turns their head to look at the camera with a slight smile.
+'''
+
+operation = client.models.generate_videos(
+    model='veo-3.1-generate-preview',
+    source=types.GenerateVideosSource(prompt=prompt, image=image),
+    config=types.GenerateVideosConfig(
+        number_of_videos=1,
+        duration_seconds=4,
+        aspect_ratio='9:16',  # Vertical format
+        resolution='1080p',
+    ),
+)
+
+while not operation.done:
+    time.sleep(20)
+    operation = client.operations.get(operation)
+
+video = operation.response.generated_videos[0].video
+with open('portrait_animation.mp4', 'wb') as f:
+    f.write(video.video_bytes)
+```
+
+## Video Extension ("Video-to-Video")
+
+Extend or transform existing video content. The Gemini API path takes the
+video as inline bytes (`video_bytes`); a `gs://` URI is a Vertex AI
+concept and does not apply here.
+
+```python
+with open("local/path/video.mp4", 'rb') as f:
+    video_data = f.read()
+
+video_input = types.Video(video_bytes=video_data, mime_type='video/mp4')
+
+operation = client.models.generate_videos(
+    model='veo-3.1-generate-preview',
+    source=types.GenerateVideosSource(
+        prompt='Transform into a cyberpunk style with neon lights',
+        video=video_input,
+    ),
+    config=types.GenerateVideosConfig(
+        number_of_videos=1,
+        duration_seconds=8,
+    ),
+)
+
+while not operation.done:
+    time.sleep(20)
+    operation = client.operations.get(operation)
+
+if operation.error:
+    raise Exception(f"Video generation failed: {operation.error}")
+
+video = operation.response.generated_videos[0].video
+```
+
+## Advanced Features
+
+### First and Last Frame (Seamless Transitions)
+
+```python
+with open("start_frame.png", 'rb') as f:
+    start_image = types.Image(image_bytes=f.read(), mime_type='image/png')
+
+with open("end_frame.png", 'rb') as f:
+    end_image = types.Image(image_bytes=f.read(), mime_type='image/png')
+
+prompt = '''
+The camera performs a smooth 180-degree arc shot, starting with the
+front-facing view and circling around to the back view. Natural camera
+movement, cinematic.
+'''
+
+operation = client.models.generate_videos(
+    model='veo-3.1-generate-preview',
+    source=types.GenerateVideosSource(prompt=prompt, image=start_image),
+    config=types.GenerateVideosConfig(
+        number_of_videos=1,
+        duration_seconds=6,
+        last_frame=end_image,
+    ),
+)
+
+while not operation.done:
+    time.sleep(20)
+    operation = client.operations.get(operation)
+
+video = operation.response.generated_videos[0].video
+```
+
+### Ingredients to Video (Consistent Characters/Objects)
+
+The SDK's own field documentation for `reference_images` describes it in
+terms of Veo 2 ("Veo 2 supports up to 3 asset images or 1 style image");
+whether this feature is fully supported on the veo-3.1 model line is
+**not verified** here — check the API's response if it matters for the task.
+
+```python
+with open("character_reference.png", 'rb') as f:
+    character_ref = types.Image(image_bytes=f.read(), mime_type='image/png')
+
+with open("office_reference.png", 'rb') as f:
+    location_ref = types.Image(image_bytes=f.read(), mime_type='image/png')
+
+prompt = '''
+Using the provided character and office setting, create a medium shot
+of the character sitting at the desk, typing on a computer. They pause,
+look up thoughtfully, and say "I think I've found something." Natural
+office lighting, realistic.
+'''
+
+operation = client.models.generate_videos(
+    model='veo-3.1-generate-preview',
+    source=types.GenerateVideosSource(prompt=prompt),
+    config=types.GenerateVideosConfig(
+        number_of_videos=1,
+        duration_seconds=6,
+        reference_images=[character_ref, location_ref],
+    ),
+)
+
+while not operation.done:
+    time.sleep(20)
+    operation = client.operations.get(operation)
+
+video = operation.response.generated_videos[0].video
+```
+
+### Timestamp Prompting
+
+Direct a multi-shot sequence with precise timing inside a single
+generation — no special parameter, just structured prompt text.
+
+```python
+prompt = '''
+[00:00-00:02] Wide shot of a coffee shop exterior on a rainy morning.
+Soft natural lighting, people with umbrellas passing by. SFX: rain and
+distant traffic.
+
+[00:02-00:04] Medium shot inside the coffee shop. A barista pours latte
+art into a white cup. Close-up on the swirling milk pattern. SFX: the
+hiss of the espresso machine, quiet jazz music.
+
+[00:04-00:06] Over-the-shoulder shot of a customer at a window seat,
+typing on a laptop while occasionally sipping coffee. They gaze out at
+the rain thoughtfully. Cozy, warm interior lighting.
+'''
+
+operation = client.models.generate_videos(
+    model='veo-3.1-generate-preview',
+    source=types.GenerateVideosSource(prompt=prompt),
+    config=types.GenerateVideosConfig(
+        number_of_videos=1,
+        duration_seconds=6,
+        aspect_ratio='16:9',
+        resolution='1080p',
+    ),
+)
+
+while not operation.done:
+    time.sleep(20)
+    operation = client.operations.get(operation)
+
+video = operation.response.generated_videos[0].video
+with open('coffee_shop_sequence.mp4', 'wb') as f:
+    f.write(video.video_bytes)
+```
+
+## Error Handling
+
+```python
+def generate_video_safe(prompt: str, **config_kwargs):
+    """Generate video with error handling and retry logic."""
+    max_retries = 3
+    retry_count = 0
+
+    while retry_count < max_retries:
+        try:
+            operation = client.models.generate_videos(
+                model='veo-3.1-generate-preview',
+                source=types.GenerateVideosSource(prompt=prompt),
+                config=types.GenerateVideosConfig(**config_kwargs),
+            )
+
+            timeout = 300  # 5 minutes
+            elapsed = 0
+            while not operation.done and elapsed < timeout:
+                time.sleep(20)
+                elapsed += 20
+                operation = client.operations.get(operation)
+
+            if not operation.done:
+                raise TimeoutError(f"Operation timed out after {timeout}s")
+            if operation.error:
+                raise Exception(f"Generation failed: {operation.error}")
+            if not operation.response:
+                raise Exception(f"No response received. Operation metadata: {operation.metadata}")
+            if not operation.response.generated_videos:
+                raise Exception(f"No videos generated. Response: {operation.response}")
+
+            return operation.response.generated_videos[0].video
+
+        except Exception as e:
+            retry_count += 1
+            if retry_count >= max_retries:
+                raise Exception(f"Failed after {max_retries} retries: {e}")
+            print(f"Retry {retry_count}/{max_retries} after error: {e}")
+            time.sleep(10 * retry_count)  # Exponential backoff
+
+# Usage
+try:
+    video = generate_video_safe(
+        "A serene mountain landscape at sunset",
+        number_of_videos=1,
+        duration_seconds=8,
+        aspect_ratio='16:9',
+    )
+except Exception as e:
+    print(f"Video generation failed: {e}")
+```
+
+## Best Practices
+
+1. `enhance_prompt` defaults to `True` and cannot be set to `False` on Veo 3.1 — omit it rather than pass it explicitly.
+2. Poll every 20 seconds; generation typically takes 2-5 minutes.
+3. Check `operation.error`, then `operation.response`, then `operation.response.generated_videos`, in that order, before touching the result.
+4. Use reference images for character consistency across shots (see the verification note above).
+5. Specify resolution and aspect ratio explicitly for production use.
+6. Include SFX and ambient noise in prompts for rich audio generation.
+7. Prefer PNG (lossless) for image inputs when maximum quality matters; JPEG is acceptable but may introduce compression artifacts.
+
+## Resources
+
+- [Veo API Reference](https://ai.google.dev/gemini-api/docs/video)
+- [Prompting Guide](./prompting-guide.md)
+- [Google GenAI Python SDK](https://github.com/googleapis/python-genai)

--- a/google/skills/veo/references/prompting-guide.md
+++ b/google/skills/veo/references/prompting-guide.md
@@ -1,0 +1,243 @@
+# Veo 3.1 Prompting Guide
+
+Complete guide to prompting Google's Veo 3.1 video generation model.
+
+Source: [Google Cloud Blog - Ultimate Prompting Guide for Veo 3.1](https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-veo-3-1)
+
+## Table of Contents
+
+1. [Model Capabilities](#model-capabilities)
+2. [Prompting Formula](#prompting-formula)
+3. [Essential Prompting Techniques](#essential-prompting-techniques)
+4. [Advanced Creative Workflows](#advanced-creative-workflows)
+
+## Model Capabilities
+
+### Core Generation Features
+
+- **High-fidelity video:** 720p or 1080p resolution
+- **Aspect ratio:** 16:9 or 9:16
+- **Variable clip length:** 4, 6, or 8 seconds
+- **Rich audio & dialogue:** Realistic, synchronized sound including multi-person conversations and precisely timed sound effects
+- **Complex scene comprehension:** Deeper understanding of narrative structure and cinematic styles for better character interactions and storytelling
+
+### Advanced Creative Controls
+
+- **Improved image-to-video:** Animate source images with greater prompt adherence and enhanced audio-visual quality
+- **Consistent elements ("ingredients to video"):** Provide reference images of scenes, characters, objects, or styles to maintain consistent aesthetics across multiple shots (includes audio generation)
+- **Seamless transitions ("first and last frame"):** Generate natural video transitions between provided start and end images, complete with audio
+- **Add/remove object:** Introduce new objects or remove existing ones from generated videos while preserving scene composition (currently uses Veo 2, no audio)
+- **Digital watermarking:** All videos marked with SynthID to indicate AI-generated content
+
+## Prompting Formula
+
+A structured prompt yields consistent, high-quality results. Use this five-part formula:
+
+**[Cinematography] + [Subject] + [Action] + [Context] + [Style & Ambiance]**
+
+### Formula Components
+
+- **Cinematography:** Camera work and shot composition
+- **Subject:** Main character or focal point
+- **Action:** What the subject is doing
+- **Context:** Environment and background elements
+- **Style & ambiance:** Overall aesthetic, mood, and lighting
+
+### Example
+
+```
+Medium shot, a tired corporate worker, rubbing his temples in exhaustion,
+in front of a bulky 1980s computer in a cluttered office late at night.
+The scene is lit by the harsh fluorescent overhead lights and the green
+glow of the monochrome monitor. Retro aesthetic, shot as if on 1980s
+color film, slightly grainy.
+```
+
+## Essential Prompting Techniques
+
+### The Language of Cinematography
+
+The [Cinematography] element is your most powerful tool for conveying tone and emotion.
+
+#### Camera Movement
+
+- Dolly shot
+- Tracking shot
+- Crane shot
+- Aerial view
+- Slow pan
+- POV shot
+
+**Example (Crane shot):**
+```
+Crane shot starting low on a lone hiker and ascending high above,
+revealing they are standing on the edge of a colossal, mist-filled
+canyon at sunrise, epic fantasy style, awe-inspiring, soft morning light.
+```
+
+#### Composition
+
+- Wide shot
+- Close-up
+- Extreme close-up
+- Low angle
+- Two-shot
+
+#### Lens & Focus
+
+- Shallow depth of field
+- Wide-angle lens
+- Soft focus
+- Macro lens
+- Deep focus
+
+**Example (Shallow depth of field):**
+```
+Close-up with very shallow depth of field, a young woman's face,
+looking out a bus window at the passing city lights with her reflection
+faintly visible on the glass, inside a bus at night during a rainstorm,
+melancholic mood with cool blue tones, moody, cinematic.
+```
+
+### Directing the Soundstage
+
+Veo 3.1 generates complete soundtracks based on text instructions.
+
+#### Dialogue
+
+Use quotation marks for specific speech:
+```
+A woman says, "We have to leave now."
+```
+
+#### Sound Effects (SFX)
+
+Describe sounds with clarity:
+```
+SFX: thunder cracks in the distance
+```
+
+#### Ambient Noise
+
+Define background soundscape:
+```
+Ambient noise: the quiet hum of a starship bridge
+```
+
+### Mastering Negative Prompts
+
+Describe what you wish to exclude affirmatively.
+
+**Instead of:** "no man-made structures"
+**Use:** "a desolate landscape with no buildings or roads"
+
+### Prompt Enhancement with Gemini
+
+Use Gemini to analyze and enrich simple prompts with more descriptive and cinematic language.
+
+## Advanced Creative Workflows
+
+Multi-step workflows offer unparalleled control by breaking down the creative process into manageable stages.
+
+### Workflow 1: Dynamic Transition with "First and Last Frame"
+
+Create specific and controlled camera movement or transformation between two distinct points of view.
+
+#### Step 1: Create the Starting Frame
+
+Use Gemini 2.5 Flash Image to generate initial shot.
+
+**Example prompt:**
+```
+Medium shot of a female pop star singing passionately into a vintage
+microphone. She is on a dark stage, lit by a single, dramatic spotlight
+from the front. She has her eyes closed, capturing an emotional moment.
+Photorealistic, cinematic.
+```
+
+#### Step 2: Create the Ending Frame
+
+Generate a second, complementary image (e.g., different POV angle).
+
+**Example prompt:**
+```
+POV shot from behind the singer on stage, looking out at a large,
+cheering crowd. The stage lights are bright, creating lens flare.
+You can see the back of the singer's head and shoulders in the foreground.
+The audience is a sea of lights and silhouettes. Energetic atmosphere.
+```
+
+#### Step 3: Animate with Veo
+
+Input both images using the **First and Last Frame** feature. Describe the transition and desired audio.
+
+**Example prompt:**
+```
+The camera performs a smooth 180-degree arc shot, starting with the
+front-facing view of the singer and circling around her to seamlessly
+end on the POV shot from behind her on stage. The singer sings
+"when you look me in the eyes, I can see a million stars."
+```
+
+### Workflow 2: Building a Dialogue Scene with "Ingredients to Video"
+
+Create multi-shot scenes with consistent characters engaged in conversation.
+
+#### Step 1: Generate Your "Ingredients"
+
+Create reference images using Gemini 2.5 Flash Image for characters and settings.
+
+#### Step 2: Compose the Scene
+
+Use **Ingredients to Video** feature with relevant reference images.
+
+**Example prompts:**
+
+Shot 1:
+```
+Using the provided images for the detective, the woman, and the office
+setting, create a medium shot of the detective behind his desk. He looks
+up at the woman and says in a weary voice, "Of all the offices in this
+town, you had to walk into mine."
+```
+
+Shot 2:
+```
+Using the provided images for the detective, the woman, and the office
+setting, create a shot focusing on the woman. A slight, mysterious smile
+plays on her lips as she replies, "You were highly recommended."
+```
+
+### Workflow 3: Timestamp Prompting
+
+Direct a complete, multi-shot sequence with precise cinematic pacing within a single generation. Assign actions to timed segments to create full scenes with multiple distinct shots efficiently.
+
+**Example:**
+
+```
+[00:00-00:02] Medium shot from behind a young female explorer with a
+leather satchel and messy brown hair in a ponytail, as she pushes aside
+a large jungle vine to reveal a hidden path.
+
+[00:02-00:04] Reverse shot of the explorer's freckled face, her expression
+filled with awe as she gazes upon ancient, moss-covered ruins in the
+background. SFX: The rustle of dense leaves, distant exotic bird calls.
+
+[00:04-00:06] Tracking shot following the explorer as she steps into the
+clearing and runs her hand over the intricate carvings on a crumbling
+stone wall. Emotion: Wonder and reverence.
+
+[00:06-00:08] Wide, high-angle crane shot, revealing the lone explorer
+standing small in the center of the vast, forgotten temple complex,
+half-swallowed by the jungle. SFX: A swelling, gentle orchestral score
+begins to play.
+```
+
+## Tips for Success
+
+1. **Be specific:** Detailed prompts yield more precise results
+2. **Use the formula:** Structure prompts with [Cinematography] + [Subject] + [Action] + [Context] + [Style & Ambiance]
+3. **Master cinematography language:** Camera movements and lens choices convey emotion
+4. **Direct audio explicitly:** Use quotation marks for dialogue, describe SFX and ambient noise
+5. **Experiment with workflows:** Combine Veo with Gemini 2.5 Flash Image for complex projects
+6. **Iterate:** The best way to master these techniques is through real-world application

--- a/google/skills/veo/references/prompting-guide.md
+++ b/google/skills/veo/references/prompting-guide.md
@@ -1,97 +1,29 @@
-# Veo 3.1 Prompting Guide
+# Veo 3.1 — prompt craft
 
-Complete guide to prompting Google's Veo 3.1 video generation model.
+The prompt text you cannot guess: cinematography vocabulary, negative
+prompting, and the three multi-input workflows written as prompts. The API
+shapes those workflows need are in [api-examples.md](./api-examples.md); the
+five-part formula and audio direction are in [SKILL.md](../SKILL.md) and are
+not repeated here.
 
-Source: [Google Cloud Blog - Ultimate Prompting Guide for Veo 3.1](https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-veo-3-1)
+Source: [Google Cloud Blog — Ultimate Prompting Guide for Veo 3.1](https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-veo-3-1)
 
-## Table of Contents
+## The language of cinematography
 
-1. [Model Capabilities](#model-capabilities)
-2. [Prompting Formula](#prompting-formula)
-3. [Essential Prompting Techniques](#essential-prompting-techniques)
-4. [Advanced Creative Workflows](#advanced-creative-workflows)
+The [Cinematography] slot of the formula is the strongest lever on tone.
 
-## Model Capabilities
+- **Camera movement** — dolly, tracking, crane, aerial, slow pan, POV
+- **Composition** — wide, close-up, extreme close-up, low angle, two-shot
+- **Lens & focus** — shallow depth of field, wide-angle, soft focus, macro, deep focus
 
-### Core Generation Features
+Two worked examples, showing how far the vocabulary carries a whole prompt:
 
-- **High-fidelity video:** 720p or 1080p resolution
-- **Aspect ratio:** 16:9 or 9:16
-- **Variable clip length:** 4, 6, or 8 seconds
-- **Rich audio & dialogue:** Realistic, synchronized sound including multi-person conversations and precisely timed sound effects
-- **Complex scene comprehension:** Deeper understanding of narrative structure and cinematic styles for better character interactions and storytelling
-
-### Advanced Creative Controls
-
-- **Improved image-to-video:** Animate source images with greater prompt adherence and enhanced audio-visual quality
-- **Consistent elements ("ingredients to video"):** Provide reference images of scenes, characters, objects, or styles to maintain consistent aesthetics across multiple shots (includes audio generation)
-- **Seamless transitions ("first and last frame"):** Generate natural video transitions between provided start and end images, complete with audio
-- **Add/remove object:** Introduce new objects or remove existing ones from generated videos while preserving scene composition (currently uses Veo 2, no audio)
-- **Digital watermarking:** All videos marked with SynthID to indicate AI-generated content
-
-## Prompting Formula
-
-A structured prompt yields consistent, high-quality results. Use this five-part formula:
-
-**[Cinematography] + [Subject] + [Action] + [Context] + [Style & Ambiance]**
-
-### Formula Components
-
-- **Cinematography:** Camera work and shot composition
-- **Subject:** Main character or focal point
-- **Action:** What the subject is doing
-- **Context:** Environment and background elements
-- **Style & ambiance:** Overall aesthetic, mood, and lighting
-
-### Example
-
-```
-Medium shot, a tired corporate worker, rubbing his temples in exhaustion,
-in front of a bulky 1980s computer in a cluttered office late at night.
-The scene is lit by the harsh fluorescent overhead lights and the green
-glow of the monochrome monitor. Retro aesthetic, shot as if on 1980s
-color film, slightly grainy.
-```
-
-## Essential Prompting Techniques
-
-### The Language of Cinematography
-
-The [Cinematography] element is your most powerful tool for conveying tone and emotion.
-
-#### Camera Movement
-
-- Dolly shot
-- Tracking shot
-- Crane shot
-- Aerial view
-- Slow pan
-- POV shot
-
-**Example (Crane shot):**
 ```
 Crane shot starting low on a lone hiker and ascending high above,
 revealing they are standing on the edge of a colossal, mist-filled
 canyon at sunrise, epic fantasy style, awe-inspiring, soft morning light.
 ```
 
-#### Composition
-
-- Wide shot
-- Close-up
-- Extreme close-up
-- Low angle
-- Two-shot
-
-#### Lens & Focus
-
-- Shallow depth of field
-- Wide-angle lens
-- Soft focus
-- Macro lens
-- Deep focus
-
-**Example (Shallow depth of field):**
 ```
 Close-up with very shallow depth of field, a young woman's face,
 looking out a bus window at the passing city lights with her reflection
@@ -99,55 +31,20 @@ faintly visible on the glass, inside a bus at night during a rainstorm,
 melancholic mood with cool blue tones, moody, cinematic.
 ```
 
-### Directing the Soundstage
+## Negative prompts
 
-Veo 3.1 generates complete soundtracks based on text instructions.
+State the exclusion affirmatively — describe the scene you want, not the
+thing you want absent.
 
-#### Dialogue
+- Instead of `no man-made structures`
+- Write `a desolate landscape with no buildings or roads`
 
-Use quotation marks for specific speech:
-```
-A woman says, "We have to leave now."
-```
+## Workflow 1 — dynamic transition (first and last frame)
 
-#### Sound Effects (SFX)
+Generate the two endpoint frames with an image model, then let Veo move
+between them.
 
-Describe sounds with clarity:
-```
-SFX: thunder cracks in the distance
-```
-
-#### Ambient Noise
-
-Define background soundscape:
-```
-Ambient noise: the quiet hum of a starship bridge
-```
-
-### Mastering Negative Prompts
-
-Describe what you wish to exclude affirmatively.
-
-**Instead of:** "no man-made structures"
-**Use:** "a desolate landscape with no buildings or roads"
-
-### Prompt Enhancement with Gemini
-
-Use Gemini to analyze and enrich simple prompts with more descriptive and cinematic language.
-
-## Advanced Creative Workflows
-
-Multi-step workflows offer unparalleled control by breaking down the creative process into manageable stages.
-
-### Workflow 1: Dynamic Transition with "First and Last Frame"
-
-Create specific and controlled camera movement or transformation between two distinct points of view.
-
-#### Step 1: Create the Starting Frame
-
-Use Gemini 2.5 Flash Image to generate initial shot.
-
-**Example prompt:**
+Starting frame:
 ```
 Medium shot of a female pop star singing passionately into a vintage
 microphone. She is on a dark stage, lit by a single, dramatic spotlight
@@ -155,11 +52,7 @@ from the front. She has her eyes closed, capturing an emotional moment.
 Photorealistic, cinematic.
 ```
 
-#### Step 2: Create the Ending Frame
-
-Generate a second, complementary image (e.g., different POV angle).
-
-**Example prompt:**
+Ending frame — a complementary point of view:
 ```
 POV shot from behind the singer on stage, looking out at a large,
 cheering crowd. The stage lights are bright, creating lens flare.
@@ -167,11 +60,7 @@ You can see the back of the singer's head and shoulders in the foreground.
 The audience is a sea of lights and silhouettes. Energetic atmosphere.
 ```
 
-#### Step 3: Animate with Veo
-
-Input both images using the **First and Last Frame** feature. Describe the transition and desired audio.
-
-**Example prompt:**
+The Veo prompt then describes the movement between them, and the audio:
 ```
 The camera performs a smooth 180-degree arc shot, starting with the
 front-facing view of the singer and circling around her to seamlessly
@@ -179,19 +68,10 @@ end on the POV shot from behind her on stage. The singer sings
 "when you look me in the eyes, I can see a million stars."
 ```
 
-### Workflow 2: Building a Dialogue Scene with "Ingredients to Video"
+## Workflow 2 — dialogue scene (ingredients to video)
 
-Create multi-shot scenes with consistent characters engaged in conversation.
-
-#### Step 1: Generate Your "Ingredients"
-
-Create reference images using Gemini 2.5 Flash Image for characters and settings.
-
-#### Step 2: Compose the Scene
-
-Use **Ingredients to Video** feature with relevant reference images.
-
-**Example prompts:**
+Generate reference images for each character and setting, then name them in
+the prompt so consecutive shots stay consistent.
 
 Shot 1:
 ```
@@ -208,11 +88,11 @@ setting, create a shot focusing on the woman. A slight, mysterious smile
 plays on her lips as she replies, "You were highly recommended."
 ```
 
-### Workflow 3: Timestamp Prompting
+## Workflow 3 — timestamp prompting
 
-Direct a complete, multi-shot sequence with precise cinematic pacing within a single generation. Assign actions to timed segments to create full scenes with multiple distinct shots efficiently.
-
-**Example:**
+A multi-shot sequence inside one generation. There is no parameter for this —
+the timing lives in the prompt text, so the segments must sum to the clip
+length you asked for.
 
 ```
 [00:00-00:02] Medium shot from behind a young female explorer with a
@@ -232,12 +112,3 @@ standing small in the center of the vast, forgotten temple complex,
 half-swallowed by the jungle. SFX: A swelling, gentle orchestral score
 begins to play.
 ```
-
-## Tips for Success
-
-1. **Be specific:** Detailed prompts yield more precise results
-2. **Use the formula:** Structure prompts with [Cinematography] + [Subject] + [Action] + [Context] + [Style & Ambiance]
-3. **Master cinematography language:** Camera movements and lens choices convey emotion
-4. **Direct audio explicitly:** Use quotation marks for dialogue, describe SFX and ambient noise
-5. **Experiment with workflows:** Combine Veo with Gemini 2.5 Flash Image for complex projects
-6. **Iterate:** The best way to master these techniques is through real-world application

--- a/google/skills/veo/references/prompting-guide.md
+++ b/google/skills/veo/references/prompting-guide.md
@@ -1,10 +1,10 @@
-# Veo 3.1 — prompt craft
+# Veo — prompt craft
 
-The prompt text you cannot guess: cinematography vocabulary, negative
-prompting, and the three multi-input workflows written as prompts. The API
-shapes those workflows need are in [api-examples.md](./api-examples.md); the
-five-part formula and audio direction are in [SKILL.md](../SKILL.md) and are
-not repeated here.
+The prompt text you cannot guess: cinematography vocabulary, audio
+direction, negative prompting, and the three multi-input workflows written
+as prompts. The API shapes those workflows need are in
+[api-examples.md](./api-examples.md); the five-part formula is in
+[SKILL.md](../SKILL.md) and is not repeated here.
 
 Source: [Google Cloud Blog — Ultimate Prompting Guide for Veo 3.1](https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-veo-3-1)
 
@@ -30,6 +30,18 @@ looking out a bus window at the passing city lights with her reflection
 faintly visible on the glass, inside a bus at night during a rainstorm,
 melancholic mood with cool blue tones, moody, cinematic.
 ```
+
+## Audio direction
+
+The soundtrack is written into the same prompt as the picture — three
+idioms carry it:
+
+- **Dialogue** — quotation marks: `A woman says, "We have to leave now."`
+- **Sound effects** — named explicitly: `SFX: thunder cracks in the distance`
+- **Ambient noise** — the background bed: `Ambient noise: the quiet hum of a starship bridge`
+
+Silence is worth stating too, when you want it — an unmentioned soundtrack
+is not the same instruction as a specified quiet one.
 
 ## Negative prompts
 

--- a/google/skills/veo/scripts/generate_video.py
+++ b/google/skills/veo/scripts/generate_video.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "google-genai>=2.3.0",
+# ]
+# ///
+"""
+Veo Video Generation via the Gemini API
+
+Text-to-video or image-to-video. Polls until the operation completes and
+writes the result to a file.
+
+Out of scope, deliberately not scripted: video-to-video (extension),
+first/last-frame transitions, and ingredients-to-video (reference images).
+Those take more inputs than a CLI comfortably carries; see
+references/api-examples.md for worked code you adapt in place.
+
+Usage (the skill runs with the user's project as cwd, never this directory,
+so every invocation goes through the plugin root):
+    SCRIPT="${CLAUDE_PLUGIN_ROOT}/skills/veo/scripts/generate_video.py"
+
+    uv run "$SCRIPT" "A neon hologram of a cat driving at top speed"
+    uv run "$SCRIPT" "Slow dolly shot, cinematic lighting" --image photo.jpg
+    uv run "$SCRIPT" "Zoom out to reveal the city skyline" --model veo-3.1-fast-generate-preview --duration 4
+
+Environment:
+    GEMINI_API_KEY - Google AI API key (required)
+
+The dependency is declared inline (PEP 723); uv resolves it. There is no
+manual install step.
+"""
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+try:
+    from google import genai
+    from google.genai import types
+except ImportError:
+    print("Error: google-genai not available. Run this through uv "
+          "(`uv run <path>/generate_video.py ...`) so the inline dependency "
+          "resolves.", file=sys.stderr)
+    sys.exit(1)
+
+
+MODEL_CHOICES = [
+    "veo-3.1-generate-preview",
+    "veo-3.1-fast-generate-preview",
+    "veo-3.1-lite-generate-preview",
+]
+DEFAULT_MODEL = "veo-3.1-generate-preview"
+
+DURATION_CHOICES = [4, 6, 8]
+DEFAULT_DURATION = 8
+
+# google-genai opts OUT of a default httpx timeout by setting it to None, so a
+# stalled request would hang with no ceiling. The SDK takes this value in
+# MILLISECONDS at its boundary.
+HTTP_TIMEOUT_SECONDS = 600
+
+POLL_INTERVAL_SECONDS = 20
+
+IMAGE_MIME_TYPES = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+}
+
+
+def load_image(path: str) -> types.Image:
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Image not found: {path}")
+    mime_type = IMAGE_MIME_TYPES.get(p.suffix.lower())
+    if mime_type is None:
+        raise ValueError(
+            f"{p.suffix or p.name} is not a supported image extension. "
+            f"Supported: {', '.join(sorted(IMAGE_MIME_TYPES))}."
+        )
+    return types.Image(image_bytes=p.read_bytes(), mime_type=mime_type)
+
+
+def generate(client: genai.Client, args: argparse.Namespace) -> types.Video:
+    source_kwargs = {"prompt": args.prompt}
+    if args.image:
+        source_kwargs["image"] = load_image(args.image)
+
+    operation = client.models.generate_videos(
+        model=args.model,
+        source=types.GenerateVideosSource(**source_kwargs),
+        config=types.GenerateVideosConfig(
+            number_of_videos=1,
+            duration_seconds=args.duration,
+            aspect_ratio=args.aspect_ratio,
+            resolution=args.resolution,
+        ),
+    )
+
+    print(f"Generating with {args.model} ({args.duration}s, "
+          f"{args.aspect_ratio}, {args.resolution})...", file=sys.stderr)
+    while not operation.done:
+        time.sleep(POLL_INTERVAL_SECONDS)
+        operation = client.operations.get(operation)
+        print("...still running", file=sys.stderr)
+
+    if operation.error:
+        raise RuntimeError(f"Video generation failed: {operation.error}")
+    if not operation.response or not operation.response.generated_videos:
+        raise RuntimeError(f"No video in response: {operation.response}")
+
+    video = operation.response.generated_videos[0].video
+    if video is None:
+        raise RuntimeError("Response carried a generated_videos entry with no video.")
+    return video
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate a video with Veo via the Gemini API",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("prompt", help="Text prompt describing the video")
+    parser.add_argument(
+        "--image",
+        help="Source image to animate (image-to-video). Omit for text-to-video.",
+    )
+    parser.add_argument(
+        "--model",
+        choices=MODEL_CHOICES,
+        default=DEFAULT_MODEL,
+        help=f"Veo variant (default: {DEFAULT_MODEL})",
+    )
+    parser.add_argument(
+        "--duration",
+        type=int,
+        choices=DURATION_CHOICES,
+        default=DEFAULT_DURATION,
+        help=f"Clip length in seconds (default: {DEFAULT_DURATION})",
+    )
+    parser.add_argument(
+        "--aspect-ratio",
+        choices=["16:9", "9:16"],
+        default="16:9",
+        help="Aspect ratio (default: 16:9)",
+    )
+    parser.add_argument(
+        "--resolution",
+        choices=["720p", "1080p"],
+        default="1080p",
+        help="Resolution (default: 1080p)",
+    )
+    parser.add_argument(
+        "--output",
+        default="output.mp4",
+        help="Output file path (default: output.mp4)",
+    )
+    args = parser.parse_args()
+
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        print("Error: GEMINI_API_KEY environment variable not set",
+              file=sys.stderr)
+        sys.exit(1)
+
+    client = genai.Client(
+        api_key=api_key,
+        http_options={"timeout": HTTP_TIMEOUT_SECONDS * 1000},
+    )
+
+    try:
+        video = generate(client, args)
+        if video.video_bytes:
+            Path(args.output).write_bytes(video.video_bytes)
+            print(f"Saved to {args.output}", file=sys.stderr)
+        elif video.uri:
+            print(f"Video available at: {video.uri}", file=sys.stderr)
+        else:
+            raise RuntimeError("Response carried neither video bytes nor a URI.")
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/google/skills/veo/scripts/generate_video.py
+++ b/google/skills/veo/scripts/generate_video.py
@@ -22,7 +22,10 @@ so every invocation goes through the plugin root):
 
     uv run "$SCRIPT" "A neon hologram of a cat driving at top speed"
     uv run "$SCRIPT" "Slow dolly shot, cinematic lighting" --image photo.jpg
-    uv run "$SCRIPT" "Zoom out to reveal the city skyline" --model veo-3.1-fast-generate-preview --duration 4
+    uv run "$SCRIPT" "Zoom out to reveal the city skyline" --model veo-3.1-fast-generate-preview --duration 4 --resolution 720p
+
+A clip shorter than 8 seconds must be 720p; --resolution defaults to 1080p,
+so the two flags move together.
 
 Environment:
     GEMINI_API_KEY - Google AI API key (required)
@@ -56,6 +59,13 @@ DEFAULT_MODEL = "veo-3.1-generate-preview"
 
 DURATION_CHOICES = [4, 6, 8]
 DEFAULT_DURATION = 8
+
+# The Veo 3.1 line couples the two: above 720p a clip is 8 seconds or nothing.
+# The default resolution is the high one, so shortening a clip alone produces a
+# pair the API rejects — and it rejects it after the request is out, naming the
+# combination rather than the flag the caller actually moved.
+FIXED_DURATION_RESOLUTIONS = {"1080p", "4k"}
+FIXED_DURATION = 8
 
 # google-genai opts OUT of a default httpx timeout by setting it to None, so a
 # stalled request would hang with no ceiling. The SDK takes this value in
@@ -160,6 +170,12 @@ def main():
         help="Output file path (default: output.mp4)",
     )
     args = parser.parse_args()
+
+    if args.resolution in FIXED_DURATION_RESOLUTIONS and args.duration != FIXED_DURATION:
+        print(f"Error: {args.resolution} is {FIXED_DURATION}s only. Either pass "
+              f"--resolution 720p to keep --duration {args.duration}, or drop "
+              f"--duration to get the {FIXED_DURATION}s default.", file=sys.stderr)
+        sys.exit(1)
 
     api_key = os.getenv("GEMINI_API_KEY")
     if not api_key:

--- a/google/skills/veo/scripts/generate_video.py
+++ b/google/skills/veo/scripts/generate_video.py
@@ -174,13 +174,23 @@ def main():
 
     try:
         video = generate(client, args)
-        if video.video_bytes:
-            Path(args.output).write_bytes(video.video_bytes)
-            print(f"Saved to {args.output}", file=sys.stderr)
-        elif video.uri:
-            print(f"Video available at: {video.uri}", file=sys.stderr)
-        else:
+        # The API may return the clip inline or as a file reference; which one
+        # arrives is not something the caller controls. A URI-only response
+        # used to be printed and left there, so the run exited 0 having written
+        # nothing — fetch it instead, and fall back to surfacing the URI only
+        # when the fetch itself fails, so the clip stays recoverable by hand.
+        if not video.video_bytes and video.uri:
+            try:
+                client.files.download(file=video)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Could not download the generated video ({e}). "
+                    f"Fetch it manually within the file's retention window: {video.uri}"
+                ) from e
+        if not video.video_bytes:
             raise RuntimeError("Response carried neither video bytes nor a URI.")
+        Path(args.output).write_bytes(video.video_bytes)
+        print(f"Saved to {args.output}", file=sys.stderr)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/google/skills/veo/scripts/generate_video.py
+++ b/google/skills/veo/scripts/generate_video.py
@@ -22,10 +22,10 @@ so every invocation goes through the plugin root):
 
     uv run "$SCRIPT" "A neon hologram of a cat driving at top speed"
     uv run "$SCRIPT" "Slow dolly shot, cinematic lighting" --image photo.jpg
-    uv run "$SCRIPT" "Zoom out to reveal the city skyline" --model veo-3.1-fast-generate-preview --duration 4 --resolution 720p
+    uv run "$SCRIPT" "Zoom out to reveal the city skyline" --duration 4 --resolution 720p
 
-A clip shorter than 8 seconds must be 720p; --resolution defaults to 1080p,
-so the two flags move together.
+Duration and resolution are not independent; --help's flag list carries the
+accepted values, and an unusable pair is rejected before the request goes out.
 
 Environment:
     GEMINI_API_KEY - Google AI API key (required)
@@ -60,11 +60,17 @@ DEFAULT_MODEL = "veo-3.1-generate-preview"
 DURATION_CHOICES = [4, 6, 8]
 DEFAULT_DURATION = 8
 
-# The Veo 3.1 line couples the two: above 720p a clip is 8 seconds or nothing.
-# The default resolution is the high one, so shortening a clip alone produces a
-# pair the API rejects — and it rejects it after the request is out, naming the
+# A local mirror of a vendor rule, kept because the alternative is learning it
+# from a rejected request: the default resolution is the high one, so shortening
+# a clip alone produces a pair the API refuses — and it refuses by naming the
 # combination rather than the flag the caller actually moved.
-FIXED_DURATION_RESOLUTIONS = {"1080p", "4k"}
+#
+# Being a mirror, it can go stale in the one direction that hurts: if the vendor
+# relaxes the pairing, this rejects a call the API would now accept. That is the
+# bug to suspect first if a valid-looking pair stops working — widen or delete
+# the check rather than working around it. Members must stay reachable through
+# the --resolution choices below, or they assert a rule nothing can trigger.
+FIXED_DURATION_RESOLUTIONS = {"1080p"}
 FIXED_DURATION = 8
 
 # google-genai opts OUT of a default httpx timeout by setting it to None, so a
@@ -190,11 +196,10 @@ def main():
 
     try:
         video = generate(client, args)
-        # The API may return the clip inline or as a file reference; which one
-        # arrives is not something the caller controls. A URI-only response
-        # used to be printed and left there, so the run exited 0 having written
-        # nothing — fetch it instead, and fall back to surfacing the URI only
-        # when the fetch itself fails, so the clip stays recoverable by hand.
+        # The API may return the clip inline or as a file reference, and which
+        # one arrives is not the caller's to control — so fetch the reference
+        # rather than reporting it, and surface the URI only when the fetch
+        # itself fails, keeping the clip recoverable by hand.
         if not video.video_bytes and video.uri:
             try:
                 client.files.download(file=video)


### PR DESCRIPTION
## What

Restores `google/skills/veo/` (text-to-video, image-to-video, video
extension, first/last-frame, ingredients-to-video, cinematography
prompting) from `b9fa95f^` — the commit that deleted it, `chore: prune
internalized and unused plugins` (2026-05-13). That commit also deleted
`google/skills/gemini/` and `google/skills/nanobanana-prompt/`; both stay
deleted, out of scope for this change.

Files came back via `git checkout b9fa95f^ -- google/skills/veo`, then
were modernized (not retyped).

## What changed vs. the restored (2026-01) version

- **Auth**: `vertexai=True` + `GOOGLE_CLOUD_PROJECT` (ADC) → `GEMINI_API_KEY`,
  matching the sibling `video-understanding` skill. This machine's active
  gcloud/ADC identity is a *work* account; this is a personal project, and
  Vertex billing must not land on the work account. Every ADC/service-account/
  GCS-URI reference was replaced (client init, video-extension example, the
  old Troubleshooting section, Best Practices).
- **Model surface**: `generate_videos(prompt=, image=, video=)` →
  `generate_videos(source=types.GenerateVideosSource(...))` throughout — the
  direct kwargs are SDK-deprecated in favor of `source`. (The specific
  removal-version string and date are in the commit message, not here — see
  "measured facts" below.)
- **Three Veo variants documented**, each with a "when to pick it" note:
  `veo-3.1-generate-preview` (best fidelity), `veo-3.1-fast-generate-preview`
  (faster iteration), `veo-3.1-lite-generate-preview` (cheapest/high-volume).
  All three, plus `gemini-omni-flash-preview` (next point), were confirmed
  present on the account's live Gemini API model list.
- **Routing change — Omni Flash first**: both the SKILL.md body and the
  frontmatter `description` now say to prefer Gemini Omni Flash for a plain
  "generate a video" request — it's Google's current default (per
  https://ai.google.dev/gemini-api/docs/video, updated 2026-06-30): better
  coherence, multi-input reasoning, character consistency, multi-turn
  editing. This skill is scoped to when Veo's own controls are actually
  needed: scene extension, last-frame control, an existing Veo pipeline.
- **Duration**: dropped the old `duration_seconds=5` example — Veo 3.x
  supports only 4/6/8s. Every example and the script default now use 8. No
  in-repo or doc evidence found that 5 still works; not tested (no paid call).
- **Watermarking**: kept the documented claim (SynthID invisible watermark on
  Veo output). Added an explicit *unverified* marker for whether API output
  additionally carries a **visible** watermark, the way some consumer
  surfaces (Gemini app, Flow) do — not asserted either way.
- **New `scripts/generate_video.py`**, matching the sibling skill's
  script-plus-SKILL.md layout (PEP 723 inline deps, `CLAUDE_PLUGIN_ROOT`
  invocation, stdout/stderr discipline) instead of the old copy-paste-block
  style. Scoped to text-to-video and image-to-video; the CLI-unfriendly
  workflows (video extension, first/last frame, ingredients, timestamp
  prompting) stay as documented code in `references/api-examples.md`.
  `--help`, an AST syntax check, and `pyright` all pass clean against the
  resolved SDK. No paid generation call was made anywhere in this change.

## Measured facts (kept out of the skill files, per this repo's
ledger-separate convention — full detail in the commit message)

- Vertex AI per-second pricing for all three variants, plus a worked
  8-second-clip example ($0.24 Lite video-only 720p; $3.20 full Veo 3.1
  with audio 1080p) — retrieved 2026-08-10. SKILL.md instead points at the
  live pricing page and states the two cost levers (resolution, audio vs
  video-only) that hold regardless of when the price changes.
- The SDK's runtime `DeprecationWarning` text for the `prompt=`/`image=`/
  `video=` kwargs, including the "not before 2026-07-31" removal floor
  (already passed as of this PR) — and that this string's presence is
  version-dependent (absent through google-genai 2.10.0, present from
  ~2.11–2.14 onward; the script's unpinned `>=2.3.0` floor means `uv run`
  resolves whatever is newest, 2.17.0 today, where it's present). Checked
  and confirmed `source=` support itself is available already at the
  existing 2.3.0 floor, so the floor did not need raising.

## `plugin.json` / `marketplace.json` — beyond the letter of the restore ask

Neither file enumerates skills individually, so the restore instruction's
literal reading was "change nothing." Two edits happened anyway, both
authorized explicitly here so they're visible rather than a silent extra:

- **`description`**: "Google Gemini video understanding" → "Google Gemini
  video understanding, Veo video generation" (in both `google/.claude-plugin/plugin.json`
  and the marketplace listing) — the old text became wrong the moment veo
  came back; `b9fa95f`'s own diff shows description is how this plugin
  tracks its skill set.
- **`version`**: bumped `2.0.1` → `2.1.0` → `2.1.1` — the repo's
  `check-version-bump` pre-commit hook requires a version bump in the same
  commit as any semantic-file change to a plugin; it fired twice (once for
  the initial restore, once for the follow-up edit that moved the pricing
  table and deprecation text out of the skill files and into the commit
  message), and both bumps satisfy it honestly rather than bypassing it.

No other edit was made to either file.

## Unverified — flagging explicitly rather than asserting

- **Visible watermark on API output**: not verified. SynthID (invisible) is
  documented as applied to Veo output; whether a *separate, visible*
  watermark appears on API output (as opposed to consumer UI surfaces like
  the Gemini app or Flow) is not confirmed either way.
- **`duration_seconds=5`**: not tested against the live API (no paid call
  made). Google's documentation states 4/6/8s are the supported values;
  the old example's `5` was replaced with `8` on that basis, not verified
  by a call.
- **Ingredients-to-video (`reference_images`) on veo-3.1**: the SDK's own
  field documentation describes this feature in terms of Veo 2 ("Veo 2
  supports up to 3 asset images or 1 style image"); full support on the
  veo-3.1 model line is not verified here.

## Rejected alternatives (full reasoning in commit message)

- Keeping Vertex AI as a documented fallback auth path — doubles the auth
  surface for no stated need, and is exactly the path that risks
  work-account billing.
- Scripting every workflow (video extension, first/last frame,
  ingredients) — CLI argument surface would be large, and none of the
  advanced paths can be verified against the account without a paid call.
