### PR TITLE
remote-tmux: correct the worker lifecycle against agent-view docs + binary

### DIFF
--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are app-reachable and addressable by SendMessage (remote-spawn skill), or keep a self-restarting --spawn-worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are app-reachable and addressable by SendMessage (remote-spawn skill), or keep a self-restarting --spawn-worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -23,7 +23,10 @@ It prints `backgrounded · <jobId> · <name>`. Report that back. The four flags 
 independent and each earns its place: `--bg` detaches without a PTY, `--worktree`
 cuts a branch `worktree-<unit>` from `origin/<default>`, `--remote-control` registers
 the app bridge, `-n` pins a permanent name (without it the name is regenerated every
-launch). Drop `--worktree` to run in the project directory itself.
+launch). Dropping `--worktree` does not opt out of isolation — it only gives up the named
+branch. A backgrounded session starts in the project directory but is held out of the
+shared checkout: edits there are rejected until the session isolates itself under
+`.claude/worktrees/`. The one opt-out is `worktree.bgIsolation: "none"` in settings.
 
 **The `cd` is what picks the project.** There is no flag for it — `--add-dir` grants tool
 access to extra paths but does not set the session's project; the spawned session simply
@@ -58,7 +61,12 @@ round trip and survives the other hazard: names collide heavily here, and a targ
 restarts changes both its ref and its auto-derived name. So read it, do not cache it.
 
 A worker keeps its socket after finishing a turn: it goes idle and resident, so
-follow-up instructions still reach it.
+follow-up instructions still reach it — but not indefinitely. The supervisor
+eventually reaps an idle worker's process, and a reaped worker keeps its row in
+`claude agents --json` while dropping out of `ListAgents` altogether: still listed,
+no longer addressable. So read addressability from `ListAgents` at send time, never
+from the fleet row. Pinning the session in agent view (`Ctrl+T`) keeps its process
+alive while it sits idle.
 
 ## Reporting contract — put it in the initial prompt
 
@@ -95,6 +103,16 @@ claude rm  <jobId>     # retires it: removes worktree and job state
 `stop` alone is not retirement — the job stays in `claude agents --json --all`. Use `rm`
 to close out a work unit, the same lease discipline a worktree gets.
 
+Retiring is not a loss to be weighed against keeping the row. Ending the process and
+taking the row out of the fleet is the point: a list of finished-looking rows is the
+cost that accumulates, and it is paid by whoever has to read the list. The
+conversation survives `rm` — the transcript stays on disk and `claude --resume
+<sessionId>` still reaches it. What does not survive is anything whose only copy sits
+on the worktree, so audit that first. Sources disagree on how far `rm` reaches there:
+`claude rm --help` says it deletes the session and its worktree outright, while the
+published docs say a worktree with uncommitted changes is kept and unpushed commits
+block deletion. Audit rather than rely on either.
+
 ## Resuming
 
 ```bash
@@ -114,7 +132,16 @@ one next time. `jobId` is the first 8 hex characters of `sessionId`, so the two 
 without a separate key.
 
 Notes to pass on when relevant:
-- No auto-restart by design — nothing revives a crashed worker (see the `rc-pool` skill for
-  the keep-alive case).
+- Nothing revives a *crashed* worker on its own, but restarts do happen: `claude respawn
+  <jobId>` (or `--all`) restarts a session onto the current binary, and the supervisor
+  restarts sessions from their transcript on a binary update or on the next attach. What
+  comes back is a fresh process, and both the messaging socket and the app bridge are
+  decided at launch — whether a restarted worker returns addressable and app-reachable is
+  untested, so re-read `ListAgents` before relying on it. For a keep-alive host, see the
+  `rc-pool` skill.
 - An already-running session cannot become addressable later; the socket is decided once at
   launch, so an old session must be restarted to join.
+- `claude daemon status` reports on the supervisor that hosts every background session;
+  `claude daemon stop --any --keep-workers` stops the supervisor while leaving the workers
+  running. Neither is wanted in normal use — they are the handles for when the fleet itself
+  misbehaves.


### PR DESCRIPTION
## Summary

Corrects four statements in `remote-tmux/skills/remote-spawn/SKILL.md` that a
verification pass found factually wrong or outdated against the official
[agent-view docs](https://code.claude.com/docs/en/agent-view) and the real
`claude` binary (v2.1.229):

1. **`--worktree` isolation** — "Drop `--worktree` to run in the project
   directory itself" was wrong: dropping the flag does not opt out of
   isolation, it only gives up the named branch. A backgrounded session
   without `--worktree` starts in the project directory but has
   shared-checkout edits rejected until it isolates itself under
   `.claude/worktrees/`; the only real opt-out is
   `worktree.bgIsolation: "none"` in settings.
2. **Idle worker addressability** — "goes idle and resident, so follow-up
   instructions still reach it" stated an unbounded guarantee. In practice
   the supervisor eventually reaps an idle worker's process; a reaped worker
   keeps its row in `claude agents --json` but drops out of `ListAgents`
   entirely — still listed, no longer addressable. The note now says to read
   addressability from `ListAgents` at send time, and mentions that pinning
   the session in agent view (`Ctrl+T`) keeps it alive.
3. **Retiring** — expands on why `claude rm` matters (clearing the fleet row
   is the point, not a loss to weigh), and flags that `claude rm --help` and
   the published docs disagree on whether `rm` deletes a worktree holding
   uncommitted changes — telling the reader to audit rather than pick a side.
4. **"No auto-restart by design"** — wrong: `claude respawn <jobId>` (or
   `--all`) exists, and the supervisor restarts sessions from their
   transcript on a binary update or the next attach. The note now covers
   `respawn` and flags that whether a restarted worker comes back addressable
   / app-reachable is untested. Also adds `claude daemon status` /
   `claude daemon stop --any --keep-workers` as the handles for when the
   fleet itself misbehaves.

Full evidence for each correction (specific `claude agents --json` sample,
flags/subcommands confirmed present in v2.1.229) is in the commit message.

Plugin version bumped `remote-tmux` 5.0.2 → 5.0.3 per this repo's
bump-on-change convention (CLAUDE.md) — the pre-commit hook enforces this for
any meaningful plugin file change, and SKILL.md qualifies.

## Conflict with PR #134

**PR #134 is open against the same file
(`remote-tmux/skills/remote-spawn/SKILL.md`) and bumps the same plugin to the
same version (5.0.3) from the same base (`origin/main` @ 5.0.2).** This
branch was cut fresh from `origin/main`, not stacked on #134, so the two
diverge from a common point rather than one building on the other.
Whichever of the two merges second will need a rebase (and likely a further
version bump beyond 5.0.3, since the first merge will already occupy that
slot). Merge order is not resolved in this PR — that's the user's call.

## Verification

- `git diff --stat` (scope): only the two intended files changed.
- `grep -c` for both retired strings ("Drop \`--worktree\` to run in the
  project directory itself", "No auto-restart by design") → 0.
- Pre-commit version-bump hook passed on its own after the bump — no
  `--no-verify` used.
