### PR TITLE
remote-tmux: state the Stint depth cost instead of capping it

### DIFF
--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are app-reachable and addressable by SendMessage (remote-spawn skill), or keep a self-restarting --spawn-worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.0.9",
+  "version": "5.0.10",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are app-reachable and addressable by SendMessage (remote-spawn skill), or keep a self-restarting --spawn-worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -112,9 +112,13 @@ confirmation step. `<child>` it describes; `<parent>` it renders from its own to
 same way across every Stint it spawns, so siblings match without either of them having to
 look anything up.
 
-Stints chain — one hands off to the next — but never nest: a worker must not spawn or
-supervise sub-workers, since only the orchestrator holds that role. That caps the spawn
-graph at one supervised level.
+Stints chain — one hands off to the next — but never nest: a Stint must not spawn or
+supervise another Stint, since that recursion is what multiplies supervision depth and
+the cognitive load that comes with it. A Stint may dispatch and supervise subagents of
+its own — a subagent adds no supervision depth, and dispatching isolated subagents is
+exactly how a Stint realizes work that must run in mutually isolated contexts. The cap
+holds at one level of Stint depth; the subagent layer beneath a Stint is a different
+kind of thing and is not what this cap counts.
 
 ## Talking to it
 
@@ -150,8 +154,10 @@ A spawned session never reads this file. Carry the contract in the brief itself:
 > request unless it carries the ref, and names collide. Send (a) an ACK on start,
 > (b) your state whenever you are blocked on a decision you cannot make alone, and
 > (c) a completion report. Do not wait for a reply — durable output (PR, parked task)
-> ships regardless of the channel. Do not spawn or supervise workers of your own: hand
-> work back to your supervisor instead, since only it holds that role.
+> ships regardless of the channel. Do not spawn or supervise another worker of your
+> own — hand that work back to your supervisor instead, since worker-to-worker nesting
+> is what multiplies supervision depth. Dispatching and supervising subagents of your
+> own is fine; that adds no such depth.
 
 ## Observing
 

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -86,10 +86,6 @@ enough to tell it from its siblings under the same parent. Three segments always
 marker, then parent and child. Two Stints from one creator:
 `stint::comment-review::port` and `stint::comment-review::review`.
 
-Because `<parent>` names whoever created the Stint, and a Stint never spawns another,
-that creator is always an orchestrator session. The no-nesting cap below holds here by
-construction rather than as an exception this rule has to carve out.
-
 Neither segment may carry whitespace, which is why both substitutions are quoted in the
 command above. That bars the character, not the phrase: a multi-word name stays
 multi-word, hyphenated — `comment-review`, not `commentreview`. Compressing a title into
@@ -112,13 +108,10 @@ confirmation step. `<child>` it describes; `<parent>` it renders from its own to
 same way across every Stint it spawns, so siblings match without either of them having to
 look anything up.
 
-Stints chain — one hands off to the next — but never nest: a Stint must not spawn or
-supervise another Stint, since that recursion is what multiplies supervision depth and
-the cognitive load that comes with it. A Stint may dispatch and supervise subagents of
-its own — a subagent adds no supervision depth, and dispatching isolated subagents is
-exactly how a Stint realizes work that must run in mutually isolated contexts. The cap
-holds at one level of Stint depth; the subagent layer beneath a Stint is a different
-kind of thing and is not what this cap counts.
+Stints chain — one hands off to the next. Each level of Stint under a Stint adds
+supervision depth, which puts another hop between a gate and whoever can answer it.
+A subagent adds no such depth: it returns to its dispatcher and supervises nothing,
+which is how a Stint realizes work that must run in mutually isolated contexts.
 
 ## Talking to it
 
@@ -154,10 +147,7 @@ A spawned session never reads this file. Carry the contract in the brief itself:
 > request unless it carries the ref, and names collide. Send (a) an ACK on start,
 > (b) your state whenever you are blocked on a decision you cannot make alone, and
 > (c) a completion report. Do not wait for a reply — durable output (PR, parked task)
-> ships regardless of the channel. Do not spawn or supervise another worker of your
-> own — hand that work back to your supervisor instead, since worker-to-worker nesting
-> is what multiplies supervision depth. Dispatching and supervising subagents of your
-> own is fine; that adds no such depth.
+> ships regardless of the channel.
 
 ## Observing
 


### PR DESCRIPTION
## What

Drops the Stint nesting cap and states the property it was standing in for. Against `main` this is a subtraction — 6 insertions, 10 deletions in `remote-tmux/skills/remote-spawn/SKILL.md`.

Three sites, two of them deletions:

- **`:89-91`, the `<parent>` paragraph — removed.** Its only job was arguing that the cap held by construction. With no cap there is nothing to argue, and `:80-81` already says the token is read off the creator, "not derived and not coined".
- **`:115-117`, the cap itself — replaced by the property.** Supervision depth puts another hop between a gate and whoever can answer it; a subagent adds no such depth because it returns to its dispatcher and supervises nothing. No `must not`, and the noun "cap" is gone.
- **`:153-154`, the reporting-contract template — removed.** Clause (b) of the same contract, "your state whenever you are blocked on a decision you cannot make alone", already covers it.

`remote-tmux` 5.0.9 → 5.0.10.

## Why

The first commit on this branch narrowed the cap to Stint-to-Stint so it would stop sweeping in subagents. Reviewing that raised a case it did not answer: a Stint that finds work larger than itself — a defect in a library the maintainer owns, surfaced mid-review — has no route except handing back, and the handback had no described shape.

The answer turned out not to be a better-scoped rule.

A prohibition earns its place on an observed nonzero base rate of the behavior it bars. The observation this branch recorded points the other way: the Stint spawned alongside the first commit needed the cap **overridden by hand** in its brief. That is the cap misfiring, not a Stint reaching to spawn Stints.

What the reader needs is the cost model and the discriminant. Both are properties, and both hold without anyone being told what to do about them.

## Why the routing is not in this file

Pace layering. The property is slow and belongs here. The routing that follows from it — report it, let the orchestrator spawn the next one, carry the evidence — is orchestration, changes at a different rate, and belongs to the epistemic-protocol layer to compose at the point of need. Writing it here would compose the slow layer out of the fast one.

This also answers the parent-vs-ancestor question without adding a token: a Stint created because another Stint's report asked for it still takes its creator's token and lands as a sibling. Where the work came from is the spawning brief's business, not the name's.

## Why the brief template loses text rather than gaining it

A spawned session reads only its brief, so this block is deployed text rather than documentation — which is why the first commit fixed it alongside the prose. Under the same reading, the prohibition there is recoverable from clause (b): whether to spawn a Stint is exactly a decision a worker cannot make alone, and a Stint is remote-control-reachable, so that gate opens onto someone who can answer it. The subagent permission goes with the prohibition — with nothing suppressing the behavior, permitting it is dead text.

## Verification

- Property statement and subagent discriminant both present at `:111-114`.
- Clause (b) untouched.
- `<parent>` semantics still stated at its original site (`:80-81`).
- Version bump present; the pre-commit hook gates per commit, so this commit carries its own.

Merge is the maintainer's call.
