### PR TITLE
remote-tmux: cut the ocx coupling and re-run the compression pass (5.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -67,7 +67,7 @@
     {
       "name": "remote-tmux",
       "source": "./remote-tmux",
-      "description": "tmux-tracked `claude remote-control` toolkit: spawn one-off sessions, app-reachable wherever the launch takes --remote-control, or keep a self-restarting --spawn-worktree pool host alive per project"
+      "description": "`claude remote-control` toolkit: spawn one-off backgrounded sessions, app-reachable wherever the launch takes --remote-control, or keep a tmux-tracked self-restarting `--spawn worktree` pool host alive per project"
     },
     {
       "name": "excalidraw-host",

--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
-  "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are addressable by SendMessage and, on a launch that takes --remote-control, app-reachable (remote-spawn skill), or keep a self-restarting --spawn-worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.2.0",
+  "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are addressable by SendMessage and, on a launch that takes --remote-control, app-reachable (remote-spawn skill), or keep a self-restarting --spawn worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
+  "version": "5.3.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/README.md
+++ b/remote-tmux/README.md
@@ -1,8 +1,8 @@
 # remote-tmux
 
-A `claude remote-control` toolkit for reaching sessions from the Claude app (claude.ai/code + mobile).
-No Telegram, no bridge — the running session *is* the aperture; voice input comes from the
-app's own dictation. It ships two skills:
+A `claude remote-control` toolkit for reaching sessions from the Claude app (claude.ai/code +
+mobile). The running session *is* the aperture — no bridge process in between. It ships two
+skills:
 
 - **`remote-spawn`** — spawn one worker session, script-free (below).
 - **`rc-pool`** — keep a self-restarting `--spawn worktree --capacity N` pool host alive per
@@ -32,41 +32,28 @@ along with the peer ref other sessions address it by — so neither is safe to c
 `--remote-control` registers the app bridge. The worktree token and the session name are
 separate on purpose — see the skill's naming section.
 
-`--remote-control` is the one a launch path may fail to carry, and it is separable: what it
-buys is the app bridge alone. The messaging socket comes from the backgrounded launch itself
-and the name from `-n`, so `SendMessage`, the fleet row and the pinned name all survive
-without it — what goes is reachability from claude.ai/code and the mobile app. Some launch paths have not
-carried it (observed: a project-local `ocx claude`-style wrapper) and the reason is
-unestablished, so do not predict it from the shape of the command — read `bridgeSessionId` in
-`~/.claude/sessions/<pid>.json`, non-null exactly when the bridge registered. Test the value
-and not the key: it can sit present and `null` on a session that never got a bridge. The
-`<pid>` is the `pid` field `claude agents --json` carries for that `<jobId>`. Going without
-is not deferrable: the bridge is decided at launch, so a worker started without one stays
-app-unreachable for the life of that run. A fresh launch on a flag-carrying path gets a
-bridge, but it is a new run rather than the same worker; carrying the conversation across
-means `--resume`, and whether the flag restores a bridge there is untested.
+`--remote-control` is separable: what it buys is the app bridge alone. The messaging socket
+comes from the backgrounded launch itself and the name from `-n`, so `SendMessage`, the fleet
+row and the pinned name all survive without it — what goes is reachability from claude.ai/code
+and the mobile app. Some launch paths have not carried it, and the shape of the command is no
+verdict on whether a given one does, so read the session instead: `bridgeSessionId` in
+`~/.claude/sessions/<pid>.json` is non-null exactly when the bridge registered. Test the value
+and not the key — it can sit present and `null` on a session that never got one. The `<pid>` is
+the `pid` field `claude agents --json` carries for that `<jobId>`. Going without is not
+deferrable: the bridge is decided at launch, so a worker started without one stays
+app-unreachable for the life of that run, and nothing attaches one mid-flight.
 
-The two pieces of shell around them are load-bearing as well. The **`cd` is what selects the
-project** — there is no flag for it, the session inherits the launching shell's directory, and
-`--worktree` needs that directory inside a git repo; the subshell keeps the caller's own cwd.
-The **`--` guards the brief** — without it a brief starting with a dash is swallowed with no
-error and the worker comes up idle having been told nothing, and wherever `--remote-control`
+The two pieces of shell around the flags are load-bearing as well. The **`cd` is what selects
+the project** — there is no flag for it, the session inherits the launching shell's directory,
+and `--worktree` needs that directory inside a git repo; the subshell keeps the caller's own
+cwd. The **`--` guards the brief** — without it a brief starting with a dash is swallowed with
+no error and the worker comes up idle having been told nothing, and wherever `--remote-control`
 is passed its optional name argument is a second way for a brief to disappear the same way.
 
 A worker keeps its socket after finishing a turn and stays idle-resident, so follow-up
-instructions reach it. Resume with `( cd <its-cwd> && claude --bg --remote-control "<name>"
--n "<name>" --resume <sessionId> … -- "<next>" )` — a resume is itself a launch, so keep
-`--remote-control` if the first launch had it, or the resumed worker comes up with no app
-bridge and cannot be given one while it runs. Context carries over but a new sessionId is
-minted; `jobId` is that id's first 8 hex characters.
-
-## Why the script went away
-
-Everything the old `rc-spawn.sh` wrapped is native: worktree creation, naming, background
-lifetime, app reachability, listing, attach, logs, stop. Two capabilities the wrapper never
-had come with it — `claude rm` actually retires the worktree lease, and a backgrounded
-session is addressable by `SendMessage`, so a supervisor can direct it instead of only
-launching it. A tmux pane could do neither.
+instructions reach it. Resuming is itself a launch — the flags are chosen again rather than
+inherited, and a new sessionId is minted. The skill's Resuming section carries the command and
+what the trade costs.
 
 Two caveats worth knowing:
 - **Permission classes must match**, which is why the command above passes `--permission-mode
@@ -93,17 +80,13 @@ bash scripts/rc-pool.sh down   <name|dir>                        # graceful SIGT
 bash scripts/rc-pool.sh status <name|dir>
 ```
 
-This one keeps its tmux pane, for two reasons a backgrounded session cannot cover: the host
-is an interactive TUI that needs a live PTY, and nothing else restarts it when it crashes.
-(TCC is *not* one of those reasons — a `--bg` session forks from the invoking shell and
-inherits its grant just as the tmux server does. The grant only goes missing under launchd,
-which is what the original comparison was about.) It also remains the only way to originate
-a session **without a CLI** — that is what makes it the phone's entry point.
+This one keeps its tmux pane, for two reasons a backgrounded session cannot cover: the host is
+an interactive TUI that needs a live PTY, and nothing else restarts it when it crashes. It also
+remains the only way to originate a session **without a CLI** — that is what makes it the
+phone's entry point.
 
-The host re-execs this script from disk each cycle (on-disk edits take effect on restart).
-The `remote-control` subcommand hard-errors on an untrusted workspace, so trust the project
-once (`claude` in the dir, accept the dialog) before `up`.
+The `remote-control` subcommand hard-errors on an untrusted workspace, so trust the project once
+(`claude` in the dir, accept the dialog) before `up`.
 
-Its children are `sdk-cli` sessions with no messaging socket: they can send but cannot
-receive a task or a reply. Work that a supervisor must direct is spawned by that supervisor
-via `remote-spawn`, not opened through the pool.
+Work that a supervisor must direct — anything it has to send instructions to after launch — is
+spawned by that supervisor via `remote-spawn`, not opened through the pool.

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -9,8 +9,8 @@ description: >
   peer, or judge whether one can be interrupted. It launches a backgrounded `claude`
   session addressable by `SendMessage` from other sessions and — on a launch that takes
   `--remote-control` — reachable from claude.ai/code and the mobile app as well. No
-  script, no tmux, no Telegram bridge. It carries the whole lifecycle of such a session:
-  spawning, addressing, receiving, observing, retiring.
+  script, no tmux. It carries the whole lifecycle of such a session: spawning, addressing,
+  receiving, observing, retiring.
 ---
 
 # Remote-Control Spawner
@@ -33,56 +33,45 @@ cuts branch `worktree-<surface>` from `origin/<default>` (or reuses it, below),
 `--remote-control` registers the app bridge. Dropping `--worktree` does not opt out
 of isolation — it only gives up the named branch. A backgrounded session starts in
 the project directory but is held out of the shared checkout: edits there are
-rejected until the session isolates itself under `.claude/worktrees/`. The one
-opt-out is `worktree.bgIsolation: "none"` in settings.
+rejected until the session isolates itself under `.claude/worktrees/`, and the one
+opt-out lives in settings rather than on the command line.
 
-**`--remote-control` is the one flag a launch path may fail to carry, and it is separable.**
-Independence is not decorative here: what the flag buys is the app bridge and nothing
-else. The messaging socket that makes a worker addressable by `SendMessage` comes from
-the backgrounded launch itself, the fleet row comes with it, and the name is pinned by
-`-n`. Drop the flag and all three still hold; what goes is reachability from
-claude.ai/code and the mobile app, which is the whole of the loss.
+**`--remote-control` is separable, and separable in one direction only.** What it buys
+is the app bridge and nothing else: the messaging socket that makes a worker addressable
+by `SendMessage` comes from the backgrounded launch itself, the fleet row comes with it,
+and the name is pinned by `-n`. Drop the flag and all three still hold; what goes is
+reachability from claude.ai/code and the mobile app, which is the whole of the loss.
 
-Some launch paths do not carry it. That is an observed fact and not a rule with a
-known mechanism: one path where the flag has not come through is a launch made via a
-project-local `ocx claude`-style wrapper, and *why* it does not is unestablished — nobody
-has run it down to a cause. So neither a wrapper in the command nor this paragraph is a
-verdict on any particular launch. Read the session instead: `bridgeSessionId` in
-`~/.claude/sessions/<pid>.json` holds a non-null value exactly when the app bridge
-registered, so one look after the spawn answers it for that session whatever the reason
-would have been. Read the value and not the key: the key can sit present and `null` on a
-session that never got a bridge, so a presence test reports every such worker as
-app-reachable. The `<pid>` is the `pid` field `claude agents --json` carries for that
-`<jobId>` — the spawn line hands back the jobId, not the pid. The check holds if the cause
-turns out to be something else, and it holds if the path is fixed later; a sentence naming
-the cause would quietly stop holding at both.
+**Some launch paths do not carry it, and the command's shape does not say which.** That
+is an observed fact rather than a rule with a known mechanism, so do not predict it —
+neither from the presence of a wrapper nor from a launch that looks direct. Read the
+session instead: `bridgeSessionId` in `~/.claude/sessions/<pid>.json` holds a non-null
+value exactly when the app bridge registered. Read the value and not the key — the key
+can sit present and `null` on a session that never got a bridge, so a presence test
+reports every such worker as app-reachable. The `<pid>` is the `pid` field `claude agents
+--json` carries for that `<jobId>`; the spawn line hands back the jobId, not the pid.
+This check survives learning the cause, and survives the path being fixed.
 
-Pass it on every spawn — reaching a worker from a phone is most of what the bridge is for,
-and no other flag offers it. The command's shape is no verdict on whether the path carries
-the flag through, so passing it and reading the session after is the only order available;
-there is no pre-launch check to run. What a path that does not take the flag does with it —
-ignore it silently, or fail the spawn on an unknown option — is unestablished, so if a spawn
-dies on the flag, relaunch without it and take the loss below. Where a launch does not take
-it, going without is the right move rather than a defeat, and it is not a deferral: the
-bridge is decided at launch, so a worker started without one stays app-unreachable for the
-life of that run. A fresh launch on a path that does take the flag gets a bridge — but that
-is a new run, not the worker already up, and nothing attaches a bridge to a session
-mid-flight. Carrying that worker's conversation across means `--resume`, and whether the
-flag restores a bridge there is untested (see Resuming).
+Pass the flag on every spawn — reaching a worker from a phone is most of what the bridge
+is for, and no other flag offers it. Since the shape is no verdict, passing it and reading
+the session after is the only order available; there is no pre-launch check. Whether a
+path that does not take it ignores it or fails the spawn on an unknown option is
+unestablished, so a spawn that dies on the flag is relaunched without it. Going without is
+not a deferral: the bridge is decided at launch, so a worker started without one stays
+app-unreachable for the life of that run. A fresh launch on a path that does take the flag
+gets a bridge, but that is a new run rather than the worker already up, and nothing
+attaches a bridge mid-flight. Carrying that worker's conversation across means `--resume`,
+and whether the flag restores a bridge there is untested (see Resuming).
 
 **`<surface>` and the session name are separate tokens on purpose.** `--worktree` puts its
 argument through `claude`'s own worktree-name validator, which is stricter than git's
-refname rules: each `/`-separated segment may hold only letters, digits, dots,
-underscores and dashes, to 64 characters total. Git's refname grammar is wider, so
-reasoning from it mispredicts — `a+b` is a legal refname and is rejected here. `<surface>`
-stays a plain hyphenated token, and the `::` the session name is built on is not available
-to it.
-
-Nor should the two share a value, independent of that constraint: several Stints can
-share one worktree, and one unit of work can span several worktrees — neither direction
-supports a fixed mapping from branch to session name. Sharing needs no special form:
-`--worktree <surface>` is find-or-create, so a second Stint passing a name that already
-exists joins that worktree and its branch rather than colliding.
+refname rules — reasoning from refname grammar mispredicts, and the validator rejects a bad
+token loudly before anything is created. Keep `<surface>` a plain hyphenated token; the `::`
+the session name is built on is not available to it. Nor should the two share a value
+independent of that constraint: several Stints can share one worktree and one unit of work
+can span several, so no fixed mapping from branch to session name holds. Sharing needs no
+special form — `--worktree <surface>` is find-or-create, so a second Stint passing an
+existing name joins that worktree and its branch rather than colliding.
 
 **The `cd` is what picks the project.** There is no flag for it — `--add-dir` grants tool
 access to extra paths but does not set the session's project; the spawned session simply
@@ -91,26 +80,23 @@ directory to be inside a git repo. Keep the `cd` inside a subshell so the caller
 working directory survives the spawn.
 
 **The `--` is what ends option parsing.** Without it the brief is parsed as options and
-consumed silently — `claude` prints `(idle — send a prompt to start)`, no error, no
-transcript, and a worker sits there having been told nothing. A brief that starts with a
-dash hits this on any launch. `--remote-control` opens a second door to the same failure
-wherever it is used: its name argument is optional, so a brief sitting after it is taken as
-that name and vanishes. Leaving the flag out closes that door and none of the first, so the
-`--` stays either way.
+consumed silently — no error, no transcript, and a worker sits there idle having been told
+nothing. A brief that starts with a dash hits this on any launch. `--remote-control` opens a
+second door to the same failure wherever it is used: its name argument is optional, so a
+brief sitting after it is taken as that name and vanishes. Leaving the flag out closes that
+door and none of the first, so the `--` stays either way.
 
 **The permission mode must match the supervisor's**, and `--permission-mode auto` is what
-that resolves to from an auto-mode supervisor. Two constraints close on the same value.
-A cross-session message from a sender in a different permission class is not delivered —
-it opens a dialog the worker never answers, so the instruction silently never arrives, which
-is why the worker takes the supervisor's class. That class is also the only one reachable
-from an auto-mode supervisor: a spawn command carrying a skip-permissions flag is refused by
-auto mode's own permission classifier, so the spawn is denied before any worker exists. Pass
-the supervisor's own class explicitly — it is the one part of
-this command that cannot be copied from a sibling. The session registry does not carry it;
-the supervisor's transcript does, as `{"type":"permission-mode","permissionMode":…}` records
-written on every mode change. Whether parity is consulted at all is decided one level up, by
-the `crossSessionInbound` setting — so a class match cannot be inferred from a message having
-arrived, and the setting is read rather than assumed when that inference would matter.
+that resolves to from an auto-mode supervisor. Two constraints close on the same value. A
+cross-session message from a sender in a different permission class is not delivered — it
+opens a dialog the worker never answers, so the instruction silently never arrives, which is
+why the worker takes the supervisor's class. That class is also the only one reachable from
+an auto-mode supervisor: a spawn command carrying a skip-permissions flag is refused by auto
+mode's own permission classifier, so the spawn is denied before any worker exists. Pass the
+supervisor's own class explicitly — it is the one part of this command that cannot be copied
+from a sibling, since the session registry does not carry it and the supervisor's transcript
+does. Whether parity is consulted at all is decided one level up by the `crossSessionInbound`
+setting, so a class match cannot be inferred from a message having arrived.
 
 ## Naming a spawned session
 
@@ -124,87 +110,68 @@ session that created this Stint, written as a short form of that session's own t
 read off the creator, not derived and not coined. Two Stints created by one session
 therefore carry the same token and Stints from different creators do not, which is the
 grouping the convention exists for. `<child>` describes this Stint freely, distinctly
-enough to tell it from its siblings under the same parent. Three segments always: the
-marker, then parent and child. Two Stints from one creator:
-`stint::comment-review::port` and `stint::comment-review::review`.
+enough to tell it from its siblings. Three segments always: the marker, then parent and
+child — `stint::comment-review::port` beside `stint::comment-review::review`.
 
 Neither segment may carry whitespace, which is why both substitutions are quoted in the
-command above. That bars the character, not the phrase: a multi-word name stays
-multi-word and hyphenated, since compressing a title into a single token to make it fit
-throws away the reading it was chosen for. The asymmetry is what to hold on to:
-`<surface>` is covered by the validator, which rejects a bad token loudly before anything
-gets created, while the session name passes through no validator at all. There a space is
-not an error but a truncation: unquoted, the name splits at the space and only its first
-piece reaches the flag — `-n stint::my unit::build` pins `stint::my` and leaves
-`unit::build` as a stray positional, so the worker comes up under a name nobody can address
-it by. `--remote-control` takes its name the same way and truncates the same way wherever
-it is passed, so quote both. The same freedom that is safe on one token fails silently on
-the other.
+command above. That bars the character, not the phrase: a multi-word name stays multi-word
+and hyphenated, since compressing a title into a single token to make it fit throws away
+the reading it was chosen for. The asymmetry is what to hold on to. `<surface>` has a
+validator behind it; the session name passes through none, so there a space is not an error
+but a truncation — unquoted, the name splits and only its first piece reaches the flag,
+leaving the rest as a stray positional and the worker under a name nobody can address it
+by. `--remote-control` takes its name the same way and truncates the same way, so quote
+both.
 
 Every name here is pinned explicitly with `-n`. Where `--remote-control` is passed it then
 deliberately takes the same value as `-n` — they are independent flags, one naming the
 session and one registering the app bridge, and holding them equal is what makes the name
-printed at spawn the same string peers address. Naming is `-n`'s job on its own, so a
-launch that cannot carry the bridge flag is named no differently and addressed no
-differently.
+printed at spawn the same string peers address. Naming is `-n`'s job on its own, so a launch
+that cannot carry the bridge flag is named no differently and addressed no differently.
 
 The orchestrator reports both tokens with the spawn line — there is no separate per-spawn
 confirmation step. `<child>` it describes; `<parent>` it renders from its own topic, the
 same way across every Stint it spawns, so siblings match without either of them having to
 look anything up.
 
-Stints chain — one hands off to the next. Each level of Stint under a Stint adds
-supervision depth, which puts another hop between a gate and whoever can answer it.
-A subagent adds no such depth: it returns to its dispatcher and supervises nothing,
-which is how a Stint realizes work that must run in mutually isolated contexts.
-
 ## Talking to it
 
 ```bash
-claude agents --json          # fleet view: name, kind, state, status, id, pid, sessionId, cwd, startedAt
+claude agents --json          # fleet view: name, kind, state, status, id, pid, sessionId, cwd
 claude logs <jobId>           # recent output (TUI frames; prefer the transcript)
 claude attach <jobId>         # open it in this terminal
 ```
 
-From a session, `ListAgents` lists addressable peers and `SendMessage` reaches them.
-Not every peer in that list is a Stint: a session you did not spawn — an interactive one
-opened in another terminal — sits in the same listing and is addressed exactly the same
-way. This section, **Before you send** and **Observing** apply to both; only the lifecycle
-around a spawned worker — the command above, the reporting contract, retiring — is
-Stint-specific.
+From a session, `ListAgents` lists addressable peers and `SendMessage` reaches them. Not
+every peer in that list is a Stint: a session you did not spawn — an interactive one opened
+in another terminal — sits in the same listing and is addressed exactly the same way. This
+section, **Before you send** and **Observing** apply to both; only the lifecycle around a
+spawned worker — the command above, the reporting contract, retiring — is Stint-specific.
 
-**Resolve the address at send time**: send the exact `name [ref]` string `ListAgents`
-just printed. The first message to a peer you have not addressed before comes back
-asking you to re-send with its `[ref]` — a one-time confirmation, after which the bare
-name resolves for the rest of that conversation. Sending the ref every time skips that
-round trip, and it also resolves where a bare name would not: the explicit-ref branch runs
-ahead of the bare-name uniqueness check, which fails closed on a collision.
+**Resolve the address at send time**: send the exact `name [ref]` string `ListAgents` just
+printed. A first message to a peer you have not addressed before comes back asking you to
+re-send with its `[ref]`; sending the ref every time skips that round trip, and it also
+resolves where a bare name would not, since a collision fails the bare-name path closed.
 
-Neither half of the address holds still. Names collide heavily here, and a collision sends
-one of the two sessions to a hyphenated variant without a notice always following — the
-startup path renames silently. A target that restarts changes both its ref and its
-auto-derived name. So read the address fresh at each send; the registry is what carries the
-current one.
+Neither half of the address holds still. Names collide here, and a collision renames one of
+the two without a notice always following; a target that restarts changes both its ref and
+its auto-derived name. So read the address fresh at each send rather than caching it. One
+session also answers to several identifiers issued by different layers — the session id
+names the conversation, a process id names the running program and titles the registry file,
+and the ` [ref]` is a display token for one listing. They are separate values, so each is
+looked up rather than derived from another; given a session id, the registry entry is where
+it and the listed name appear together.
 
-A row for another session **on this machine** is already the result of a live socket
-connect attempt, so it needs no separate liveness check. Rows for cloud or Remote Control
-sessions reach the list by another route and carry no such guarantee.
+A row for another session **on this machine** is already the result of a live socket connect
+attempt, so it needs no separate liveness check. Rows for cloud or Remote Control sessions
+reach the list by another route and carry no such guarantee.
 
-One session answers to several identifiers, each issued by a different layer: the session
-id names the conversation and titles its transcript, a process id names the running
-program and titles both the registry file and its socket, and the ` [ref]` in a listing
-row is a display token for that listing. They are separate values, so each is looked up
-rather than derived from another. Given a session id, the registry entry is where it and
-the listed name appear together — read the name there, then address by that name.
-
-
-A worker keeps its socket after finishing a turn: it goes idle and resident, so
-follow-up instructions still reach it — but not indefinitely. The supervisor
-eventually reaps an idle worker's process, and a reaped worker keeps its row in
-`claude agents --json` while dropping out of `ListAgents` altogether: still listed,
-no longer addressable. So read addressability from `ListAgents` at send time, never
-from the fleet row. Pinning the session in agent view (`Ctrl+T`) keeps its process
-alive while it sits idle.
+A worker keeps its socket after finishing a turn: it goes idle and resident, so follow-up
+instructions still reach it — but not indefinitely. The supervisor eventually reaps an idle
+worker's process, and a reaped worker keeps its fleet row while dropping out of `ListAgents`
+altogether: still listed, no longer addressable. So read addressability from `ListAgents` at
+send time, never from the fleet row. Pinning the session in agent view (`Ctrl+T`) keeps its
+process alive while it sits idle.
 
 ## Before you send
 
@@ -212,14 +179,14 @@ Know what the target is working on before interrupting it. A peer mid-task pays 
 message that does not concern it, and an overlap worth writing about is invisible from the
 name alone — a backgrounded session's row carries its own task title, while an interactive
 one is named after its cwd and says nothing about what it is doing. The topic lives in the
-session registry (`~/.claude/sessions/*.json`, for session id and cwd) and in the
-transcript (`~/.claude/projects/*/<sessionId>.jsonl`), where the human turns carry it: a
-peer's inbound envelope and an interrupted request both land in that same `user` stream
-while being written by someone other than that session's human.
+session registry (`~/.claude/sessions/*.json`, for session id and cwd) and in the transcript
+(`~/.claude/projects/*/<sessionId>.jsonl`), where the human turns carry it: a peer's inbound
+envelope and an interrupted request both land in that same `user` stream while being written
+by someone other than that session's human.
 
-Delegate that read at the haiku tier rather than doing it inline. It is a bounded
-extract-and-judge pass, and delegating returns only what the send decision needs while
-keeping another session's conversation out of this one's context.
+Delegate that read rather than doing it inline. It is a bounded extract-and-judge pass, and
+delegating returns only what the send decision needs while keeping another session's
+conversation out of this one's context.
 
 ## Reporting contract — put it in the initial prompt
 
@@ -236,41 +203,41 @@ A spawned session never reads this file. Carry the contract in the brief itself:
 ## Receiving
 
 A message from another session is a claim, and its arrival establishes nothing about its
-accuracy. The claim was formed against that session's substrate rather than yours, and the
-scope its author could observe may be narrower than the sentence they wrote — a peer states
-as general what held everywhere they could see. Before acting on such a message or
-answering it, run `/inquire` at the sonnet tier against the real substrate. The asymmetry
-with the sending side is deliberate: reading outward is cheap, taking something inward and
-acting on it is not.
+accuracy. It was formed against that session's substrate rather than yours, and the scope
+its author could observe may be narrower than the sentence they wrote — a peer states as
+general what held everywhere they could see. So before acting on such a message or answering
+it, verify the claim against the real substrate, and delegate that read rather than pulling
+the peer's context into this one. Where an investigation protocol is installed, that is the
+shape this takes (`/inquire`, if present); where none is, the verification still happens by
+hand — the discipline is the check, not the tool. The asymmetry with the sending side is
+deliberate: reading outward is cheap, taking something inward and acting on it is not.
 
 This binds a message carrying a claim you would act on. An acknowledgement, a status note,
 or a reply that closes an exchange takes an answer, not an investigation.
 
-It binds a Stint's own report too, which is why the discipline sits in this file rather
-than anywhere on the delegation side. A Stint reports by `SendMessage` — the contract above
+It binds a Stint's own report too, which is why the discipline sits in this file rather than
+anywhere on the delegation side. A Stint reports by `SendMessage` — the contract above
 instructs it to — so its report arrives on this inbound path and not as a completion
 notification from a dispatched agent. Nothing on the harvest-a-delegated-result side fires
 on it: an inbound message is the one moment in a session's lifecycle that somebody else
 starts, so a supervisor waiting on a notification is not waiting on this.
 
-Both tiers named here — haiku for the outward read, sonnet for the inward one — are
-per-situation choices for these two reads, not standing routes for anything else.
-
 ## Observing
 
 `claude agents --json` covers most needs — it is also where `state` lives (background entries
-only). The registry at `~/.claude/sessions/<pid>.json` is a different surface and answers a
-different question: **`messagingSocketPath` is present exactly when the session is addressable
-by `SendMessage`**, which nothing else reports. Alongside it, `bridgeSessionId` is where app
-reachability is read — non-null exactly when `--remote-control` registered the bridge, and
-present-and-`null` on a session that never got one, so test the value rather than the key —
-and `statusUpdatedAt` is what the staleness judgment below rests on.
+only). The registry at `~/.claude/sessions/<pid>.json` is a different surface and answers
+different questions: `bridgeSessionId` is where app reachability is read — non-null exactly
+when `--remote-control` registered the bridge, and present-and-`null` on a session that never
+got one, so test the value rather than the key — and `statusUpdatedAt` is what the staleness
+judgment below rests on. `messagingSocketPath` is the registry's own trace of addressability,
+but `ListAgents` is the authority at send time and the registry is not; where the two
+disagree, the listing decides.
 
 **`status` is a rough interruptibility signal, not an account of the work.** It collapses
 distinctions the caller may care about — `busy` covers generating and having a delegated task
-in flight alike, and some delegated work is not counted at all — and `waiting` means an
-unanswered dialog exists, which a worker still accepts app input and processes peer messages
-through. Judge a suspected stall by how long `statusUpdatedAt` has been frozen.
+in flight alike — and `waiting` means an unanswered dialog exists, which a worker still
+accepts app input and processes peer messages through. Judge a suspected stall by how long
+`statusUpdatedAt` has been frozen.
 
 ## Retiring
 
@@ -279,31 +246,29 @@ claude stop <jobId>    # ends the run, LEAVES the job and its worktree
 claude rm  <jobId>     # retires it: removes worktree and job state
 ```
 
-`stop` alone is not retirement — the job stays in `claude agents --json --all`. Use `rm`
-to close out a work unit, the same lease discipline a worktree gets.
-
-Retiring is the point. A finished session holds a row, a process slot and possibly a
-worktree, and a list of finished-looking rows is a cost paid by whoever has to read it.
+`stop` alone is not retirement — the job stays in `claude agents --json --all`. Use `rm` to
+close out a work unit, the same lease discipline a worktree gets. Retiring is the point: a
+finished session holds a row, a process slot and possibly a worktree, and a list of
+finished-looking rows is a cost paid by whoever has to read it.
 
 What survives retirement is the conversation: the transcript stays on disk and `claude
---resume <sessionId>` still reaches it. What does not survive is anything whose only copy
-sits on the worktree — that is what the audit before retiring is for, and it asks about
-unpushed commits and uncommitted files rather than about where you happen to be standing.
-Recoverability is what makes the removal cheap; the worktree audit is what makes it safe,
-and neither substitutes for the other.
+--resume <sessionId>` still reaches it. What does not survive is anything whose only copy sits
+on the worktree — that is what the audit before retiring is for, and it asks about unpushed
+commits and uncommitted files rather than about where you happen to be standing.
+Recoverability is what makes the removal cheap; the worktree audit is what makes it safe, and
+neither substitutes for the other.
 
-Sources disagree on how far `rm` reaches into the worktree: `claude rm --help` says it
-deletes the session and its worktree outright, while the published docs say a worktree with
-uncommitted changes is kept and unpushed commits block deletion. Audit rather than rely on
-either.
+Sources disagree on how far `rm` reaches into the worktree — one says it deletes the worktree
+outright, another that uncommitted changes are kept and unpushed commits block deletion.
+Audit rather than rely on either.
 
-Standing inside a finished session's worktree is not itself a reason to defer; the
-hazard is narrower. A job that *created* its own worktree takes that directory with it, so
-retiring it from inside pulls the ground out from underfoot — while a job spawned into a
-worktree that already existed does not own it, and retiring that one should touch only job
-state. That ownership split is a reading to verify against the run rather than established
-behaviour, and the retirement's own report is where it shows: the owning case names the
-worktree path and the other does not. Read that line rather than predicting it.
+Standing inside a finished session's worktree is not itself a reason to defer; the hazard is
+narrower. A job that *created* its own worktree takes that directory with it, so retiring it
+from inside pulls the ground out from underfoot — while a job spawned into a worktree that
+already existed does not own it, and retiring that one should touch only job state. That
+ownership split is a reading to verify against the run rather than established behaviour, and
+the retirement's own report is where it shows: the owning case names the worktree path and
+the other does not. Read that line rather than predicting it.
 
 ## Resuming
 
@@ -312,30 +277,29 @@ worktree path and the other does not. Read that line rather than predicting it.
                          --permission-mode auto -- "<next instruction>" )
 ```
 
-A resume is itself a launch, so the flags are chosen again here rather than inherited from
-the previous run. Carry `--remote-control` through when that run had it: it composes with
+A resume is itself a launch, so the flags are chosen again here rather than inherited from the
+previous run. Carry `--remote-control` through when that run had it: it composes with
 `--resume`, and dropping it costs the resumed worker its app bridge for the whole of the new
 run — the socket and the bridge are both decided at launch, so a session that comes back
 without them cannot be given them later. A resume on a path that cannot pass the flag
 therefore buys the conversation back at the cost of the bridge; whether the trade runs the
 other way — adding the flag while resuming a worker that never had a bridge — is untested.
 
-Resume restores the conversation, not the working directory, so the same `cd` applies;
-`claude agents --json` reports each session's `cwd`, which is where to read it from.
+Resume restores the conversation, not the working directory, so the same `cd` applies; `claude
+agents --json` reports each session's `cwd`, which is where to read it from.
 
-Prior context carries over intact, but a **new sessionId is minted** — resume the newest
-one next time. `jobId` is the first 8 hex characters of `sessionId`, so the two views join
-without a separate key.
+Prior context carries over intact, but a **new sessionId is minted** — resume the newest one
+next time. `jobId` is the first 8 hex characters of `sessionId`, so the two views join without
+a separate key.
 
 Notes to pass on when relevant:
-- Nothing revives a *crashed* worker on its own, but restarts do happen: `claude respawn
-  <jobId>` (or `--all`) restarts a session onto the current binary, and the supervisor
-  restarts sessions from their transcript on a binary update or on the next attach. What
-  comes back is a fresh process, and both the messaging socket and the app bridge are
-  decided at launch — whether a restarted worker returns addressable and app-reachable is
-  untested, so re-read `ListAgents` before relying on it. For a keep-alive host, see the
-  `rc-pool` skill.
+- Nothing revives a *crashed* worker on its own, but restarts do happen: a session can be
+  restarted onto the current binary, and the supervisor restarts sessions from their transcript
+  on a binary update or on the next attach. What comes back is a fresh process, and both the
+  messaging socket and the app bridge are decided at launch — whether a restarted worker returns
+  addressable and app-reachable is untested, so re-read `ListAgents` and re-check
+  `bridgeSessionId` before relying on either. For a keep-alive host, see the `rc-pool` skill.
 - An already-running session cannot become addressable later; the socket is decided once at
   launch, so an old session must be restarted to join.
-- `claude daemon status` and `claude daemon stop --any --keep-workers` reach the supervisor
-  that hosts every background session — the handles for when the fleet itself misbehaves.
+- `claude daemon status` reaches the supervisor that hosts every background session — the handle
+  for when the fleet itself misbehaves.


### PR DESCRIPTION
Stacked on #144 — base is `worktree-rc-optional`, so this diff shows only this pass. Merge #144 first.

## What

A second run of the compression pass 9e9c5b4 defined for this same file (pace layering / white-bear / zero-shot, with that commit's halt rule overriding all three), plus removal of two dependencies that made the plugin unusable outside the author's own setup.

`SKILL.md` 341 → 305, `README.md` 109 → 92, version 5.2.0 → 5.3.0.

## The couplings

**`ocx`** — the one observed launch path that had not carried `--remote-control` was named in both files. It is an anchoring instance, which is exactly what zero-shot cuts, and the observation already lives in #144's commit message where the ledger rule puts it. What replaces it is the rule that held anyway: the command's shape is no verdict, so read `bridgeSessionId` after the spawn.

**`/inquire`** — found while auditing for the same shape, in a place the request had not named. `## Receiving` instructed the reader to run a protocol that ships in the *epistemic-protocols* marketplace and is absent from this one. Anyone installing `remote-tmux` alone was handed an unrunnable instruction. Fixed the same way: the discipline is stated as the check, and the protocol is named as the shape it takes where installed. Two model-tier designations went with it — routing for one setup, not part of the discipline.

## Two verified metadata defects

- Both plugin descriptions advertised `--spawn-worktree`. The flag is `--spawn worktree` (`scripts/rc-pool.sh:102` is the ground truth; the rc-pool skill and README were already right).
- `marketplace.json`'s leading "tmux-tracked" modified a sentence covering both skills while being false of `remote-spawn`, which uses no tmux. Structurally the same defect #144 fixed one clause to the right in the same description. Rescoped onto the pool clause.

## A cross-vendor consult, and what was declined

Consulted codex (gpt-5.6-sol, xhigh). Its density criterion is adopted and is better than the one it was given: the unit of an LLM-facing instruction is **action → tempting wrong inference → authoritative check**, not a bare imperative. Its dated-observation list is taken almost whole and is the bulk of what left.

**Declined:** cutting `## Receiving` and `## Before you send`, and splitting the lifecycle into an on-demand `references/lifecycle.md`. The consult read 47418f3 as having introduced the whole-lifecycle framing to solve a routing problem since retired; that commit says the opposite — *"the receiving discipline is the load-bearing part of the move, and the frontmatter description was widened for it"* — and it deleted the discipline's prior home as its counterpart, so there is nothing to fall back to.

**Also declined:** relocating `stint::<parent>::<child>` as owner-local. It is owner-local; the ask was independence from a tool, not from the author's own conventions.

## Changed footing, not resolved

`SKILL.md` had asserted `messagingSocketPath` is present exactly when a session is addressable by `SendMessage`. #144 recorded local evidence against it and left it out of scope. The sentence was being rewritten regardless, so rather than restate an unsupported mechanism or swap in another categorical claim, it now routes to the authority: `ListAgents` decides addressability at send time, the registry does not. **The underlying contradiction is still open** and wants its own pass.

## Scope note

The compression target set before the work was 180–200 lines; it landed at 305. The gap is the two declined verdicts, not slack left in the prose — keeping every section is most of the remaining length. Whether 100 lines of spawn core against 205 of post-spawn lifecycle is the right ratio is a separate question and is not settled here.
