### PR TITLE
remote-tmux: split worktree token from Stint session name (5.0.5)

### DIFF
--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are app-reachable and addressable by SendMessage (remote-spawn skill), or keep a self-restarting --spawn-worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are app-reachable and addressable by SendMessage (remote-spawn skill), or keep a self-restarting --spawn-worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are app-reachable and addressable by SendMessage (remote-spawn skill), or keep a self-restarting --spawn-worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are app-reachable and addressable by SendMessage (remote-spawn skill), or keep a self-restarting --spawn-worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/README.md
+++ b/remote-tmux/README.md
@@ -14,7 +14,8 @@ No script. One command gives a session that is background-resident, worktree-iso
 app-reachable, and addressable by `SendMessage` from other sessions:
 
 ```bash
-( cd ~/src/foo && claude --bg --worktree foo --remote-control foo -n foo \
+( cd ~/src/foo && claude --bg --worktree foo \
+                         --remote-control stint::foo::build -n stint::foo::build \
                          --permission-mode auto -- "<brief>" )
 
 claude agents --json     # fleet view (no TTY needed)
@@ -27,7 +28,8 @@ claude rm     <jobId>    # retire it: removes worktree and job state
 Each flag is load-bearing: `--bg` detaches without a PTY, `--worktree` cuts a branch from
 `origin/<default>`, `--remote-control` registers the app bridge, `-n` pins a permanent name
 (otherwise it is regenerated every launch, along with the peer ref other sessions address it
-by — so neither is safe to cache).
+by — so neither is safe to cache). The worktree token and the session name are separate on
+purpose — see the skill's naming section.
 
 The two pieces of shell around them are load-bearing as well. The **`cd` is what selects the
 project** — there is no flag for it, the session inherits the launching shell's directory, and

--- a/remote-tmux/README.md
+++ b/remote-tmux/README.md
@@ -15,7 +15,7 @@ app-reachable, and addressable by `SendMessage` from other sessions:
 
 ```bash
 ( cd ~/src/foo && claude --bg --worktree foo \
-                         --remote-control stint::foo::build -n stint::foo::build \
+                         --remote-control "stint::foo::build" -n "stint::foo::build" \
                          --permission-mode auto -- "<brief>" )
 
 claude agents --json     # fleet view (no TTY needed)

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -15,7 +15,7 @@ One command spawns a worker that is background-resident, worktree-isolated,
 app-reachable, and message-addressable:
 
 ```bash
-( cd <project-dir> && claude --bg --worktree <unit> \
+( cd <project-dir> && claude --bg --worktree <surface> \
                              --remote-control "stint::<constituent>::<relation>" \
                              -n "stint::<constituent>::<relation>" \
                              --permission-mode auto -- "<brief + reporting contract>" )
@@ -23,27 +23,26 @@ app-reachable, and message-addressable:
 
 It prints `backgrounded · <jobId> · <name>`. Report that back. The four flags are
 independent and each earns its place: `--bg` detaches without a PTY, `--worktree`
-cuts branch `worktree-<unit>` from `origin/<default>` (or reuses it, below),
-`--remote-control` registers
-the app bridge, `-n` pins a permanent name (without it the name is regenerated every
-launch). Dropping `--worktree` does not opt out of isolation — it only gives up the named
+cuts branch `worktree-<surface>` from `origin/<default>` (or reuses it, below),
+`--remote-control` registers the app bridge, `-n` pins a permanent name (without it the
+name is regenerated every launch). Dropping `--worktree` does not opt out of isolation — it only gives up the named
 branch. A backgrounded session starts in the project directory but is held out of the
 shared checkout: edits there are rejected until the session isolates itself under
 `.claude/worktrees/`. The one opt-out is `worktree.bgIsolation: "none"` in settings.
 
-**`<unit>` and the session name are separate tokens on purpose.** `--worktree` puts its
+**`<surface>` and the session name are separate tokens on purpose.** `--worktree` puts its
 argument through `claude`'s own worktree-name validator, which is stricter than git's
 refname rules: each `/`-separated segment may hold only letters, digits, dots,
 underscores and dashes, to 64 characters total. Reason from git's rules instead and you
 will mispredict — `a+b`, `a,b` and `a@b` are all legal refnames and all rejected here.
-So `<unit>` stays a plain hyphenated token, and the `::` the session name is built on is
+So `<surface>` stays a plain hyphenated token, and the `::` the session name is built on is
 not available to it.
 
 Nor should the two share a value, independent of that constraint: several Stints can
 share one worktree (a build pass and a review pass on the same surface), and one unit of
 work can span several worktrees (a change landing in two repos) — neither direction
 supports a fixed mapping from branch to session name. Sharing needs no special form:
-`--worktree <unit>` is find-or-create, so a second Stint passing a name that already
+`--worktree <surface>` is find-or-create, so a second Stint passing a name that already
 exists joins that worktree and its branch rather than colliding.
 
 **The `cd` is what picks the project.** There is no flag for it — `--add-dir` grants tool
@@ -90,15 +89,18 @@ time, before any such session could be known. Two Stints sharing one unit:
 `<relation>` has to be unique inside its unit — it is the only thing separating two
 Stints that share a `<constituent>`, so reusing one collides on the whole name. Where two
 Stints genuinely hold the same role, the distinguishing coordinate goes into the relation
-itself: `review-137` and `review-153`, two review Stints on one unit.
+itself rather than anywhere else in the name.
 
 Neither segment may carry whitespace, which is why both substitutions are quoted in the
-command above. The asymmetry is the part worth holding on to: `<unit>` is covered by the
-validator, which rejects a bad token loudly before anything gets created, while the
-session name passes through no validator at all. There a space is not an error but a
-truncation — `--remote-control stint::my unit::build` registers `stint::my` and leaves
-the rest as a stray positional, so the worker comes up under a name nobody can address it
-by. The same free derivation that is safe on one token fails silently on the other.
+command above. That bars the character, not the phrase: a multi-word name stays
+multi-word, hyphenated — `comment-review`, not `commentreview`. Compressing a title into
+a single token to make it fit throws away the reading the token was chosen for. The
+asymmetry is the part worth holding on to: `<surface>` is covered by the validator,
+which rejects a bad token loudly before anything gets created, while the session name
+passes through no validator at all. There a space is not an error but a truncation —
+`--remote-control stint::my unit::build` registers `stint::my` and leaves the rest as a
+stray positional, so the worker comes up under a name nobody can address it by. The same
+free derivation that is safe on one token fails silently on the other.
 
 `claude` does ship `--remote-control-session-name-prefix`, and this convention does not
 use it: it prefixes auto-generated names only, while every name here is pinned explicitly

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -16,8 +16,8 @@ app-reachable, and message-addressable:
 
 ```bash
 ( cd <project-dir> && claude --bg --worktree <surface> \
-                             --remote-control "stint::<constituent>::<relation>" \
-                             -n "stint::<constituent>::<relation>" \
+                             --remote-control "stint::<parent>::<child>" \
+                             -n "stint::<parent>::<child>" \
                              --permission-mode auto -- "<brief + reporting contract>" )
 ```
 
@@ -74,22 +74,21 @@ When the spawning session is an orchestrator and this session is a **Stint** —
 whose scope exceeds one context lifecycle; smaller work goes to a subagent instead — name
 it:
 
-    stint::<constituent>::<relation>
+    stint::<parent>::<child>
 
 `stint` is the fixed first segment marking the row as orchestrator-spawned. `::` is the
-namespace connector, used at every boundary, not just the last one. `<constituent>` names
-the unit this session belongs to: the conducting session where one exists, or the session
-itself where none does — one field, not two, because a conductor also refers to itself,
-so the name always has exactly three segments. `<relation>` is this session's place
-*within* that unit (`port`, `review`, …) — a role inside the unit, not a forward pointer
-to a session that does not exist yet, which matters because `-n` fixes the name at launch
-time, before any such session could be known. Two Stints sharing one unit:
+namespace connector, used at every boundary, not just the last one. `<parent>` is the
+session that created this Stint, written as a short form of that session's own topic —
+read off the creator, not derived and not coined. Two Stints created by one session
+therefore carry the same token and Stints from different creators do not, which is the
+grouping the convention exists for. `<child>` describes this Stint freely, distinctly
+enough to tell it from its siblings under the same parent. Three segments always: the
+marker, then parent and child. Two Stints from one creator:
 `stint::comment-review::port` and `stint::comment-review::review`.
 
-`<relation>` has to be unique inside its unit — it is the only thing separating two
-Stints that share a `<constituent>`, so reusing one collides on the whole name. Where two
-Stints genuinely hold the same role, the distinguishing coordinate goes into the relation
-itself rather than anywhere else in the name.
+Because `<parent>` names whoever created the Stint, and a Stint never spawns another,
+that creator is always an orchestrator session. The no-nesting cap below holds here by
+construction rather than as an exception this rule has to carve out.
 
 Neither segment may carry whitespace, which is why both substitutions are quoted in the
 command above. That bars the character, not the phrase: a multi-word name stays
@@ -100,7 +99,7 @@ which rejects a bad token loudly before anything gets created, while the session
 passes through no validator at all. There a space is not an error but a truncation —
 `--remote-control stint::my unit::build` registers `stint::my` and leaves the rest as a
 stray positional, so the worker comes up under a name nobody can address it by. The same
-free derivation that is safe on one token fails silently on the other.
+freedom that is safe on one token fails silently on the other.
 
 `claude` does ship `--remote-control-session-name-prefix`, and this convention does not
 use it: it prefixes auto-generated names only, while every name here is pinned explicitly
@@ -108,15 +107,10 @@ with `-n`. `-n` and `--remote-control` then deliberately take the same value —
 independent flags, one naming the session and one registering the app bridge, and holding
 them equal is what makes the name printed at spawn the same string peers address.
 
-The orchestrator derives both tokens from accumulated context and the user's utterance
-and reports them with the spawn line — there is no separate per-spawn confirmation step.
-The first Stint of a unit fixes `<constituent>`; every later Stint in that unit reuses it
-verbatim, carried forward on the handoff itself — the parked task the outgoing Stint
-leaves behind. Do not plan on reading it back off `claude agents --json`: the default
-listing drops retired sessions (`--all` still holds them), and because Stints chain,
-retire-then-spawn is the ordinary path — so by the time the next Stint needs the token,
-the row it would have read is already gone and the token gets re-derived instead of
-reused.
+The orchestrator reports both tokens with the spawn line — there is no separate per-spawn
+confirmation step. `<child>` it describes; `<parent>` it renders from its own topic, the
+same way across every Stint it spawns, so siblings match without either of them having to
+look anything up.
 
 Stints chain — one hands off to the next — but never nest: a worker must not spawn or
 supervise sub-workers, since only the orchestrator holds that role. That caps the spawn

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -15,7 +15,8 @@ One command spawns a worker that is background-resident, worktree-isolated,
 app-reachable, and message-addressable:
 
 ```bash
-( cd <project-dir> && claude --bg --worktree <unit> --remote-control <unit> -n <unit> \
+( cd <project-dir> && claude --bg --worktree <unit> --remote-control stint::<constituent>::<relation> \
+                             -n stint::<constituent>::<relation> \
                              --permission-mode auto -- "<brief + reporting contract>" )
 ```
 
@@ -27,6 +28,14 @@ launch). Dropping `--worktree` does not opt out of isolation — it only gives u
 branch. A backgrounded session starts in the project directory but is held out of the
 shared checkout: edits there are rejected until the session isolates itself under
 `.claude/worktrees/`. The one opt-out is `worktree.bgIsolation: "none"` in settings.
+
+**`<unit>` and the session name are separate tokens on purpose.** `--worktree` cuts a
+branch, so its argument stays a plain hyphenated surface token — `:` is not legal in a
+git refname, and the session name below is built on `::`, so the two cannot share a
+value. Nor should they, independent of the refname constraint: several sessions can
+share one worktree (a build pass and a review pass on the same surface), and one unit of
+work can span several worktrees (a change landing in two repos) — neither direction
+supports a fixed mapping from branch to session name.
 
 **The `cd` is what picks the project.** There is no flag for it — `--add-dir` grants tool
 access to extra paths but does not set the session's project; the spawned session simply
@@ -50,6 +59,33 @@ before any worker exists. Pass the supervisor's own class explicitly — it is t
 this command that cannot be copied from a sibling. The session registry does not carry it;
 the supervisor's transcript does, as `{"type":"permission-mode","permissionMode":…}` records
 written on every mode change.
+
+## Naming a spawned session
+
+When the spawning session is an orchestrator and this session is a **Stint** — a worker
+whose scope exceeds one context lifecycle; smaller work goes to a subagent instead — name
+it:
+
+    stint::<constituent>::<relation>
+
+`stint` is the fixed first segment marking the row as orchestrator-spawned. `::` is the
+namespace connector, used at every boundary, not just the last one. `<constituent>` names
+the unit this session belongs to: the conducting session where one exists, or the session
+itself where none does — one field, not two, because a conductor also refers to itself,
+so the name always has exactly three segments. `<relation>` is this session's place
+*within* that unit (`port`, `review`, …) — a role inside the unit, not a forward pointer
+to a session that does not exist yet, which matters because `-n` fixes the name at launch
+time, before any such session could be known. Two Stints sharing one unit:
+`stint::comment-review::port` and `stint::comment-review::review`.
+
+The orchestrator derives both tokens from accumulated context and the user's utterance
+and reports them with the spawn line — there is no separate per-spawn confirmation step.
+The first Stint of a unit fixes `<constituent>`; every later Stint in that unit reuses it
+verbatim (read the live names off `claude agents --json` rather than re-deriving).
+
+Stints chain — one hands off to the next — but never nest: a worker must not spawn or
+supervise sub-workers, since only the orchestrator holds that role. That caps the spawn
+graph at one supervised level.
 
 ## Talking to it
 

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -15,27 +15,36 @@ One command spawns a worker that is background-resident, worktree-isolated,
 app-reachable, and message-addressable:
 
 ```bash
-( cd <project-dir> && claude --bg --worktree <unit> --remote-control stint::<constituent>::<relation> \
-                             -n stint::<constituent>::<relation> \
+( cd <project-dir> && claude --bg --worktree <unit> \
+                             --remote-control "stint::<constituent>::<relation>" \
+                             -n "stint::<constituent>::<relation>" \
                              --permission-mode auto -- "<brief + reporting contract>" )
 ```
 
 It prints `backgrounded · <jobId> · <name>`. Report that back. The four flags are
 independent and each earns its place: `--bg` detaches without a PTY, `--worktree`
-cuts a branch `worktree-<unit>` from `origin/<default>`, `--remote-control` registers
+cuts branch `worktree-<unit>` from `origin/<default>` (or reuses it, below),
+`--remote-control` registers
 the app bridge, `-n` pins a permanent name (without it the name is regenerated every
 launch). Dropping `--worktree` does not opt out of isolation — it only gives up the named
 branch. A backgrounded session starts in the project directory but is held out of the
 shared checkout: edits there are rejected until the session isolates itself under
 `.claude/worktrees/`. The one opt-out is `worktree.bgIsolation: "none"` in settings.
 
-**`<unit>` and the session name are separate tokens on purpose.** `--worktree` cuts a
-branch, so its argument stays a plain hyphenated surface token — `:` is not legal in a
-git refname, and the session name below is built on `::`, so the two cannot share a
-value. Nor should they, independent of the refname constraint: several sessions can
+**`<unit>` and the session name are separate tokens on purpose.** `--worktree` puts its
+argument through `claude`'s own worktree-name validator, which is stricter than git's
+refname rules: each `/`-separated segment may hold only letters, digits, dots,
+underscores and dashes, to 64 characters total. Reason from git's rules instead and you
+will mispredict — `a+b`, `a,b` and `a@b` are all legal refnames and all rejected here.
+So `<unit>` stays a plain hyphenated token, and the `::` the session name is built on is
+not available to it.
+
+Nor should the two share a value, independent of that constraint: several Stints can
 share one worktree (a build pass and a review pass on the same surface), and one unit of
 work can span several worktrees (a change landing in two repos) — neither direction
-supports a fixed mapping from branch to session name.
+supports a fixed mapping from branch to session name. Sharing needs no special form:
+`--worktree <unit>` is find-or-create, so a second Stint passing a name that already
+exists joins that worktree and its branch rather than colliding.
 
 **The `cd` is what picks the project.** There is no flag for it — `--add-dir` grants tool
 access to extra paths but does not set the session's project; the spawned session simply
@@ -78,10 +87,34 @@ to a session that does not exist yet, which matters because `-n` fixes the name 
 time, before any such session could be known. Two Stints sharing one unit:
 `stint::comment-review::port` and `stint::comment-review::review`.
 
+`<relation>` has to be unique inside its unit — it is the only thing separating two
+Stints that share a `<constituent>`, so reusing one collides on the whole name. Where two
+Stints genuinely hold the same role, the distinguishing coordinate goes into the relation
+itself: `review-137` and `review-153`, two review Stints on one unit.
+
+Neither segment may carry whitespace, which is why both substitutions are quoted in the
+command above. The asymmetry is the part worth holding on to: `<unit>` is covered by the
+validator, which rejects a bad token loudly before anything gets created, while the
+session name passes through no validator at all. There a space is not an error but a
+truncation — `--remote-control stint::my unit::build` registers `stint::my` and leaves
+the rest as a stray positional, so the worker comes up under a name nobody can address it
+by. The same free derivation that is safe on one token fails silently on the other.
+
+`claude` does ship `--remote-control-session-name-prefix`, and this convention does not
+use it: it prefixes auto-generated names only, while every name here is pinned explicitly
+with `-n`. `-n` and `--remote-control` then deliberately take the same value — they are
+independent flags, one naming the session and one registering the app bridge, and holding
+them equal is what makes the name printed at spawn the same string peers address.
+
 The orchestrator derives both tokens from accumulated context and the user's utterance
 and reports them with the spawn line — there is no separate per-spawn confirmation step.
 The first Stint of a unit fixes `<constituent>`; every later Stint in that unit reuses it
-verbatim (read the live names off `claude agents --json` rather than re-deriving).
+verbatim, carried forward on the handoff itself — the parked task the outgoing Stint
+leaves behind. Do not plan on reading it back off `claude agents --json`: the default
+listing drops retired sessions (`--all` still holds them), and because Stints chain,
+retire-then-spawn is the ordinary path — so by the time the next Stint needs the token,
+the row it would have read is already gone and the token gets re-derived instead of
+reused.
 
 Stints chain — one hands off to the next — but never nest: a worker must not spawn or
 supervise sub-workers, since only the orchestrator holds that role. That caps the spawn
@@ -90,7 +123,7 @@ graph at one supervised level.
 ## Talking to it
 
 ```bash
-claude agents --json          # fleet view: kind, state, status, id, sessionId, cwd
+claude agents --json          # fleet view: name, kind, state, status, id, pid, sessionId, cwd, startedAt
 claude logs <jobId>           # recent output (TUI frames; prefer the transcript)
 claude attach <jobId>         # open it in this terminal
 ```
@@ -121,7 +154,8 @@ A spawned session never reads this file. Carry the contract in the brief itself:
 > request unless it carries the ref, and names collide. Send (a) an ACK on start,
 > (b) your state whenever you are blocked on a decision you cannot make alone, and
 > (c) a completion report. Do not wait for a reply — durable output (PR, parked task)
-> ships regardless of the channel.
+> ships regardless of the channel. Do not spawn or supervise workers of your own: hand
+> work back to your supervisor instead, since only it holds that role.
 
 ## Observing
 


### PR DESCRIPTION
## What

Splits the `remote-spawn` canonical command's single `<unit>` token into two independent tokens:

- `--worktree <unit>` — unchanged: a plain hyphenated surface token, cuts branch `worktree-<unit>`.
- `--remote-control` / `-n` — now `stint::<constituent>::<relation>`, the namespaced convention resolved with the user for naming an orchestrator-spawned worker session ("Stint" in Martin's vocabulary).

Also documents the naming convention and what a Stint is (§ "Naming a spawned session"), and bumps `remote-tmux` 5.0.4 → 5.0.5 per this repo's existing convention of bumping on semantic skill changes.

## Why the split is forced

`:` is rejected in a git refname, and `--worktree <token>` builds `worktree-<token>`:

```
$ git check-ref-format refs/heads/worktree-stint::comment-review::port
(exit 1 — REJECTED)
$ git check-ref-format refs/heads/worktree-stint/comment-review/port
(exit 0 — OK)
```

So `::` can never reach `--worktree`'s argument. But the mapping fails independently of that constraint too: several Stints can share one worktree (a build pass and a review pass on the same surface), and one unit of work can span several worktrees (a change landing in two repos) — neither `<relation>` nor `<constituent>` maps onto a branch in either direction. `--worktree` and the session name were always semantically independent; the refname rule just makes the independence syntactically unavoidable too.

## Naming convention (inscribed in SKILL.md)

`stint::<constituent>::<relation>` — `stint` marks orchestrator-spawned rows, `::` is the connector used at every boundary, `<constituent>` is the unit's name (conducting session, or the Stint itself if none), `<relation>` is this Stint's role within the unit (not a forward pointer — `-n` fixes the name before any later session exists). Full rationale is in the SKILL.md diff.

## Scope

`remote-tmux/` only. `README.md`'s example command showed the superseded single-token form (`--worktree foo --remote-control foo -n foo`); the executor left it alone as out of its stated brief and flagged it, and the follow-up landed on this same branch as f002c7b rather than as a separate PR — a README that teaches the superseded form fails silently, since a reader who copies it gets a name carrying no unit information and nothing errors. The README points at the skill's naming section instead of restating the convention, so the two surfaces cannot drift apart.

## Verification

```
$ git log -1 --stat
$ git diff origin/main --stat
```
(pasted in the review thread / reachable via the commit — see commit 3f8b7e7 for the full measured-constraint ledger entry)

