### PR TITLE
remote-tmux: fix eight review findings on the --remote-control-optional docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -67,7 +67,7 @@
     {
       "name": "remote-tmux",
       "source": "./remote-tmux",
-      "description": "tmux-tracked `claude remote-control` toolkit: spawn one-off sessions or keep a self-restarting --spawn-worktree pool host alive per project, reachable from the Claude app wherever the launch takes --remote-control"
+      "description": "tmux-tracked `claude remote-control` toolkit: spawn one-off sessions, app-reachable wherever the launch takes --remote-control, or keep a self-restarting --spawn-worktree pool host alive per project"
     },
     {
       "name": "excalidraw-host",

--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are addressable by SendMessage and, on a launch that takes --remote-control, app-reachable (remote-spawn skill), or keep a self-restarting --spawn-worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/README.md
+++ b/remote-tmux/README.md
@@ -1,6 +1,6 @@
 # remote-tmux
 
-A `claude remote-control` toolkit reachable from the Claude app (claude.ai/code + mobile).
+A `claude remote-control` toolkit for reaching sessions from the Claude app (claude.ai/code + mobile).
 No Telegram, no bridge — the running session *is* the aperture; voice input comes from the
 app's own dictation. It ships two skills:
 
@@ -32,15 +32,19 @@ along with the peer ref other sessions address it by — so neither is safe to c
 `--remote-control` registers the app bridge. The worktree token and the session name are
 separate on purpose — see the skill's naming section.
 
-`--remote-control` is the one a launch can be missing, and it is separable: what it buys is
+`--remote-control` is the one a launch path may fail to carry, and it is separable: what it buys is
 the app bridge alone. The messaging socket comes from the backgrounded launch itself and the
 name from `-n`, so `SendMessage`, the fleet row and the pinned name all survive without it —
 what goes is reachability from claude.ai/code and the mobile app. Some launch paths have not
 carried it (observed: a project-local `ocx claude`-style wrapper) and the reason is
 unestablished, so do not predict it from the shape of the command — read `bridgeSessionId` in
-`~/.claude/sessions/<pid>.json`, written exactly when the bridge registered. Going without is
-not deferrable: the bridge is decided at launch, so a worker started without one stays
-app-unreachable until it is launched again on a path that does take the flag.
+`~/.claude/sessions/<pid>.json`, non-null exactly when the bridge registered. Test the value
+and not the key: it can sit present and `null` on a session that never got a bridge. The
+`<pid>` is the `pid` field `claude agents --json` carries for that `<jobId>`. Going without
+is not deferrable: the bridge is decided at launch, so a worker started without one stays
+app-unreachable for the life of that run. A fresh launch on a flag-carrying path gets a
+bridge, but it is a new run rather than the same worker; carrying the conversation across
+means `--resume`, and whether the flag restores a bridge there is untested.
 
 The two pieces of shell around them are load-bearing as well. The **`cd` is what selects the
 project** — there is no flag for it, the session inherits the launching shell's directory, and
@@ -50,8 +54,8 @@ error and the worker comes up idle having been told nothing, and wherever `--rem
 is passed its optional name argument is a second way for a brief to disappear the same way.
 
 A worker keeps its socket after finishing a turn and stays idle-resident, so follow-up
-instructions reach it. Resume with `( cd <its-cwd> && claude --bg --remote-control <name> -n
-<name> --resume <sessionId> … -- "<next>" )` — a resume is itself a launch, so keep
+instructions reach it. Resume with `( cd <its-cwd> && claude --bg --remote-control "<name>"
+-n "<name>" --resume <sessionId> … -- "<next>" )` — a resume is itself a launch, so keep
 `--remote-control` if the first launch had it, or the resumed worker comes up with no app
 bridge and cannot be given one while it runs. Context carries over but a new sessionId is
 minted; `jobId` is that id's first 8 hex characters.

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -33,7 +33,7 @@ the project directory but is held out of the shared checkout: edits there are
 rejected until the session isolates itself under `.claude/worktrees/`. The one
 opt-out is `worktree.bgIsolation: "none"` in settings.
 
-**`--remote-control` is the one flag a launch can be missing, and it is separable.**
+**`--remote-control` is the one flag a launch path may fail to carry, and it is separable.**
 Independence is not decorative here: what the flag buys is the app bridge and nothing
 else. The messaging socket that makes a worker addressable by `SendMessage` comes from
 the backgrounded launch itself, the fleet row comes with it, and the name is pinned by
@@ -45,17 +45,27 @@ known mechanism: one path where the flag has not come through is a launch made v
 project-local `ocx claude`-style wrapper, and *why* it does not is unestablished — nobody
 has run it down to a cause. So neither a wrapper in the command nor this paragraph is a
 verdict on any particular launch. Read the session instead: `bridgeSessionId` in
-`~/.claude/sessions/<pid>.json` is written exactly when the app bridge registered, so one
-look after the spawn answers it for that session whatever the reason would have been. The
-check holds if the cause turns out to be something else, and it holds if the path is fixed
-later; a sentence naming the cause would quietly stop holding at both.
+`~/.claude/sessions/<pid>.json` holds a non-null value exactly when the app bridge
+registered, so one look after the spawn answers it for that session whatever the reason
+would have been. Read the value and not the key: the key can sit present and `null` on a
+session that never got a bridge, so a presence test reports every such worker as
+app-reachable. The `<pid>` is the `pid` field `claude agents --json` carries for that
+`<jobId>` — the spawn line hands back the jobId, not the pid. The check holds if the cause
+turns out to be something else, and it holds if the path is fixed later; a sentence naming
+the cause would quietly stop holding at both.
 
-Pass it wherever the launch takes it — reaching a worker from a phone is most of what the
-bridge is for, and no other flag offers it. Where a launch does not take it, going without is the right
-move rather than a defeat, and it is not a deferral: the bridge is decided at launch, so a
-worker started without one stays app-unreachable for the life of that run. Reaching it
-from the app means launching it again on a path that does take the flag, not attaching a
-bridge to the worker already up.
+Pass it on every spawn — reaching a worker from a phone is most of what the bridge is for,
+and no other flag offers it. The command's shape is no verdict on whether the path carries
+the flag through, so passing it and reading the session after is the only order available;
+there is no pre-launch check to run. What a path that does not take the flag does with it —
+ignore it silently, or fail the spawn on an unknown option — is unestablished, so if a spawn
+dies on the flag, relaunch without it and take the loss below. Where a launch does not take
+it, going without is the right move rather than a defeat, and it is not a deferral: the
+bridge is decided at launch, so a worker started without one stays app-unreachable for the
+life of that run. A fresh launch on a path that does take the flag gets a bridge — but that
+is a new run, not the worker already up, and nothing attaches a bridge to a session
+mid-flight. Carrying that worker's conversation across means `--resume`, and whether the
+flag restores a bridge there is untested (see Resuming).
 
 **`<surface>` and the session name are separate tokens on purpose.** `--worktree` puts its
 argument through `claude`'s own worktree-name validator, which is stricter than git's
@@ -189,9 +199,10 @@ A spawned session never reads this file. Carry the contract in the brief itself:
 only). The registry at `~/.claude/sessions/<pid>.json` is a different surface and answers a
 different question: **`messagingSocketPath` is present exactly when the session is addressable
 by `SendMessage`**, which nothing else reports. Alongside it: `entrypoint`, `bridgeSessionId`
-(written exactly when `--remote-control` registered the app bridge — the after-the-fact
-answer to whether this session is reachable from the app), `nameSource`, `jobId`,
-`statusUpdatedAt`, and `waitingFor` — the last
+(non-null exactly when `--remote-control` registered the app bridge — the after-the-fact
+answer to whether this session is reachable from the app; it can also sit present and `null`
+on a session that never got one, so test the value rather than the key), `nameSource`,
+`jobId`, `statusUpdatedAt`, and `waitingFor` — the last
 written only while the session is actually waiting, so its absence is the normal case.
 
 `status: "waiting"` means **an unanswered dialog exists, not that the session is stuck** —
@@ -221,7 +232,7 @@ block deletion. Audit rather than rely on either.
 ## Resuming
 
 ```bash
-( cd <its-cwd> && claude --bg --remote-control <name> -n <name> --resume <sessionId> \
+( cd <its-cwd> && claude --bg --remote-control "<name>" -n "<name>" --resume <sessionId> \
                          --permission-mode auto -- "<next instruction>" )
 ```
 


### PR DESCRIPTION
Fixes the eight findings a `/code-review high` pass returned against #144. Stacked on `worktree-rc-optional`, so #144 stays reviewed as reviewed and these repairs read as their own unit.

Nothing here reaches past what the review found. The full reasoning — including the registry survey the first finding rests on — is in the commit message.

## What the findings were

| # | Site | Defect |
|---|---|---|
| 1 | `SKILL.md:47`, `:191`, `README.md:40` | `bridgeSessionId` phrased as "written exactly when the bridge registered", which invites a key-presence test. The key can sit present and `null` on a session with no bridge, so a presence test reports such a worker as app-reachable. All three sites now test the value. |
| 2 | `SKILL.md:53` | "Pass it wherever the launch takes it" was undecidable before launch — the paragraph above forbids predicting from the command's shape and offers only an after-the-fact read. |
| 3 | `README.md:42` | Asserted as fact a recovery path `SKILL.md:233-234` marks untested. |
| 4 | `.claude-plugin/marketplace.json:70` | The app-reachability caveat attached to a sentence covering both skills; the pool host's app presence comes from the `remote-control` subcommand, not the flag. |
| 5 | `SKILL.md:36`, `README.md:35` | "the one flag a launch can be missing" is falsified by the two sentences above it, which describe `-n` and `--worktree` as droppable. |
| 6 | `SKILL.md:224`, `README.md:53` | Both resume templates passed `<name>` unquoted while the same document had just strengthened the rule to quote both. |
| 7 | `SKILL.md:47`, `README.md:40` | The prescribed check needs a `<pid>` the reader never received — the spawn line prints only `<jobId>`. |
| 8 | `README.md:3` | Headline still asserted unconditional app reachability. |

## Two fixes that are more than wording

**Finding 2 changes the advice, not just its phrasing.** Old text: pass the flag where the launch takes it. New text: pass it on every spawn and read the session after. That is the only rule that survives "you cannot know before launch" — but it is a behavioral change to the skill, not a clarification. The gap it cannot close is named rather than resolved: whether a non-carrying path ignores the flag or fails the spawn on an unknown option is unestablished, so a spawn that dies on the flag is relaunched without it.

**Finding 3 is fixed by separating two cases rather than hedging both.** A fresh launch on a flag-carrying path plainly gets a bridge; what `SKILL.md` marks untested is adding the flag while *resuming* a worker that never had one. The README had collapsed these into an unhedged "launched again on a path that does take the flag", which reads as a recovery path for the worker already up. Both files now say the fresh launch is a new run rather than that worker, and route conversation continuity to `--resume` with the untested status attached there.

Finding 8's obvious move — appending the flag caveat to the headline — is deliberately not taken. The headline covers both skills and the caveat is false of `rc-pool`, for the same reason it was false in `marketplace.json`.

## Scope note — an adjacent claim left alone

`SKILL.md:199-200` asserts **`messagingSocketPath` is present exactly when the session is addressable by `SendMessage`** — structurally the same presence test finding 1 just corrected one line below, and it predates #144. It is left untouched here because it is outside what the review found, but local evidence does not support it as written: a registry sweep found an `entrypoint: sdk-cli` session carrying `messagingSocketPath` with a value, while `README.md:103` states that pool children are "`sdk-cli` sessions with no messaging socket". Those two claims and that file cannot all be true at once. Worth its own pass.

## Verification

- Version 5.1.0 → 5.1.1; `.githooks/check-version-bump.sh origin/worktree-rc-optional HEAD` exits 0.
- Both changed JSON files re-parse.
- Docs-only; no measured facts inscribed in the artifacts (the survey lives in the commit message).
