### PR TITLE
remote-tmux: spawn with --permission-mode auto, not the bypass flag

### DIFF
--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are app-reachable and addressable by SendMessage (remote-spawn skill), or keep a self-restarting --spawn-worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/README.md
+++ b/remote-tmux/README.md
@@ -15,7 +15,7 @@ app-reachable, and addressable by `SendMessage` from other sessions:
 
 ```bash
 ( cd ~/src/foo && claude --bg --worktree foo --remote-control foo -n foo \
-                         --dangerously-skip-permissions -- "<brief>" )
+                         --permission-mode auto -- "<brief>" )
 
 claude agents --json     # fleet view (no TTY needed)
 claude logs   <jobId>    # recent output
@@ -51,9 +51,13 @@ session is addressable by `SendMessage`, so a supervisor can direct it instead o
 launching it. A tmux pane could do neither.
 
 Two caveats worth knowing:
-- **Permission classes must match.** A cross-session message from a different permission
-  class is not delivered — it opens a dialog the worker never answers, so the instruction
-  silently never arrives.
+- **Permission classes must match**, which is why the command above passes `--permission-mode
+  auto` rather than a bypass flag. A cross-session message from a different permission class is
+  not delivered — it opens a dialog the worker never answers, so the instruction silently never
+  arrives. From an auto-mode supervisor the bypass flag is not an option regardless:
+  `--dangerously-skip-permissions` inside a spawn command is refused by auto mode's own
+  classifier, denying the spawn before a worker exists. Pass whatever class the supervisor is
+  actually in — the registry does not record it, but the supervisor's transcript does.
 - `status: "waiting"` in the registry means an unanswered dialog exists, **not** that the
   session is stuck; it still takes app input and peer messages. Judge by how long
   `statusUpdatedAt` has been frozen.

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -16,7 +16,7 @@ app-reachable, and message-addressable:
 
 ```bash
 ( cd <project-dir> && claude --bg --worktree <unit> --remote-control <unit> -n <unit> \
-                             --dangerously-skip-permissions -- "<brief + reporting contract>" )
+                             --permission-mode auto -- "<brief + reporting contract>" )
 ```
 
 It prints `backgrounded · <jobId> · <name>`. Report that back. The four flags are
@@ -36,10 +36,17 @@ starts with a dash, or that follows `--remote-control` (whose name argument is o
 will happily swallow it), is consumed silently — `claude` prints `(idle — send a prompt to
 start)`, no error, no transcript, and a worker sits there having been told nothing.
 
-**The permission mode must match the supervisor's.** A cross-session message from a
-sender in a different permission class is not delivered — it opens a dialog the worker
-never answers, so the instruction silently never arrives. Spawn workers in the same
-class as whoever will be messaging them.
+**The permission mode must match the supervisor's**, and `--permission-mode auto` is what
+that resolves to from an auto-mode supervisor. Two constraints close on the same value.
+A cross-session message from a sender in a different permission class is not delivered —
+it opens a dialog the worker never answers, so the instruction silently never arrives, which
+is why the worker takes the supervisor's class rather than the most permissive one available.
+And from that class the permissive one is not available anyway: `--dangerously-skip-permissions`
+in a spawn command is refused by auto mode's own permission classifier, so the spawn is denied
+before any worker exists. Pass the supervisor's own class explicitly — it is the one part of
+this command that cannot be copied from a sibling. The session registry does not carry it;
+the supervisor's transcript does, as `{"type":"permission-mode","permissionMode":…}` records
+written on every mode change.
 
 ## Talking to it
 
@@ -99,7 +106,7 @@ to close out a work unit, the same lease discipline a worktree gets.
 
 ```bash
 ( cd <its-cwd> && claude --bg --remote-control <name> -n <name> --resume <sessionId> \
-                         --dangerously-skip-permissions -- "<next instruction>" )
+                         --permission-mode auto -- "<next instruction>" )
 ```
 
 Carry `--remote-control` through the resume too. It composes, and dropping it costs the


### PR DESCRIPTION
The documented spawn command carried `--dangerously-skip-permissions`. From a supervisor running in **auto** mode — which is the class these supervisors actually run in — it fails twice over.

## Evidence

Session `3dc63240-f066-43a8-82c4-569d07df23fc` (repo `delightroom/infra`, supervisor `permissionMode: "auto"`), spawning worker `daro-prod-warpstream`:

**1. The documented form was denied.**

```
Permission for this action was denied by the Claude Code auto mode classifier.
Reason: Blocked by classifier.
```

No worker was created. The bypass flag inside a spawn command does not survive the launching session's own classifier.

**2. The same command with `--permission-mode auto` succeeded.**

```
backgrounded · 8f22c4c6 · daro-prod-warpstream
```

worktree `.claude/worktrees/daro-prod-warpstream`, branch `worktree-daro-prod-warpstream`, base `a5b9ef94` == `origin/main` HEAD.

**3. Cross-session messaging then worked**, in the direction the skill's class-matching rule predicts — the worker's ACK reached the supervisor as `<cross-session-message from-name="daro-prod-warpstream">`. auto supervisor → auto worker delivers.

## What changed

The two constraints converge rather than trading off: the class-matching rule already required the supervisor's class, and from that class the more permissive flag is unavailable anyway. Examples now show the flag that works; the caveat states both halves.

- `skills/remote-spawn/SKILL.md` — spawn example, resume example, permission-mode note
- `README.md` — spawn example, "Permission classes must match" caveat
- version 5.0.2 → 5.0.3

## Corrected while verifying

A draft of the note pointed readers at `~/.claude/sessions/<pid>.json` to read a supervisor's class. **That file carries no permission field** — its keys are `pid, sessionId, cwd, startedAt, procStart, version, peerProtocol, kind, entrypoint, messagingSocketPath, name, nameSource, status, updatedAt, statusUpdatedAt` (plus `jobId`/`bridgeSessionId` on background entries). The class lives in the session's own transcript as `{"type":"permission-mode","permissionMode":…}` records. The shipped text says that instead.

## Deliberately not touched

rc-pool's `--permission-mode bypassPermissions` (`skills/rc-pool/SKILL.md`, `scripts/rc-pool.sh`). That flag configures the pool *host* rather than a spawn command, so the classifier never sees it — but the same class-matching consequence applies to its children, and changing a running host's class is a behavior change rather than an example correction. Left as a separate decision.
