### PR TITLE
codex-plus: gpt-5.6-luna opt-in 모델 추가 + 기본 effort를 high로

### DIFF
--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/scripts/codex-run.sh
+++ b/codex-plus/scripts/codex-run.sh
@@ -13,7 +13,11 @@ CDPATH=
 
 # Defaults
 readonly DEFAULT_MODEL="gpt-5.6-sol"
-readonly DEFAULT_EFFORT="xhigh"
+# high is a floor, not a ceiling. Raising effort is a per-call judgment made
+# from the task in front of the caller; a default cannot read the task, so
+# pinning the top of the ladder here spends it on every run that never
+# needed it. Callers escalate to xhigh or max deliberately.
+readonly DEFAULT_EFFORT="high"
 # workspace-write, not read-only, for one reason: the network. codex exposes no
 # network switch under read-only — the toggle lives in the
 # sandbox_workspace_write table and does nothing while the mode is read-only
@@ -37,7 +41,8 @@ Usage: codex-run.sh [options] <prompt_file>
 
 Options:
   -m, --model MODEL      Model name (default: gpt-5.6-sol)
-  -r, --effort EFFORT    Reasoning effort: medium|high|xhigh|max (default: xhigh)
+  -r, --effort EFFORT    Reasoning effort: medium|high|xhigh|max (default: high,
+                         a floor rather than a ceiling — escalate per task)
   -s, --sandbox SANDBOX  Sandbox: read-only|workspace-write|danger-full-access
                          (default: workspace-write, which this wrapper always
                          runs with network access enabled, and which already
@@ -62,7 +67,7 @@ no most-recent fallback, so it is never a race under parallel sessions.
 
 Examples (<scratchpad> = the calling session's scratchpad directory):
   codex-run.sh <scratchpad>/codex_prompt_a3f9.txt
-  codex-run.sh -m gpt-5.6-terra -r high <scratchpad>/codex_prompt_a3f9.txt
+  codex-run.sh -m gpt-5.6-luna -r xhigh <scratchpad>/codex_prompt_a3f9.txt
   codex-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 <scratchpad>/codex_prompt_a3f9.txt
 USAGE
   exit "${1:-0}"

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -74,10 +74,13 @@ When the delegated task is image generation or image editing:
 1. Ask the user (via `AskUserQuestion`) which model(s) and reasoning effort in a **single prompt with two questions**. Model selection is **multi-select** — multiple models can be chosen for parallel execution.
 
    Models to offer:
-   - `gpt-5.6-sol` — current default model for Codex CLI tasks.
+   - `gpt-5.6-sol` — the default. A run uses Sol unless the caller named another model.
    - `gpt-5.6-terra` — balanced 5.6 variant; lighter usage, faster than Sol, same effort ladder.
+   - `gpt-5.6-luna` — opt-in, and only where the caller names it: browser / computer-use E2E runs, and implementation work that writes a lot of code, at `xhigh`. It is routed to for cost-efficient operation on those two shapes, so it does not stand in for Sol generally.
 
-   Reasoning effort is selected once and applied identically to all chosen models.
+   Any model other than `gpt-5.6-sol` is used only when the caller specifies it. The ask above covers the case where nothing was fixed upstream; left unanswered, the answer is Sol.
+
+   Reasoning effort is selected once and applied identically to all chosen models. `high` is the wrapper's default and the floor here — raise it to `xhigh` or `max` where the task's reasoning depth warrants, and do not go below `high`.
 
 2. Select sandbox mode. Omitting `-s` gives `workspace-write` **with network access** — codex offers no network under `read-only` at all, so this is the only mode short of full access that has any. Pass `-s read-only` when a run must neither touch the tree nor reach off-machine; `-s danger-full-access` only when it must write outside the workspace. Because the default already permits writes, what bounds a run that is meant to only read is the role its prompt declares — state it.
 3. Craft prompt per Context Classification and Prompt Template — classify context, write to `<scratchpad>/codex_prompt_<suffix>.txt`.
@@ -101,7 +104,7 @@ Base patterns:
 
 Modifiers, added to any base pattern above:
 - Different working directory — `-C <DIR>`; pass it again on resume (step 6)
-- Model and effort — `-m gpt-5.6-terra`, `-r high`
+- Model and effort — `-m gpt-5.6-luna`, `-r xhigh` (effort defaults to `high`; `-r` raises it)
 - Capture the answer to a file — `-o <FILE>` writes codex's final message to FILE deterministically
 
 ## Following Up

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -71,14 +71,14 @@ When the delegated task is image generation or image editing:
 - Use `references/image-gen-models-prompting-guide.ipynb` only as the backing reference for model choice, prompt structure, text rendering, edits, and multi-image workflows.
 
 ## Running a Task
-1. Ask the user (via `AskUserQuestion`) which model(s) and reasoning effort in a **single prompt with two questions**. Model selection is **multi-select** — multiple models can be chosen for parallel execution.
+1. Run on `gpt-5.6-sol` at `high` unless the caller named otherwise. Designation normally arrives upstream, in the request itself, so a model or effort already named there IS the answer — do not re-ask it.
 
-   Models to offer:
-   - `gpt-5.6-sol` — the default. A run uses Sol unless the caller named another model.
+   Ask (via `AskUserQuestion`, a **single prompt with two questions**; model selection is **multi-select**, so several models can run in parallel) only where the choice is genuinely open: neither model nor effort was named, and the task's shape does not settle them.
+
+   Models:
+   - `gpt-5.6-sol` — the default, used whenever no model was named.
    - `gpt-5.6-terra` — balanced 5.6 variant; lighter usage, faster than Sol, same effort ladder.
    - `gpt-5.6-luna` — opt-in, and only where the caller names it: browser / computer-use E2E runs, and implementation work that writes a lot of code, at `xhigh`. It is routed to for cost-efficient operation on those two shapes, so it does not stand in for Sol generally.
-
-   Any model other than `gpt-5.6-sol` is used only when the caller specifies it. The ask above covers the case where nothing was fixed upstream; left unanswered, the answer is Sol.
 
    Reasoning effort is selected once and applied identically to all chosen models. `high` is the wrapper's default and the floor here — raise it to `xhigh` or `max` where the task's reasoning depth warrants, and do not go below `high`.
 


### PR DESCRIPTION
## 무엇이 바뀌나

- `skills/codex/SKILL.md` 모델 목록에 `gpt-5.6-luna` 추가 — **호출자가 명시적으로 지목할 때만** 쓰이는 opt-in 항목. 용례는 browser/computer-use E2E 실행과 코드를 많이 작성하는 구현 작업, `xhigh`로.
- **step 1을 "항상 묻는다"에서 "sol/high로 돌린다"로 변경.** 지목은 보통 요청 자체에서 올라오므로, 이미 지정된 모델·effort는 다시 묻지 않고, `AskUserQuestion`은 선택이 진짜 열려 있을 때만 띄웁니다.
- `codex-run.sh`의 `DEFAULT_EFFORT`를 `xhigh` → `high`. high는 바닥이고 천장이 아님 — `xhigh`/`max`는 작업을 보고 올리는 판단.
- `plugin.json` 2.9.0 → 2.10.1.

`DEFAULT_MODEL`은 `gpt-5.6-sol` 그대로입니다.

## step 1을 함께 고친 이유

처음엔 "sol이 아닌 모델은 지정했을 때만 쓴다"를 step 1 아래 문단으로만 넣었는데, step 1 본문의 명령형("Ask the user … which model(s) and reasoning effort")은 그대로 무조건이었습니다. 서로 어긋나는 두 지시가 한 파일에 있고, 세션이 실제로 실행하는 쪽은 명령형입니다 — 즉 매 실행마다 luna가 선택지로 뜨는 picker가 열렸을 겁니다. opt-in 규칙이 막으려던 바로 그 경로라, 문단을 다는 대신 step 1 자체를 고쳤습니다.

## luna 설명을 성능이 아니라 용례로 쓴 이유

substrate 어디에도 luna가 없습니다 — `codex exec --help`(codex-cli 0.149.0), `~/.codex/config.toml`, `~/.claude/rules/*` 모두 이 이름을 언급하지 않습니다. 그래서 "Sol보다 빠르다/가볍다" 같은 줄은 항상 로드되는 스킬 파일에 검증되지 않은 상태 주장을 심는 일이 됐을 겁니다. 대신 관측된 것만 적었습니다: 사용자가 이 모델을 언제 꺼내 쓰는지.

## 코드 변경이 거의 없는 이유

`codex-run.sh`는 `-m` 값을 검증하지 않습니다 — 옵션 파서 주석이 그 비대칭(`-S`/`-C`/`-o`만 빈 값 검사)을 의도적인 설계로 밝혀두고 있습니다. 그래서 "모델 추가"는 허용 목록 분기가 아니라 SKILL.md 등록부 항목 하나 + 문서입니다.

## 검증

```
$ bash -n scripts/codex-run.sh
(no output — syntax OK)

$ ./scripts/codex-run.sh -h | sed -n '4,6p'
  -m, --model MODEL      Model name (default: gpt-5.6-sol)
  -r, --effort EFFORT    Reasoning effort: medium|high|xhigh|max (default: high,
                         a floor rather than a ceiling — escalate per task)
```

`xhigh`를 기본값으로 적어둔 다른 파일이 남아 있는지 저장소 전체를 훑었고, 남은 언급은 이번에 의도적으로 쓴 것들과 업스트림 프롬프팅 가이드 인용뿐입니다.

luna로 실제 codex 호출을 돌려 모델 이름이 해석되는지는 **확인하지 않았습니다**(unverified) — 첫 실사용이 그 확인이 됩니다.

## 범위

요청 문구대로 플러그인 안쪽만. `~/.claude/rules/delegation.md`의 advisor fallback tier 핀(`gpt-5.6-sol`)과 `~/.codex/config.toml`은 손대지 않았습니다.

의사결정 좌표는 `/elicit`(euporia) 두 순환으로 표면화했고, 근거·기각된 대안은 커밋 메시지에 있습니다.
