### PR TITLE
codex-plus: luna를 평범한 선택지로 — opt-in 예외절 제거 (#141 후속)

### DIFF
--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/scripts/codex-run.sh
+++ b/codex-plus/scripts/codex-run.sh
@@ -67,7 +67,7 @@ no most-recent fallback, so it is never a race under parallel sessions.
 
 Examples (<scratchpad> = the calling session's scratchpad directory):
   codex-run.sh <scratchpad>/codex_prompt_a3f9.txt
-  codex-run.sh -m gpt-5.6-luna -r xhigh <scratchpad>/codex_prompt_a3f9.txt
+  codex-run.sh -m gpt-5.6-terra -r xhigh <scratchpad>/codex_prompt_a3f9.txt
   codex-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 <scratchpad>/codex_prompt_a3f9.txt
 USAGE
   exit "${1:-0}"

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -75,13 +75,14 @@ When the delegated task is image generation or image editing:
 
    Ask (via `AskUserQuestion`, a **single prompt with two questions**; model selection is **multi-select**, so several models can run in parallel) only where the choice is genuinely open: neither model nor effort was named, and the task's shape does not settle them.
 
-   Models to offer in that ask:
+   Models:
    - `gpt-5.6-sol` — the default, used whenever no model was named.
    - `gpt-5.6-terra` — balanced 5.6 variant; lighter usage, faster than Sol, same effort ladder.
+   - `gpt-5.6-luna` — named-only, never offered in the ask: the ask fires only when no model was named, which is the one state luna is barred in. Reached for browser / computer-use E2E runs and implementation work that writes a lot of code, at `xhigh`, running alone rather than alongside another model. codex's own registry calls it a "Fast and affordable agentic coding model".
 
-   `gpt-5.6-luna` is kept out of that list on purpose: the ask fires only when no model was named, which is the one state luna is barred in — offering it there would make it selectable exactly where its rule excludes it. It is reached only where the caller names it, for browser / computer-use E2E runs and implementation work that writes a lot of code. codex's own model registry calls it a "Fast and affordable agentic coding model", which is what makes it worth naming for those two shapes.
+   So the ask offers Sol and Terra; luna enters by being named.
 
-   Reasoning effort is selected once and applied identically to all chosen models, so a named luna run is not bundled into a multi-model selection — it runs alone, at the effort its task warrants (`xhigh` for the two shapes above). `high` is the wrapper's default and the floor here — raise it to `xhigh` or `max` where the task's reasoning depth warrants, and do not go below `high`.
+   Reasoning effort is selected once and applied identically to all chosen models — which is why a named luna run is not bundled into a multi-model selection. `high` is the wrapper's default and the floor here — raise it to `xhigh` or `max` where the task's reasoning depth warrants, and do not go below `high`.
 
 2. Select sandbox mode. Omitting `-s` gives `workspace-write` **with network access** — codex offers no network under `read-only` at all, so this is the only mode short of full access that has any. Pass `-s read-only` when a run must neither touch the tree nor reach off-machine; `-s danger-full-access` only when it must write outside the workspace. Because the default already permits writes, what bounds a run that is meant to only read is the role its prompt declares — state it.
 3. Craft prompt per Context Classification and Prompt Template — classify context, write to `<scratchpad>/codex_prompt_<suffix>.txt`.

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -75,12 +75,13 @@ When the delegated task is image generation or image editing:
 
    Ask (via `AskUserQuestion`, a **single prompt with two questions**; model selection is **multi-select**, so several models can run in parallel) only where the choice is genuinely open: neither model nor effort was named, and the task's shape does not settle them.
 
-   Models:
+   Models to offer in that ask:
    - `gpt-5.6-sol` — the default, used whenever no model was named.
    - `gpt-5.6-terra` — balanced 5.6 variant; lighter usage, faster than Sol, same effort ladder.
-   - `gpt-5.6-luna` — opt-in, and only where the caller names it: browser / computer-use E2E runs, and implementation work that writes a lot of code, at `xhigh`. It is routed to for cost-efficient operation on those two shapes, so it does not stand in for Sol generally.
 
-   Reasoning effort is selected once and applied identically to all chosen models. `high` is the wrapper's default and the floor here — raise it to `xhigh` or `max` where the task's reasoning depth warrants, and do not go below `high`.
+   `gpt-5.6-luna` is kept out of that list on purpose: the ask fires only when no model was named, which is the one state luna is barred in — offering it there would make it selectable exactly where its rule excludes it. It is reached only where the caller names it, for browser / computer-use E2E runs and implementation work that writes a lot of code. codex's own model registry calls it a "Fast and affordable agentic coding model", which is what makes it worth naming for those two shapes.
+
+   Reasoning effort is selected once and applied identically to all chosen models, so a named luna run is not bundled into a multi-model selection — it runs alone, at the effort its task warrants (`xhigh` for the two shapes above). `high` is the wrapper's default and the floor here — raise it to `xhigh` or `max` where the task's reasoning depth warrants, and do not go below `high`.
 
 2. Select sandbox mode. Omitting `-s` gives `workspace-write` **with network access** — codex offers no network under `read-only` at all, so this is the only mode short of full access that has any. Pass `-s read-only` when a run must neither touch the tree nor reach off-machine; `-s danger-full-access` only when it must write outside the workspace. Because the default already permits writes, what bounds a run that is meant to only read is the role its prompt declares — state it.
 3. Craft prompt per Context Classification and Prompt Template — classify context, write to `<scratchpad>/codex_prompt_<suffix>.txt`.
@@ -104,7 +105,7 @@ Base patterns:
 
 Modifiers, added to any base pattern above:
 - Different working directory — `-C <DIR>`; pass it again on resume (step 6)
-- Model and effort — `-m gpt-5.6-luna`, `-r xhigh` (effort defaults to `high`; `-r` raises it)
+- Model and effort — `-m gpt-5.6-terra`, `-r xhigh` (effort defaults to `high`; `-r` raises it)
 - Capture the answer to a file — `-o <FILE>` writes codex's final message to FILE deterministically
 
 ## Following Up

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -78,11 +78,9 @@ When the delegated task is image generation or image editing:
    Models:
    - `gpt-5.6-sol` — the default, used whenever no model was named.
    - `gpt-5.6-terra` — balanced 5.6 variant; lighter usage, faster than Sol, same effort ladder.
-   - `gpt-5.6-luna` — named-only, never offered in the ask: the ask fires only when no model was named, which is the one state luna is barred in. Reached for browser / computer-use E2E runs and implementation work that writes a lot of code, at `xhigh`, running alone rather than alongside another model. codex's own registry calls it a "Fast and affordable agentic coding model".
+   - `gpt-5.6-luna` — a "Fast and affordable agentic coding model" in codex's own registry; the cost-efficient pick for browser / computer-use E2E runs and implementation work that writes a lot of code, usually at `xhigh`.
 
-   So the ask offers Sol and Terra; luna enters by being named.
-
-   Reasoning effort is selected once and applied identically to all chosen models — which is why a named luna run is not bundled into a multi-model selection. `high` is the wrapper's default and the floor here — raise it to `xhigh` or `max` where the task's reasoning depth warrants, and do not go below `high`.
+   Reasoning effort is selected once and applied identically to all chosen models. `high` is the wrapper's default and the floor here — raise it to `xhigh` or `max` where the task's reasoning depth warrants, and do not go below `high`.
 
 2. Select sandbox mode. Omitting `-s` gives `workspace-write` **with network access** — codex offers no network under `read-only` at all, so this is the only mode short of full access that has any. Pass `-s read-only` when a run must neither touch the tree nor reach off-machine; `-s danger-full-access` only when it must write outside the workspace. Because the default already permits writes, what bounds a run that is meant to only read is the role its prompt declares — state it.
 3. Craft prompt per Context Classification and Prompt Template — classify context, write to `<scratchpad>/codex_prompt_<suffix>.txt`.


### PR DESCRIPTION
#141은 luna를 "호출자가 명시할 때만" 쓰는 opt-in 항목으로 넣었습니다. 이 PR은 그 예외절을 걷어내고 luna를 sol·terra와 동등한 선택지로 만듭니다.

## 왜 걷어내나

예외 하나를 유지하는 데 **항상 로드되는 스킬 파일에서 지침 세 개**가 들었습니다 — 항목의 제한절, ask가 무엇을 제공하는지 밝히는 줄, effort 문단의 "단독 실행" 단서. 그리고 이 브랜치의 이전 수정들이 전부 그 예외가 미처 못 닿은 표면(picker, effort 문단, `-h` 예시)으로 새는 걸 막는 작업이었습니다. 표면마다 패치가 필요한 규칙은 자기 유지비를 파일 예산에서 빼 쓰는 셈입니다.

luna 항목의 effort도 요구에서 관례로 낮췄습니다(`usually at xhigh`) — 그래야 "effort는 한 번 골라 모든 선택 모델에 동일 적용"과 부딪치지 않습니다.

## luna 성격이 더 이상 unverified가 아닙니다

#141은 substrate에 이 모델 이름이 없다는 이유로 성격 대신 운용 규칙만 적었습니다. 있습니다:

```
$ strings -a "$(readlink -f "$(command -v codex)")" | grep -B3 -A3 "Fast and affordable agentic coding model"
      "display_name": "GPT-5.6-Luna",
      "description": "Fast and affordable agentic coding model.",
```

codex-cli 0.149.0의 model-preset 레지스트리에 `slug: gpt-5.6-luna`로 존재하고, `context_window` 272000 / `max_context_window` 872000으로 sol·terra와 동일하며 `supported_reasoning_levels`에 `xhigh`가 있습니다. 인용된 description이 이제 SKILL.md의 항목 설명이고, 수치는 커밋 메시지에 있습니다.

## 그 밖에

`-h`와 Quick Reference의 `-m` 예시를 terra로 되돌렸습니다. 래퍼는 모델명을 검증하지 않으므로 `--help`가 직접 호출자의 유일한 표면인데, 거기서 특정 모델을 표준 예시로 광고할 이유가 없습니다.

## 검증

```
$ bash -n scripts/codex-run.sh
(no output — syntax OK)
```

main 대비 순 변경은 SKILL.md 두 줄, `codex-run.sh` 한 줄, `plugin.json` 2.10.1 → 2.10.4 (훅이 커밋마다 bump를 요구).
