### PR TITLE
version gate: name the baseline difference between hook and CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,8 +2,10 @@
 # Pre-commit: enforce per-plugin version bumps (index mode).
 #
 # Thin wrapper — the rule logic is the single source of truth in
-# check-version-bump.sh, which CI also runs (in range mode) so the local hook
-# and CI never drift. Activate this hook with: git config core.hooksPath .githooks
+# check-version-bump.sh, which CI also runs (in range mode). The rule cannot
+# drift; the baseline differs by design — index vs HEAD here, merge-base with the
+# PR base there — so this can fail on a later commit that CI already accepts.
+# Activate this hook with: git config core.hooksPath .githooks
 # Bypass once with: git commit --no-verify
 set -euo pipefail
 dir=$(cd "$(dirname "$0")" && pwd)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,21 +67,22 @@ see the current shape.
 
 ## Versioning
 
-Edit `version` in `{plugin}/.claude-plugin/plugin.json`; `marketplace.json`
-carries source paths only.
+Edit `version` in `{plugin}/.claude-plugin/plugin.json`.
 
 **Bump-on-change.** When a plugin's meaningful files change in a change-set, that
 plugin's `version` must actually change (re-ordering/reformatting alone does not
-count). Exception: top-level non-meaningful files only — `.claude-plugin/`
-metadata and plugin-root `README*`/`LICENSE`/`.gitignore`/`.gitattributes`; a
-same-named file in a subdirectory counts as content. A `git rm` of a meaningful
-file counts. A new plugin satisfies it via its initial version.
+count). Exception: a plugin's own top-level metadata and boilerplate — the same
+name one directory down counts as content. A `git rm` of a meaningful file
+counts. A new plugin satisfies it via its initial version.
 
-Logic SSOT: `.githooks/check-version-bump.sh` (pure bash). Two entry points call
-it — the local pre-commit hook (`git config core.hooksPath .githooks`, once per
-clone; best-effort, bypassable) and CI
-(`.github/workflows/version-bump-check.yml`, the real gate; range mode; not
-bypassable).
+Logic SSOT: `.githooks/check-version-bump.sh` (pure bash), which also holds the
+exception list. Two entry points call it, and they share the rule while differing
+in baseline: the local pre-commit hook (`git config core.hooksPath .githooks`,
+once per clone; best-effort, bypassable) compares the staged index against `HEAD`,
+CI (`.github/workflows/version-bump-check.yml`, the real gate; not bypassable)
+against the merge-base with the PR base. A later commit on a branch therefore
+needs its own bump to pass the hook after CI is already satisfied by an earlier
+one, so such a branch carries one bump per such commit.
 
 ## Workflow
 


### PR DESCRIPTION
## What

`CLAUDE.md` never said what the version gate's two entry points compare against, and `.githooks/pre-commit` said something about them that is not true. Both fixed, plus two subtractions the audit turned up.

## The baseline difference

Same rule, different baseline — and the baseline is what decides the verdict.

| Entry point | Compares |
|---|---|
| pre-commit, index mode | staged index against `HEAD` (`check-version-bump.sh:52`, `:65`) |
| CI, range mode | `HEAD` against the **merge-base** with the PR base (`:46-50`, `:62`) |

CI uses the merge-base rather than the base tip on purpose, so the comparison survives `main` advancing after the branch forked.

The consequence does not follow from "same logic, two entry points", which is why it is now written down: a second commit on a branch is measured against the first, so it needs its own bump even though CI is already satisfied. Such a branch carries one bump per semantic commit.

Observed on #138 — the second commit failed the hook while the range was clean. Resolved by bumping `5.0.9 → 5.0.10`, not by `--no-verify`.

## The inaccurate claim

`.githooks/pre-commit` asserted the hook and CI "never drift". Shared logic is not a shared verdict. Rewritten to say which part cannot drift and which part differs by design.

## Subtractions

- **`marketplace.json` carries source paths only** — restates the Architecture entry forty lines above, which already says "plugin list + source paths (no versions)". Removed.
- **The exception enumeration** (`.claude-plugin/` metadata, plugin-root `README*`/`LICENSE`/`.gitignore`/`.gitattributes`) — mirrored `check-version-bump.sh:104` while the next paragraph declares that script the logic SSOT. The list is structure the script defines and enforces, so it belongs where it is used; a second copy here has nothing keeping it current. `CLAUDE.md` keeps the shape of the exception and points at the owner.

  This one is a judgment call — it trades a small navigation cost (an author now reads bash to see the exact list) against a silent-staleness liability. Easy to revert if the trade reads wrong.

The discriminants that are not enumerations stay: the value must actually change, a `git rm` counts, a new plugin is satisfied by its initial version.

## Notes

- Follows the revision-time procedure added in #139, applied to the surface that added it. #139 is still open; it touches `Conventions` and adds a section, this touches `Versioning` — no overlap, either order merges.
- No plugin version bump: both files sit outside every plugin directory. Pre-commit hook passed clean.
