### PR TITLE
CLAUDE.md: bind the premise layer at revision time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,31 +39,34 @@ Frontmatter shapes (skill/agent YAML, multi-skill loading, tool restriction, MCP
 HTTP/Command forms) are re-derivable from existing siblings — read a neighbor to
 see the current shape.
 
+## Revising a surface
+
+A `SKILL.md`, an `agents/*.md`, and this file are LLM-facing instruction
+surfaces. Changing one is a revision of a durable instruction layer, which is
+the moment `premise/instruction-authoring.md` governs — read it before drafting
+the change.
+
 ## Conventions
 
-- **Helper scripts: Python by default; Bun TypeScript when the other half runs
-  in a browser.** *Python* = PEP 723 + uv — inline script metadata (`# ///
-  script … ///`), invoked as `uv run scripts/x.py` (sidesteps the `python` vs
-  `python3` ambiguity), with `dependencies = []` declared even when empty.
-  *Bun TypeScript* — `bun scripts/x.ts` — when the script's counterpart is a
-  page the plugin ships, such as a preview server driving its own browser
-  client: one language spans the wire, and HTTP + WebSocket + file-watch come
-  from the runtime instead of a dependency list. Both are prerequisites rather
-  than vendored artifacts; a skill that needs one says so, and says how to
-  install it.
+- **Helper scripts: Python by default; Bun TypeScript when the script's
+  counterpart is a page the plugin ships.** *Python* = PEP 723 + uv — inline
+  script metadata (`# /// script … ///`), `dependencies = []` declared even when
+  empty, invoked as `uv run scripts/x.py`. *Bun TypeScript* — `bun
+  scripts/x.ts`. Both are prerequisites rather than vendored artifacts; a skill
+  that needs one says so, and says how to install it.
 - **Agent vs Skill.** Agent = how to behave (principles, boundaries, error
   philosophy). Skill = what to do (workflow, procedures, commands). A
   `skills:`-loaded skill is the single home for its workflow; the agent adds only
   behavior it does not carry.
 - **Gap tracking (Syneidesis).** Mark unverified assumptions/procedures with a
-  `[Gap:Type]` prefix in TodoWrite — `Procedural`, `Assumption`, `Consideration`.
+  `[Gap:Type]` prefix on the tracked task — `Procedural`, `Assumption`,
+  `Consideration`.
 - **Importing external-tool capability — 3 tests, all required.** (1)
   *Irreducibility*: not reproducible from existing primitives (ergonomic wrappers
   stay inside scripts). (2) *Environment neutrality*: a protocol-level capability
-  (e.g. CDP) that works without the originating tool installed. (3) *SSOT
-  respect*: authoritative state (browser cookies/`localStorage`/…) is reached
-  through its authoritative path — the source owns get/set/clear rather than a
-  mirror.
+  that works without the originating tool installed. (3) *SSOT respect*:
+  authoritative state is reached through its authoritative path — the source owns
+  get/set/clear rather than a mirror.
 
 ## Versioning
 


### PR DESCRIPTION
## What

One new section in `CLAUDE.md`, plus the three subtractions that writing it turned up.

```markdown
## Revising a surface

A `SKILL.md`, an `agents/*.md`, and this file are LLM-facing instruction
surfaces, and `premise/` ranks above all of them. Changing one is a revision of
a durable instruction layer — a moment that layer's own index names, so read
from there before drafting the change.
```

| Site | Change |
|---|---|
| new section | ranks `premise/` above this repo's surfaces and binds it at revision time |
| Gap tracking | `TodoWrite` → the tracked task (stale instrument name) |
| Helper scripts | 10 → 6 lines, rationale to the ledger |
| External-tool 3 tests | 7 → 6 lines, two anchoring examples dropped |

## Why four lines

The premise index already names this moment — "when writing or revising instructions and durable records". Availability was never the problem; recognition was. A skill edit here reads as a wording change and does not announce itself as a durable-layer revision.

Naming which files in this repo *are* that surface is the only specificity this adds beyond the default's own wording, so it is the only thing the section carries.

Two clauses were drafted and dropped: a subtraction-first ordering clause (fully recoverable from the layer this points at) and a ledger-routing clause (already bound by a global default, so a restatement).

## Why a directory and not a document

The section first named `premise/instruction-authoring.md` by filename. That breaks silently if the document is renamed, split, or absorbed, and it fixes in advance which premise document governs a revision — when the index exists precisely so the reader recognizes their own moment among several.

Borrowed from the sibling marketplace, `jongwony/epistemic-protocols`, which solves the same problem without naming any premise document at all. Its `AGENTS.md:17` ranks instruction surfaces — `premise/` → `AGENTS.md` → `.claude/rules/` → `.claude/principles/` → `docs/` — and states that where two disagree the higher governs and the lower is what gets corrected. The literal string `instruction-authoring` appears **zero times** in that file and the binding still holds, because ranking the directory is what carries it.

Not borrowed: the rank list itself, and the `/place` routing at `AGENTS.md:88`. That repo has five local surfaces to order; this one has this file, so a rank list would have a single element. The relation to `premise/` is the only tier here that is real.

## What occasioned it

#138. The first two drafts of that change both grew the file. The correct answer — two of three sites were deletions, not rewrites — appeared only after the premise layer was consulted. That is the measurable friction the Override Gate asks for before a directive enters an always-loaded surface.

## The audit

`Subtraction at Revision Time` puts the entries already on a surface back in scope when it is opened, and asks what it can shed *before* what it adds is settled. Running that produced four candidates; three are in this PR.

The fourth is `Bump-on-change`, kept — the hook and CI actually enforce it. The gap it did have is fixed separately in #140.

Removed rationale is preserved in the commit messages, per this repo's ledger binding.

## Verification

- No plugin version bump — `CLAUDE.md` sits outside every plugin directory; pre-commit hook passed clean on both commits.
- Directive force intact at all three compressed entries; the `ergonomic wrappers stay inside scripts` parenthetical kept, since it routes the rejected case rather than illustrating the accepted one.
- `AGENTS.md:17` / `:88` and the zero-hit `instruction-authoring` grep were read directly in the sibling repo's source checkout, not taken from a report.
