### PR TITLE
browser-e2e: new plugin, two vendor-separated executor paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -105,6 +105,11 @@
       "description": "Browser-preview comment loop for markdown/HTML artifacts — right-click an element to anchor a comment by CSS selector, apply the queue back as edits, hot-reload"
     },
     {
+      "name": "browser-e2e",
+      "source": "./browser-e2e",
+      "description": "End-to-end browser flows in Chrome through two vendor-separated executors (codex by default, Claude on request) over one shared operation set"
+    },
+    {
       "name": "agent-device-preflight",
       "source": "./agent-device-preflight",
       "description": "Resolve agent-device attachment prerequisites before `open` — device lock state, signing team from the certificate OU, developer-account device registration, developer disk image mount, macOS DevToolsSecurity, stale runner cache and daemon environment, and physical-vs-virtual device selection"

--- a/browser-e2e/.claude-plugin/plugin.json
+++ b/browser-e2e/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-e2e",
   "description": "End-to-end browser flows in Chrome through two vendor-separated executors (codex by default, Claude on request) over one shared operation set",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/browser-e2e/.claude-plugin/plugin.json
+++ b/browser-e2e/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-e2e",
   "description": "End-to-end browser flows in Chrome through two vendor-separated executors (codex by default, Claude on request) over one shared operation set",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/browser-e2e/.claude-plugin/plugin.json
+++ b/browser-e2e/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-e2e",
   "description": "End-to-end browser flows in Chrome through two vendor-separated executors (codex by default, Claude on request) over one shared operation set",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/browser-e2e/.claude-plugin/plugin.json
+++ b/browser-e2e/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-e2e",
   "description": "End-to-end browser flows in Chrome through two vendor-separated executors (codex by default, Claude on request) over one shared operation set",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/browser-e2e/.claude-plugin/plugin.json
+++ b/browser-e2e/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "browser-e2e",
+  "description": "End-to-end browser flows in Chrome through two vendor-separated executors (codex by default, Claude on request) over one shared operation set",
+  "version": "0.1.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/browser-e2e/.claude-plugin/plugin.json
+++ b/browser-e2e/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-e2e",
   "description": "End-to-end browser flows in Chrome through two vendor-separated executors (codex by default, Claude on request) over one shared operation set",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/browser-e2e/skills/browser-e2e/SKILL.md
+++ b/browser-e2e/skills/browser-e2e/SKILL.md
@@ -29,12 +29,18 @@ machine state that changes underneath the skill.
 | Claude (named) | The Claude in Chrome extension connected to this session | `tabs_context_mcp` returns a tab group instead of an error |
 
 > **⛔ Open blocker on the default path.** Measured 2026-08-30 on codex-cli
-> 0.150.1: a `codex exec` run's tool inventory contains **no** chrome plugin and
-> no JS REPL to reach `agent.browsers.get("chrome")` — confirmed from two working
-> directories, and true even with `[plugins."chrome@openai-bundled"] enabled =
-> true` in `~/.codex/config.toml`. The four diagnostics all pass while the browser
-> API stays out of reach, so **a green preflight does not mean the path works**.
-> Which codex surface reaches the browser is unsettled: `references/codex.md`.
+> 0.150.1: the CLI never loads the chrome plugin, so no `codex exec` run can reach
+> `agent.browsers.get("chrome")`. Root cause is upstream of the browser entirely —
+> `codex plugin marketplace list` registers only `openai-curated`, while the
+> plugin is `chrome@openai-bundled`, a marketplace the CLI does not know. The
+> `enabled = true` in `~/.codex/config.toml`, the populated cache directory, and
+> the `browser_use` feature flag all look like enablement and none of them
+> resolves the plugin.
+>
+> Confirmed three times, including once with a Chrome tab open by hand, so the
+> extension is not the blocker. The four diagnostics all pass while the browser
+> API stays out of reach: **a green preflight does not mean the path works.**
+> Full evidence and what remains unverified: `references/codex.md`.
 
 > **Note**: no Chrome launch flag is required — neither path uses
 > `--remote-debugging-port`. Both reach Chrome through their vendor's own
@@ -148,6 +154,12 @@ outcome, whichever branch is running.
 the operation itself was not exercised. Treat a ᵁ cell as expected-to-work, and
 if it does not, report that rather than working around it (see *No fallback*).
 
+> **Read the ᴹ in the codex column narrowly.** Those operations were measured
+> through *some* codex surface whose identity could not be established, and the
+> CLI this skill documents cannot load the chrome plugin at all (blocker above).
+> They are evidence that the API exists somewhere — not that this skill's
+> invocation reaches it.
+
 `chrome.nameSession()` is Chrome-specific and must be called **before** opening or
 claiming tabs on the codex side.
 
@@ -197,10 +209,15 @@ assumptions:
 - **`tab.markHandoff()` lifetime across sessions** is unknown — whether a handoff
   marked in one codex run is still meaningful to a later one has not been tested.
   `references/codex.md`.
-- **Which codex surface exposes the chrome plugin.** The blocker above. The
-  operations in the codex column were measured through *some* surface but not
-  through `codex exec`, so every ᴹ in that column is evidence about the API, not
-  about the invocation this skill documents.
+- **Which codex surface exposes the chrome plugin.** The blocker above. Two
+  specific unknowns: whether the Codex desktop app (`codex app`) exposes the
+  browser API, and whether registering the `openai-bundled` marketplace would make
+  the CLI load it. The second writes to the user's codex config, so it is not the
+  skill's to try unasked.
+- **The provenance of the codex column's measurements.** The operations were
+  recorded as measured on a surface nobody has since been able to name; the
+  session originally credited with them has stated it made no codex measurement.
+  Not "probably fine" — unverified as to where it came from, and marked so.
 
 ### What a dogfood run already found
 

--- a/browser-e2e/skills/browser-e2e/SKILL.md
+++ b/browser-e2e/skills/browser-e2e/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: browser-e2e
+description: |
+  This skill should be used when the user asks to "run an E2E", "browser E2E",
+  "test this flow in the browser", "walk through the signup flow in Chrome",
+  "drive Chrome for a test", "check this page end to end", or invokes
+  `/browser-e2e`. Runs an end-to-end browser flow in Chrome through one of two
+  vendor-separated executors — codex (default) or Claude (only when named).
+  Pass the user's request verbatim: the first word may name the executor, and
+  everything after it is the task.
+user_invocable: true
+---
+
+# Browser E2E
+
+Run an end-to-end browser flow in Chrome. Two executors, **one shared operation
+set** — whichever one runs, the same operations are available and the run behaves
+the same way for the user. There is no automatic switching between them.
+
+## Prerequisites
+
+**Chrome specifically.** Both executors drive Google Chrome. The system default
+browser on this machine is Dia, which neither path supports, so the browser is
+always named explicitly — never left to the default.
+
+| Path | Needs | Check |
+|------|-------|-------|
+| codex (default) | `codex` CLI on PATH; the bundled `chrome` plugin's extension **and** native host installed; Chrome running | Preflight step 2 below runs the four bundled diagnostics |
+| Claude (named) | The Claude in Chrome extension connected to this session | `tabs_context_mcp` returns a tab group instead of an error |
+
+> **Note**: no Chrome launch flag is required — neither path uses
+> `--remote-debugging-port`. Both reach Chrome through their vendor's own
+> extension + native-host channel, so they drive **your real Chrome profile**.
+> That is the reason most E2E runs start already logged in (see Preflight step 3).
+
+## Invocation
+
+Branch on the **first token of the argument**, not on availability:
+
+```
+/browser-e2e <task>            → codex   (default)
+/browser-e2e claude <task>     → Claude
+```
+
+| Executor | When | Settings | Path detail |
+|----------|------|----------|-------------|
+| **codex** | Always, unless the user typed `claude` | model `gpt-5.6-luna`, reasoning effort `xhigh` | `references/codex.md` |
+| **Claude** | Only when the user's argument starts with `claude` | this session's own `mcp__claude-in-chrome__*` tools | `references/claude.md` |
+
+The literal token `claude` is consumed as the executor name; the rest of the
+argument is the task, passed through verbatim. Any other first token is part of
+the task — do not guess at an executor from the task's wording.
+
+## No fallback
+
+**A failure is reported, not routed around.** If the chosen executor cannot run,
+or fails mid-flow, say which precondition or which step failed and stop. Do not
+re-run the task on the other executor, and do not offer to — the user picks the
+executor, and silently switching would report a result from a surface they did
+not choose.
+
+The shared operation set below exists for **consistency between the branches**,
+so the two behave identically for the user. It is not a fallback substrate, and
+nothing here should be read as making one path a stand-in for the other.
+
+## Preflight
+
+Run these four in order before the first operation of a flow.
+
+**1. Executor.** Parse it from the argument per *Invocation*. Default is codex.
+Do not re-ask when the user already typed one.
+
+**2. Surface.** Establish the executor's own tab surface.
+
+- **Claude** → call `tabs_context_mcp` with `createIfEmpty: true`. The session's
+  binding to its tab group expires on its own while the group and its tabs stay
+  on screen, so **finding no group here is the normal path, not an error path** —
+  create and continue without comment.
+- **codex** → `agent.browsers.get("chrome")`, explicitly by name. If that fails,
+  run the bundled diagnostics and **name which precondition is unmet** rather than
+  reporting a generic browser failure:
+
+  ```bash
+  D="$HOME/.codex/plugins/cache/openai-bundled/chrome/latest/scripts"
+  node "$D/installed-browsers.js" --check --json          # 1 = no browser installed
+  node "$D/chrome-is-running.js" --check --json           # 1 = Chrome not running
+  node "$D/check-extension-installed.js" --json           # 1 = installed, disabled; 2 = not installed
+  node "$D/check-native-host-manifest.js" --json          # 1 = manifest missing/incorrect
+  ```
+
+  Exit codes and the `--check` requirement are detailed in `references/codex.md`.
+  Two of the four exit `0` regardless unless `--check` is passed — pass it.
+
+**3. Target — a new tab is the default.** Open a new tab and navigate to the
+flow's entry URL. Do **not** attach to a tab the agent did not open. Chrome
+profile auth is inherited by a fresh tab, so most E2E runs start already logged
+in; a fresh navigation is therefore the cheaper and more reproducible start.
+
+Attach is the **exception path**, taken only when the flow needs in-tab state that
+a fresh navigation cannot reproduce — an unsubmitted form, a live WebSocket,
+in-memory SPA state, a one-time URL already consumed. Procedure for both
+vendors: `references/attach.md`.
+
+**4. Only if nothing works, ask the human.** Name the empty precondition, then
+identify the target **by a marker visible on screen** — the tab group's name as
+Chrome renders it, not an internal id.
+
+> Real incident: two tab groups named `Claude` and `✅Claude` were open at once,
+> and the tab was placed in the wrong one. The checkmark marked the active
+> session's group. When two groups could be confused, quote the exact on-screen
+> string, including any prefix character.
+
+This is a last resort. The skill discovers, creates, and tears down its own tab
+group — `chrome.nameSession(name)` on the codex side, `tabs_context_mcp` on the
+Claude side. Give the group a name distinctive enough to be a screen marker at
+step 4 before it is needed, and close what it opened when the flow ends.
+
+## The shared operation set
+
+Both executors reach every row below **by an agent call alone**. Same row, same
+outcome, whichever branch is running.
+
+| Operation | codex | Claude |
+|-----------|-------|--------|
+| claim / name the surface | `chrome.nameSession(name)` ᴹ | `tabs_context_mcp{createIfEmpty}` ᴹ |
+| open a tab | `chrome.tabs.new()` ᴹ | `tabs_create_mcp` ᴹ |
+| list this session's tabs | `chrome.tabs.list()` ᴹ | `tabs_context_mcp` ᴹ |
+| navigate | `tab.goto(url)` ᴹ | `navigate` ᴹ |
+| read page structure | `tab.playwright.domSnapshot()` ᴹ | `read_page` / `get_page_text` ᵁ |
+| locate an element | `tab.playwright.locator(sel)` ᴹ | `find` ᵁ |
+| click | `locator.click()` ᴹ | `computer` ᵁ |
+| type into a field | `locator.type()` ᴹ | `form_input` ᵁ |
+| scroll | `tab.dom_cua.scroll({x,y})` ᴹ | `computer` ᵁ |
+| screenshot | `tab.screenshot()` ᴹ | `computer` ᵁ |
+| read console | `tab.dev.logs({})` ᴹ | `read_console_messages` ᵁ |
+| close a tab | `tab.close()` ᴹ | `tabs_close_mcp` ᴹ |
+
+**ᴹ measured** — exercised and confirmed working, 2026-08-30.
+**ᵁ unmeasured** — present in the vendor's tool surface and described there, but
+the operation itself was not exercised. Treat a ᵁ cell as expected-to-work, and
+if it does not, report that rather than working around it (see *No fallback*).
+
+`chrome.nameSession()` is Chrome-specific and must be called **before** opening or
+claiming tabs on the codex side.
+
+### What counts as in the set
+
+> An operation is **in** the shared set when **both** vendors can reach it by an
+> agent call alone. If one vendor needs a human to complete it, it is **not** in
+> the set — it belongs in `references/`.
+
+Write this test down against every future addition. It is about reachability by
+the agent, not about how similar the two APIs look: two calls with different
+shapes belong in the same row when both land the same outcome unattended, and a
+capability one vendor exposes richly still stays out when the other vendor's
+route to it passes through a person.
+
+## Beyond the shared set
+
+Everything outside the table lives in `references/` — attempt it only when the
+situation allows, and on failure solve the task within the shared set instead:
+[`attach.md`](references/attach.md) (drive a tab the agent did not open, both
+vendors) · [`codex-privileged.md`](references/codex-privileged.md) (raw CDP,
+network response bodies) · [`claude-only.md`](references/claude-only.md)
+(`read_network_requests`, `gif_creator`).
+
+## Error handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| codex: `browsers.get("chrome")` fails | One of four preconditions unmet | Run the step-2 diagnostics with `--check --json` and name the failing one; do not switch executors |
+| codex: browser resolves to Dia or another app | Browser left to the system default | Always pass `"chrome"` explicitly — Dia is this machine's default and is unsupported |
+| codex: `cdp.send()` rejected | A saved per-origin permission denies it | Out of the shared set — `references/codex-privileged.md`; solve the step within the shared set instead |
+| Claude: no tab group found | The session-to-group binding expired while the group stayed on screen | Normal — `tabs_context_mcp{createIfEmpty: true}` and continue |
+| Claude: `Couldn't determine which page this action targets` | The tab is outside this session's group; a valid Chrome tabId from outside does not address it | The Claude session cannot reach it programmatically — `references/attach.md` |
+| Claude: the group vanished | Closing the group's last tab auto-removes the group | Expected — the next `tabs_context_mcp{createIfEmpty}` starts a fresh group |
+| Either: needed network response bodies | No shared-set operation covers response bodies | Vendor-specific and asymmetric — `references/claude-only.md` or `references/codex-privileged.md` |
+| Either: the flow's step genuinely failed | The page or the app under test | Report the failing step with its evidence. Do not retry on the other executor |
+
+## Unverified
+
+Carried openly so a later session can close them rather than inherit them as
+assumptions:
+
+- **The CDP permitted-command allowlist** (reported as 20 methods) has never been
+  measured. Detail and current blocker: `references/codex-privileged.md`.
+- **Claude-side `find`, `computer`, `read_console_messages`, `gif_creator`** are
+  known from their tool descriptions, not from a run. Marked ᵁ above.
+- **`tab.markHandoff()` lifetime across sessions** is unknown — whether a handoff
+  marked in one codex run is still meaningful to a later one has not been tested.
+  `references/codex.md`.

--- a/browser-e2e/skills/browser-e2e/SKILL.md
+++ b/browser-e2e/skills/browser-e2e/SKILL.md
@@ -28,19 +28,21 @@ machine state that changes underneath the skill.
 | codex (default) | `codex` CLI on PATH; the bundled `chrome` plugin's extension **and** native host installed; Chrome running; **plus a codex surface that actually exposes the chrome plugin — see below** | Preflight step 2 below runs the four bundled diagnostics |
 | Claude (named) | The Claude in Chrome extension connected to this session | `tabs_context_mcp` returns a tab group instead of an error |
 
-> **⛔ Open blocker on the default path.** Measured 2026-08-30 on codex-cli
-> 0.150.1: the CLI never loads the chrome plugin, so no `codex exec` run can reach
-> `agent.browsers.get("chrome")`. Root cause is upstream of the browser entirely —
-> `codex plugin marketplace list` registers only `openai-curated`, while the
-> plugin is `chrome@openai-bundled`, a marketplace the CLI does not know. The
-> `enabled = true` in `~/.codex/config.toml`, the populated cache directory, and
-> the `browser_use` feature flag all look like enablement and none of them
-> resolves the plugin.
+> **⚠️ Check which `codex` you are running, before anything else.** `codex` on
+> `PATH` may be a wrapper that redirects `CODEX_HOME` to a project-isolated home,
+> and an isolated home has no bundled marketplace — so the chrome plugin never
+> loads and no run gets a browser capability. Measured on this machine
+> 2026-08-30: that is exactly what `command -v codex` resolved to, and it cost
+> three probes before it was noticed.
 >
-> Confirmed three times, including once with a Chrome tab open by hand, so the
-> extension is not the blocker. The four diagnostics all pass while the browser
-> API stays out of reach: **a green preflight does not mean the path works.**
-> Full evidence and what remains unverified: `references/codex.md`.
+> ```bash
+> command -v codex                 # wrapper, or the real binary?
+> codex plugin marketplace list    # openai-bundled must appear
+> ```
+>
+> The four diagnostics pass under either home — they are shell `node` scripts, not
+> plugin tools — so **a green preflight does not prove the path works.** Details
+> and what this rules out: `references/codex.md`.
 
 > **Note**: no Chrome launch flag is required — neither path uses
 > `--remote-debugging-port`. Both reach Chrome through their vendor's own
@@ -154,11 +156,9 @@ outcome, whichever branch is running.
 the operation itself was not exercised. Treat a ᵁ cell as expected-to-work, and
 if it does not, report that rather than working around it (see *No fallback*).
 
-> **Read the ᴹ in the codex column narrowly.** Those operations were measured
-> through *some* codex surface whose identity could not be established, and the
-> CLI this skill documents cannot load the chrome plugin at all (blocker above).
-> They are evidence that the API exists somewhere — not that this skill's
-> invocation reaches it.
+The codex column's calls are JavaScript, evaluated through the
+**`mcp__node_repl__js`** tool. A prompt that names the operations but not the tool
+leaves the run to find the mechanism itself — name it.
 
 `chrome.nameSession()` is Chrome-specific and must be called **before** opening or
 claiming tabs on the codex side.
@@ -209,15 +209,12 @@ assumptions:
 - **`tab.markHandoff()` lifetime across sessions** is unknown — whether a handoff
   marked in one codex run is still meaningful to a later one has not been tested.
   `references/codex.md`.
-- **Which codex surface exposes the chrome plugin.** The blocker above. Two
-  specific unknowns: whether the Codex desktop app (`codex app`) exposes the
-  browser API, and whether registering the `openai-bundled` marketplace would make
-  the CLI load it. The second writes to the user's codex config, so it is not the
-  skill's to try unasked.
-- **The provenance of the codex column's measurements.** The operations were
-  recorded as measured on a surface nobody has since been able to name; the
-  session originally credited with them has stated it made no codex measurement.
-  Not "probably fine" — unverified as to where it came from, and marked so.
+- **The provenance of the codex column's original measurements.** They were handed
+  over as measured, but on a surface nobody has since been able to name; the
+  session first credited with them has stated it made none. The operations are
+  being re-measured under a known `CODEX_HOME` — until that lands, read the codex
+  column's ᴹ as unverified-provenance, which is a distinct state from unmeasured
+  and from confirmed.
 
 ### What a dogfood run already found
 
@@ -233,3 +230,10 @@ of the *writing*, not of the design:
   The real finding — "the browser API is not exposed in this session" — appeared
   once in its working notes and never reached its report. When a delegated run
   names a cause, check its trace against it.
+
+A third lesson came from the investigation rather than the run. Three probes each
+returned "no browser capability," and that was counted as three confirmations; it
+was one fault reproduced three times, because every probe went through the same
+`PATH` wrapper. Varying the working directory and the browser state varied nothing
+that mattered — both sit below the wrapper. **Repetition is not independence**, and
+one `command -v codex` would have said more than all three.

--- a/browser-e2e/skills/browser-e2e/SKILL.md
+++ b/browser-e2e/skills/browser-e2e/SKILL.md
@@ -19,14 +19,22 @@ the same way for the user. There is no automatic switching between them.
 
 ## Prerequisites
 
-**Chrome specifically.** Both executors drive Google Chrome. The system default
-browser on this machine is Dia, which neither path supports, so the browser is
-always named explicitly — never left to the default.
+**Chrome specifically.** Both executors drive Google Chrome, and the browser is
+always named explicitly rather than left to the system default — a default is
+machine state that changes underneath the skill.
 
 | Path | Needs | Check |
 |------|-------|-------|
-| codex (default) | `codex` CLI on PATH; the bundled `chrome` plugin's extension **and** native host installed; Chrome running | Preflight step 2 below runs the four bundled diagnostics |
+| codex (default) | `codex` CLI on PATH; the bundled `chrome` plugin's extension **and** native host installed; Chrome running; **plus a codex surface that actually exposes the chrome plugin — see below** | Preflight step 2 below runs the four bundled diagnostics |
 | Claude (named) | The Claude in Chrome extension connected to this session | `tabs_context_mcp` returns a tab group instead of an error |
+
+> **⛔ Open blocker on the default path.** Measured 2026-08-30 on codex-cli
+> 0.150.1: a `codex exec` run's tool inventory contains **no** chrome plugin and
+> no JS REPL to reach `agent.browsers.get("chrome")` — confirmed from two working
+> directories, and true even with `[plugins."chrome@openai-bundled"] enabled =
+> true` in `~/.codex/config.toml`. The four diagnostics all pass while the browser
+> API stays out of reach, so **a green preflight does not mean the path works**.
+> Which codex surface reaches the browser is unsettled: `references/codex.md`.
 
 > **Note**: no Chrome launch flag is required — neither path uses
 > `--remote-debugging-port`. Both reach Chrome through their vendor's own
@@ -189,3 +197,22 @@ assumptions:
 - **`tab.markHandoff()` lifetime across sessions** is unknown — whether a handoff
   marked in one codex run is still meaningful to a later one has not been tested.
   `references/codex.md`.
+- **Which codex surface exposes the chrome plugin.** The blocker above. The
+  operations in the codex column were measured through *some* surface but not
+  through `codex exec`, so every ᴹ in that column is evidence about the API, not
+  about the invocation this skill documents.
+
+### What a dogfood run already found
+
+An acceptance run on 2026-08-30 (gpt-5.6-luna at xhigh, handed this skill and
+`references/codex.md`) reached none of the shared-set operations. Two defects it
+exposed are fixed in the files rather than left as notes, and both were failures
+of the *writing*, not of the design:
+
+- Handed the whole of `references/codex.md`, the codex run read its *Invoking*
+  section as addressed to itself and re-invoked `codex exec`, nesting a second
+  codex inside the first. That file now states which reader each section is for.
+- The run then reported the nested process's crash as the browser path's failure.
+  The real finding — "the browser API is not exposed in this session" — appeared
+  once in its working notes and never reached its report. When a delegated run
+  names a cause, check its trace against it.

--- a/browser-e2e/skills/browser-e2e/SKILL.md
+++ b/browser-e2e/skills/browser-e2e/SKILL.md
@@ -145,8 +145,8 @@ outcome, whichever branch is running.
 | read page structure | `tab.playwright.domSnapshot()` ᴹ | `read_page` / `get_page_text` ᵁ |
 | locate an element | `tab.playwright.locator(sel)` ᴹ | `find` ᵁ |
 | click | `locator.click()` ᴹ | `computer` ᵁ |
-| type into a field | `locator.type()` ᴹ | `form_input` ᵁ |
-| scroll | `tab.dom_cua.scroll({x,y})` ᴹ | `computer` ᵁ |
+| type into a field | `locator.type()` ᴹ⚠ | `form_input` ᵁ |
+| scroll | `tab.dom_cua.scroll({x,y})` ⚠✗ | `computer` ᵁ |
 | screenshot | `tab.screenshot()` ᴹ | `computer` ᵁ |
 | read console | `tab.dev.logs({})` ᴹ | `read_console_messages` ᵁ |
 | close a tab | `tab.close()` ᴹ | `tabs_close_mcp` ᴹ |
@@ -155,10 +155,23 @@ outcome, whichever branch is running.
 **ᵁ unmeasured** — present in the vendor's tool surface and described there, but
 the operation itself was not exercised. Treat a ᵁ cell as expected-to-work, and
 if it does not, report that rather than working around it (see *No fallback*).
+**⚠ works, with a documented hazard.** **✗ measured NOT working.**
+
+Two rows carry a mark that the whole codex column had before it was exercised:
+
+- **`type()` ⚠** — typing right after `goto()` fails with `Detached while handling
+  command`. A wait alone does not fix it; the locator must be rebuilt after the
+  navigation. Procedure: `references/codex.md`.
+- **`scroll()` ✗** — returns the success shape while `scrollY` stays `0` and the
+  page does not move. **A flow that scrolls then asserts will read a stale page as
+  a real one.** Verify by reading `scrollY` back. Whether this row survives in the
+  shared set is pending one re-test on a plain long document.
 
 The codex column's calls are JavaScript, evaluated through the
-**`mcp__node_repl__js`** tool. A prompt that names the operations but not the tool
-leaves the run to find the mechanism itself — name it.
+**`mcp__node_repl__js`** tool — and `agent` does not exist there until the
+plugin's `browser-client.mjs` is imported and `setupBrowserRuntime()` is called.
+Every call is async. Name the tool and the bootstrap when delegating; a run given
+the operations alone has to rediscover both.
 
 `chrome.nameSession()` is Chrome-specific and must be called **before** opening or
 claiming tabs on the codex side.
@@ -209,12 +222,14 @@ assumptions:
 - **`tab.markHandoff()` lifetime across sessions** is unknown — whether a handoff
   marked in one codex run is still meaningful to a later one has not been tested.
   `references/codex.md`.
-- **The provenance of the codex column's original measurements.** They were handed
-  over as measured, but on a surface nobody has since been able to name; the
-  session first credited with them has stated it made none. The operations are
-  being re-measured under a known `CODEX_HOME` — until that lands, read the codex
-  column's ᴹ as unverified-provenance, which is a distinct state from unmeasured
-  and from confirmed.
+- **Whether the `scroll()` row belongs in the shared set.** It failed silently in
+  the run above; one re-test on a plain long document decides it.
+- **`claimTab()`** stays unmeasured on purpose — exercising it takes over a tab the
+  user is browsing.
+
+The codex column's provenance question is closed: the operations were re-measured
+end to end on 2026-08-30 under an explicit `CODEX_HOME`, so the ᴹ marks now rest
+on this repository's own run rather than on a handoff nobody could source.
 
 ### What a dogfood run already found
 

--- a/browser-e2e/skills/browser-e2e/references/attach.md
+++ b/browser-e2e/skills/browser-e2e/references/attach.md
@@ -1,0 +1,90 @@
+# Attach — the exception path
+
+Driving a tab the agent did not open. Both vendors, and they differ in kind: on
+codex it is an agent call, on Claude it needs a person. That asymmetry is why
+attach is outside the shared operation set — the membership test in SKILL.md
+fails on exactly this shape.
+
+## When it is warranted
+
+The default is a new tab plus a navigation. Chrome profile auth is inherited by a
+fresh tab (measured: a new tab in a new group loaded `github.com` already logged
+in), so **"the flow needs me to be logged in" is not a reason to attach** — that
+was the old reason, and it no longer holds.
+
+Attach only when the flow needs **in-tab state a fresh navigation cannot
+reproduce**:
+
+- an unsubmitted form the user has already filled
+- a live WebSocket or SSE stream mid-conversation
+- in-memory SPA state with no URL that restores it (a multi-step wizard past
+  step 1, an unsaved editor buffer)
+- a one-time URL already consumed — a magic link, a single-use OAuth callback
+- a page whose current render depends on a POST that cannot be replayed
+
+If the entry state can be reached by navigating to a URL, navigate. Attach costs
+a human on one of the two paths and inherits state nobody can fully describe; a
+fresh tab costs neither.
+
+## codex — an agent call
+
+Measured end to end, 2026-08-30.
+
+```js
+const chrome = agent.browsers.get("chrome");
+chrome.nameSession("browser-e2e ✅");        // before claiming, as before opening
+
+const tabs = chrome.user.openTabs();
+// -> [{ id, lastOpened, providerTabId, tabGroup, title, url }]
+
+const entry = tabs.find(t => /* match on url or title */);
+chrome.user.claimTab(entry);
+```
+
+`chrome.user.claimTab(entry)` works on a tab this session did not create — that is
+the verified capability, and it is codex-only.
+
+Pick the entry by `url` first and `title` second. `lastOpened` orders the list but
+does not identify anything; two tabs on the same app differ by URL, not recency.
+When more than one entry matches, **do not pick one** — which tab to take over is
+a user-private choice, and taking the wrong one acts on state the user did not
+offer. List the candidates by title and URL and let the user pick.
+
+Claiming makes the tab this session's. Teardown is a judgment: a tab the run
+created is the run's to close, and a tab it claimed from the user is not — leave
+it open unless the user said otherwise.
+
+## Claude — needs a human, so it is not attach
+
+The session is bound to one tab group and cannot enumerate or address anything
+outside it; a valid Chrome tabId from outside returns `Couldn't determine which
+page this action targets`. There is no agent call that pulls an external tab in.
+
+The only route is a person dragging the tab into the session's group. That makes
+this the last-resort ask from SKILL.md preflight step 4, and it carries that
+step's requirement:
+
+- Name the empty precondition first — *the tab holding the state is outside this
+  session's group, and this path has no call that reaches it.*
+- Identify the destination **by its on-screen name**, quoted exactly, including
+  any prefix character. Two groups named `Claude` and `✅Claude` once coexisted
+  and the tab went into the wrong one; the checkmark marked the active session's
+  group.
+- After the move, `tabs_context_mcp` to confirm the tab is now listed. If it is
+  not, the tab went into a different group — say which group was meant rather
+  than repeating the same request.
+
+Before asking, check whether the state is really irreproducible. A human step is
+the most expensive thing this skill can spend, and the list above narrows the
+cases that justify it.
+
+## If attach fails
+
+Attach is outside the shared set, so its failure follows the progressive-
+disclosure rule rather than the fallback rule: **solve the task within the shared
+set instead.** In practice that means restarting the flow from a fresh tab and a
+navigation, and reporting which part of the original in-tab state could not be
+reproduced.
+
+That is not a vendor fallback and does not license switching executors. The
+executor stays as the user named it; only the target changes.

--- a/browser-e2e/skills/browser-e2e/references/claude-only.md
+++ b/browser-e2e/skills/browser-e2e/references/claude-only.md
@@ -1,0 +1,52 @@
+# Claude-only: network reading and GIF recording
+
+Outside the shared operation set — codex has no equivalent for either. Attempt
+only when the situation allows; on failure, solve the step within the shared set
+(SKILL.md).
+
+Both are **unmeasured**: known from their tool descriptions in this session's
+surface, not from a run on 2026-08-30.
+
+## `read_network_requests`
+
+The asymmetry is total rather than a matter of degree. codex's `dev` namespace
+contains `logs()` and nothing else (measured) — no request list at all, and
+response bodies there need raw CDP, which is currently blocked
+(`codex-privileged.md`). On the Claude path the capability is a plain tool call.
+
+Reach for it when the flow's assertion is genuinely about the request: a status
+code the page never renders, a payload shape, a call that should *not* have
+fired.
+
+When it fails or returns nothing useful, fall back **inside the shared set**, not
+to the other executor:
+
+- assert on what the page rendered (`read_page` / `get_page_text`) — for an E2E
+  flow this is usually the better assertion anyway, since it is what the user sees
+- assert on `read_console_messages`, when the app logs its own request outcomes
+
+## `gif_creator`
+
+Records a multi-step interaction as a GIF. Claude-only; there is no codex
+equivalent, and no shared-set substitute — the closest is a sequence of
+screenshots, which is a different artifact.
+
+Use it when the user wants to **review or share** the run rather than just read
+its verdict — a reproduction to attach to a bug report, a demo of a flow.
+
+When recording:
+
+- capture extra frames before and after each action, so playback is legible
+  rather than a jump cut between states
+- name the file for what it shows (`checkout_flow_failure.gif`), not for the run
+
+## Reporting
+
+Both tools sit outside the shared set, so a run that used either **did not behave
+identically to the codex branch**. Say so in the result: name which step used a
+Claude-only capability, so the user knows that step would need a different
+approach if the same flow is later run on the default executor.
+
+The reverse also holds and is the more common trap: never quietly switch a run to
+the Claude executor in order to reach these. The user picks the executor, and
+reaching a capability is not a reason to override that (SKILL.md, *No fallback*).

--- a/browser-e2e/skills/browser-e2e/references/claude.md
+++ b/browser-e2e/skills/browser-e2e/references/claude.md
@@ -1,0 +1,93 @@
+# Claude executor — the named path
+
+Taken **only** when the user's argument starts with the literal token `claude`.
+It is never selected because the codex path was unavailable (SKILL.md, *No
+fallback*).
+
+## What runs
+
+This session's own `mcp__claude-in-chrome__*` tools, in this conversation — there
+is no subprocess and no separate model. Reasoning tier is this session's, which is
+why the branch is named rather than defaulted: it costs the main context directly.
+
+If those tools are deferred, load them in **one** `ToolSearch` call rather than
+one per tool:
+
+```
+select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__tabs_create_mcp,mcp__claude-in-chrome__tabs_close_mcp,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__read_page,mcp__claude-in-chrome__find,mcp__claude-in-chrome__computer,mcp__claude-in-chrome__form_input,mcp__claude-in-chrome__read_console_messages
+```
+
+That set covers the whole shared operation set. Add `read_network_requests` or
+`gif_creator` to the same call only when the flow already calls for them
+(`claude-only.md`).
+
+## The tab group is the whole world
+
+The session is bound to **one** tab group, which it owns. It cannot enumerate or
+address anything outside that group: a valid Chrome tabId from outside returns
+`Couldn't determine which page this action targets`. This is the structural fact
+that shapes every other behaviour on this path.
+
+Three consequences, all measured 2026-08-30:
+
+1. **A missing group at start is normal.** The session-to-group binding expires on
+   its own while the group and its tabs remain visible on screen. Checking for a
+   group and finding none is the ordinary opening move, not a fault to report —
+   `tabs_context_mcp{createIfEmpty: true}` and continue silently.
+2. **Closing the group's last tab removes the group.** The next
+   `tabs_context_mcp{createIfEmpty: true}` starts a fresh one. Teardown therefore
+   needs no separate group-deletion step.
+3. **Attach needs a human.** There is no programmatic route to a tab outside the
+   group, so putting one in requires a person to move it. That is why attach is
+   out of the shared set on this side — `attach.md`.
+
+## Profile auth is inherited
+
+**Measured**: a *new* tab in a *new* group loaded `github.com` already logged in
+(`loggedIn: true`, `signInLinkVisible: false`). No attach, no cookie transfer, no
+launch flag — the extension drives the real Chrome profile.
+
+This is the evidence behind the default target in SKILL.md preflight step 3. Open
+a new tab and navigate; reach for attach only when the flow needs in-tab state a
+fresh navigation cannot reproduce.
+
+## Operations
+
+| Shared-set operation | Tool | Evidence |
+|----------------------|------|----------|
+| claim / name the surface | `tabs_context_mcp{createIfEmpty: true}` | measured |
+| open a tab | `tabs_create_mcp` | measured |
+| list this session's tabs | `tabs_context_mcp` | measured |
+| navigate | `navigate` | measured |
+| read page structure | `read_page` / `get_page_text` | unmeasured |
+| locate an element | `find` | unmeasured |
+| click, scroll, screenshot | `computer` | unmeasured |
+| type into a field | `form_input` | unmeasured |
+| read console | `read_console_messages` | unmeasured |
+| close a tab | `tabs_close_mcp` | measured |
+
+**Unmeasured** means the tool is present in this session's surface and described
+there, but the operation was not exercised on 2026-08-30. It is expected to work;
+if it does not, report that rather than routing around it.
+
+Also present on this path but outside the shared set: `javascript_tool`,
+`browser_batch`, `resize_window`, `file_upload`, `upload_image`,
+`read_network_requests`, `gif_creator`. The last two are covered in
+`claude-only.md`; the rest are unmeasured and undocumented here — reach for one
+only when the flow already needs it, and say so when reporting the run.
+
+## Do not open a dialog
+
+`alert` / `confirm` / `prompt` and browser modals block every subsequent event, so
+a triggered dialog ends the run's ability to act at all and needs a human to
+dismiss it in Chrome. In an E2E flow this matters most at destructive controls —
+a Delete button behind a confirm. When the flow's own steps require crossing one,
+say so before acting rather than discovering it mid-run.
+
+## Naming the group for the human ask
+
+The group's on-screen name is the only marker a person can act on at preflight
+step 4. A real incident: two groups named `Claude` and `✅Claude` were open at
+once and the tab went into the wrong one — the checkmark marked the active
+session's group. When asking, quote the exact on-screen string including any
+prefix character, and say which of the visible groups is meant.

--- a/browser-e2e/skills/browser-e2e/references/codex-privileged.md
+++ b/browser-e2e/skills/browser-e2e/references/codex-privileged.md
@@ -1,0 +1,65 @@
+# codex-only: raw CDP and network response bodies
+
+Outside the shared operation set — Claude has no equivalent. Attempt only when the
+situation allows; on failure, solve the step within the shared set (SKILL.md).
+
+**Currently blocked.** Read this before spending a run on it.
+
+## Why this path exists at all
+
+The codex path has **no high-level network API**. `api.json`'s `dev` namespace
+contains `logs()` and nothing else (measured) — no request list, no response
+bodies, no timing. Anything network-shaped on this path has to come from raw CDP.
+
+The Claude path has `read_network_requests` instead and does not need this
+(`claude-only.md`). The two vendors solve the same need on opposite mechanisms,
+which is precisely why neither is in the shared set.
+
+## The capability and the block
+
+```js
+tab.capabilities.get("cdp");   // acquirable — measured
+cdp.send(/* … */);             // every call blocked — measured
+```
+
+The capability is acquirable. Every `cdp.send()` is then rejected by a **saved
+per-origin permission** — a stored decision, not a live prompt, so nothing appears
+on screen to approve and retrying changes nothing.
+
+Local config at `~/.codex/browser/config.toml` reads
+`approval_mode = "never_ask"` with `full_cdp_access_enabled = true`. Those settings
+did **not** unblock the calls in the measurement, so the saved per-origin
+permission takes precedence over both. Whether clearing that saved permission
+would unblock it, and where it is stored, is **unmeasured**.
+
+## Unverified: the permitted-command allowlist
+
+CDP access on this path is reported to be limited to an allowlist of **20
+methods**. That allowlist has **never been measured** — its membership, and
+whether it would even apply once the per-origin block is cleared, are both open.
+
+Do not plan a flow around a specific CDP method being permitted. Two things would
+have to hold, and neither has been shown:
+
+1. the saved per-origin permission no longer denies `cdp.send()`, and
+2. the method is on the allowlist.
+
+Closing this needs one deliberate measurement session against a disposable origin,
+not an opportunistic attempt in the middle of someone's E2E run. **Do not measure
+it as a side effect of a task run** — it touches a saved permission that governs
+the user's real profile.
+
+## If a flow needs response bodies
+
+The honest options, in order:
+
+1. **Read it off the page instead.** If the response is rendered, `domSnapshot()`
+   or `get_page_text` reaches the same information inside the shared set. An E2E
+   assertion is usually about what the user sees, and the rendered value is the
+   better assertion anyway.
+2. **Assert on console.** `tab.dev.logs({})` is in the shared set; an app that
+   logs its own request outcomes exposes them there.
+3. **Report the gap.** If the flow genuinely needs a body the page never renders,
+   say that this path cannot reach it and name why. Do not switch to the Claude
+   executor to get `read_network_requests` — that is the fallback the design
+   rules out, and the user chose the executor.

--- a/browser-e2e/skills/browser-e2e/references/codex.md
+++ b/browser-e2e/skills/browser-e2e/references/codex.md
@@ -125,9 +125,23 @@ are evaluated through; without it, it does not.
 
 ## The browser handle
 
+**Bootstrap first — `agent` does not exist yet.** A fresh `mcp__node_repl__js`
+environment exposes only `nodeRepl`; evaluating `agent.browsers…` straight away
+raises `ReferenceError: agent is not defined` (measured 2026-08-30). Import the
+plugin's browser client and call `setupBrowserRuntime()` before anything else.
+The client lives beside the diagnostics:
+
+```
+$HOME/.codex/plugins/cache/openai-bundled/chrome/latest/scripts/browser-client.mjs
+```
+
+**Everything is async.** `browsers.get()` and every tab method return Promises.
+The snippets below elide `await` for readability — a real run needs it on each
+call, and a dropped `await` surfaces later as an unrelated-looking failure.
+
 ```js
-const chrome = agent.browsers.get("chrome");   // explicit, always
-chrome.nameSession("browser-e2e ✅");           // BEFORE opening or claiming tabs
+const chrome = await agent.browsers.get("chrome");   // explicit, always
+await chrome.nameSession("browser-e2e ✅");           // BEFORE opening or claiming tabs
 ```
 
 Naming the browser explicitly is not optional bookkeeping — the default is machine
@@ -152,27 +166,86 @@ distinct from any group already open.
 
 ## Operations
 
-Shared-set operations, all measured 2026-08-30:
+Exercised end to end 2026-08-30 under a known `CODEX_HOME`. `await` elided.
 
 ```js
 const tab = chrome.tabs.new();          // default target: a new tab
-chrome.tabs.list();                     // this session's tabs
+chrome.tabs.list();                     // this session's tabs only — verified
 tab.goto(url);
 
-tab.playwright.domSnapshot();           // page structure
+tab.playwright.domSnapshot();           // -> string
 const el = tab.playwright.locator(sel);
-el.click();
-el.type(text);
-
-tab.dom_cua.scroll({ x, y });
-tab.screenshot();
-tab.dev.logs({});                       // console
-tab.close();                            // tear down what the run opened
+el.click();                             // -> undefined
+el.type(text);                          // -> undefined; see the detachment race
+tab.screenshot();                       // -> Uint8Array of PNG bytes
+tab.dev.logs({});                       // -> [{ level, message, timestamp, url }]
+tab.close();                            // -> undefined
 ```
 
-`tab.dev.logs({})` is the **only** member of the `dev` namespace. There is no
-high-level network API on this path at all — `api.json`'s `dev` namespace contains
-`logs()` and nothing else. Response bodies require raw CDP: `codex-privileged.md`.
+### Return shapes
+
+Most calls return `undefined` and are used for effect — `nameSession`, `click`,
+`type`, `markDeliverable`, `markHandoff`, `close`. Do not test them for success;
+verify the effect instead (read the page back, list the tabs).
+
+The three that return data:
+
+| Call | Returns | Observed |
+|---|---|---|
+| `domSnapshot()` | string | 232 chars / 5 lines for `example.com` — compact, not a DOM dump |
+| `screenshot()` | `Uint8Array` | 14,206 bytes of PNG — **bytes, not a path or handle**; write them yourself if a file is wanted |
+| `dev.logs({})` | array of objects | `{ level, message, timestamp, url }`; captured a live page `TypeError` |
+
+### ⚠️ The detachment race — the gap a real flow hits first
+
+**Measured.** Typing into a field immediately after `goto()` fails with
+`Detached while handling command`. The locator resolved against the pre-navigation
+document and the navigation invalidated it.
+
+`waitForLoadState({ state: "load" })` does **not** prevent it. And `networkidle`
+is not available at all:
+
+```
+playwright_wait_for_load_state does not support networkidle
+```
+
+What worked: `waitForTimeout(500)`, then build a **fresh** locator. Re-using the
+old one after the wait still fails — the wait alone is not the fix; re-targeting
+is.
+
+```js
+tab.goto(url);
+tab.playwright.waitForTimeout(500);
+tab.playwright.locator("#username").type("…");   // fresh locator, after the wait
+```
+
+Treat every navigation as invalidating every locator held across it. `click()`
+that triggers navigation is the same hazard for whatever comes next.
+
+### ⚠️ `dom_cua.scroll()` did not scroll
+
+**Measured, and this one is a defect rather than a caveat.**
+`tab.dom_cua.scroll({x, y})` returned `undefined` — the success shape — while
+`scrollY` stayed `0`, and screenshots and snapshots were unchanged. Both positive
+and negative values were tried. The runtime's own reference describes the
+arguments as deltas.
+
+Because the call reports success, **a flow that scrolls and then asserts will read
+a stale page as a real one.** Until this is understood, verify any scroll by
+reading `scrollY` back rather than trusting the return.
+
+Whether the scroll row survives in the shared operation set depends on one more
+measurement — this run used
+`the-internet.herokuapp.com/infinite_scroll`, whose own JS may interact with it.
+Re-test on a plain long document before deciding. The row stays in SKILL.md's
+table for now, flagged there.
+
+### The `dev` namespace
+
+`tab.dev.logs({})` is the **only** member — confirmed by enumeration: `tab.dev`
+has no enumerable own members, and its prototype exposes `logs` and `constructor`
+and nothing else. There is no high-level network API on this path. Response
+bodies require raw CDP: `codex-privileged.md`.
 
 ### Enumerating and claiming beyond this session
 
@@ -181,8 +254,14 @@ chrome.user.openTabs();      // -> [{ id, lastOpened, providerTabId, tabGroup, t
 chrome.user.claimTab(entry); // attach; works on a tab this session did not create
 ```
 
-Both measured. `claimTab` is the codex-only attach route and is an **exception
-path**, not a default — `attach.md` states when it is warranted.
+`openTabs()` is **confirmed**: 11 entries on a live profile, fields exactly
+`id`, `lastOpened`, `providerTabId`, `tabGroup`, `title`, `url` — no more, no
+fewer. Note the contrast with `chrome.tabs.list()`, which returned only the
+session's own single tab: `list()` is session-scoped, `openTabs()` is not.
+
+`claimTab` remains **unmeasured** — deliberately not exercised, since claiming
+takes over a tab the user is browsing. It is the codex-only attach route and an
+**exception path**, not a default — `attach.md` states when it is warranted.
 
 ### Deliverable and handoff markers
 
@@ -191,11 +270,23 @@ tab.markDeliverable();
 tab.markHandoff();
 ```
 
-Both measured as calls. **Unverified**: `markHandoff()`'s lifetime across
-sessions — whether a handoff marked in one codex run remains meaningful to a
-later run, or is scoped to the session that set it, has not been tested. Do not
-build a multi-run flow that depends on a handoff surviving; if a later run needs
-the same tab, re-establish it through `openTabs()` / `claimTab()`.
+Both return `undefined` in 1–2 ms and produced **no observable effect** within the
+session — the tab listing did not change, and nothing visible marked the tab
+(measured). So a single session cannot tell a working marker from a no-op.
+
+**Unverified**: `markHandoff()`'s lifetime across sessions — whether a handoff
+marked in one codex run remains meaningful to a later run, or is scoped to the
+session that set it. The in-session silence above makes this harder to close, not
+easier: there is no local signal to check against. Do not build a multi-run flow
+that depends on a handoff surviving; if a later run needs the same tab,
+re-establish it through `openTabs()` / `claimTab()`.
+
+### Teardown
+
+`tab.close()` returned in ~42 ms, after which `chrome.tabs.list()` returned an
+empty array. **The API cannot distinguish a removed tab group from an empty one**
+— both read as `[]`. If a flow needs to know which happened, it needs a signal
+from outside this API.
 
 ## Diagnostics
 

--- a/browser-e2e/skills/browser-e2e/references/codex.md
+++ b/browser-e2e/skills/browser-e2e/references/codex.md
@@ -4,6 +4,48 @@ How a `/browser-e2e <task>` run reaches Chrome. Everything here is the **default
 branch; the Claude branch is `claude.md`, and neither substitutes for the other
 (SKILL.md, *No fallback*).
 
+## ⚠️ Two readers, and they must not swap roles
+
+This file is read by both sides of the delegation, and they need different parts.
+Check which one you are before acting on anything here.
+
+| If you are… | Read | Do **not** act on |
+|---|---|---|
+| **the orchestrator** (Claude Code, holding the user's `/browser-e2e` request) | *Settings*, *Invoking*, *Diagnostics* | — |
+| **the codex run itself** (already inside codex, given this file) | everything **except** *Invoking* | *Invoking* — you are already the run |
+
+**Measured 2026-08-30**: handed this whole file, a codex run read *Invoking* as an
+instruction addressed to itself and executed `codex exec` **again**, nesting a
+second codex inside the first. The nested process died at
+`failed to initialize in-process app-server client: Operation not permitted`, and
+the run then reported that error as the browser path's failure — which it was not.
+Do not remove this table.
+
+## ⛔ Blocker: `codex exec` does not expose the chrome plugin
+
+**Measured 2026-08-30, codex-cli 0.150.1.** A `codex exec` run's tool inventory
+contains no chrome plugin, no browser plugin, and no JS/Node REPL through which
+`agent.browsers.get("chrome")` could be evaluated. Confirmed twice, from the
+worktree and from the trust-listed parent repository, so it is neither a
+`trust_level` nor a sandbox effect. `codex exec --help` offers no flag that
+enables a plugin for the run.
+
+This holds **even though** `~/.codex/config.toml` carries
+`[plugins."chrome@openai-bundled"]` with `enabled = true`. Config enablement and
+exec-surface exposure are separate things.
+
+Everything in *Operations* below was measured through some codex surface, but
+**not through `codex exec`** — the invocation in *Invoking* is therefore
+unconfirmed as a route to the browser API, and the operations are recorded here as
+what that other surface showed. Which surface reaches them (the interactive
+`codex` TUI, the Codex desktop app — `config.toml` carries
+`BROWSER_USE_CODEX_APP_VERSION` and a `codex-app-tools@openai-bundled` plugin — or
+an exec configuration not yet found) is **open**, and is the one thing this path
+needs settled before it can be the default in practice.
+
+The four *Diagnostics* below are unaffected: they are plain `node` scripts and ran
+correctly from inside `codex exec`.
+
 ## Settings
 
 | Setting | Value | Why fixed |
@@ -14,9 +56,17 @@ branch; the Claude branch is `claude.md`, and neither substitutes for the other
 
 ## Invoking
 
-Write the task to a prompt file, then hand it to `codex exec`. Delegate the run to
-a Bash subagent so codex's banner and step-by-step output stay out of this
-conversation — only the outcome comes back.
+> **Orchestrator only.** If you are the codex run reading this file, skip this
+> section entirely — see the two-readers table above. Acting on it nests a second
+> codex inside yourself, which has been measured to fail.
+
+> **Unconfirmed as a route to the browser API** — see the blocker above. The flags
+> below are the correct codex invocation and the run starts cleanly; what has not
+> been shown is that the resulting run can reach Chrome.
+
+Write the task to a prompt file, then hand it to `codex exec`. Run it in the
+background with output redirected to a file so codex's banner and step-by-step
+output stay out of this conversation — only the outcome comes back.
 
 ```bash
 codex exec --skip-git-repo-check \
@@ -34,10 +84,11 @@ an E2E run needs a follow-up turn against browser state it already established.
 Read `$OUT` for codex's final message rather than relying on the subagent's
 summary; an E2E verdict is exactly the part a summary flattens.
 
-> **Unverified**: the measured operations below were confirmed working headless
-> through `codex exec`, but the sandbox mode in force during that measurement was
-> not recorded. The settings above follow the repo's codex default rather than a
-> measured requirement for browser control specifically.
+**Measured 2026-08-30**: this exact invocation starts a run cleanly under
+`gpt-5.6-luna` / `xhigh` / `workspace-write` with network — the banner reports all
+three back, `--output-last-message` captures the final message, and the
+`session id: <uuid>` line appears on stderr as described. What the run does *not*
+get is the browser API (see the blocker above).
 
 ## The browser handle
 
@@ -46,9 +97,19 @@ const chrome = agent.browsers.get("chrome");   // explicit, always
 chrome.nameSession("browser-e2e ✅");           // BEFORE opening or claiming tabs
 ```
 
-Naming the browser explicitly is not optional bookkeeping. This machine's system
-default browser is Dia, which the plugin does not support, so a `browsers.get()`
-that relies on the default resolves to an unsupported app.
+Naming the browser explicitly is not optional bookkeeping — the default is machine
+state that changes underneath the skill, and the plugin supports Chrome.
+
+An earlier note here claimed the system default was Dia. **That is not what the
+machine reports.** `installed-browsers.js --check --json`, run 2026-08-30, gives
+`default_browser` as `com.google.chrome` for both `http` and `https`, and lists
+exactly one installed browser: Google Chrome 151.0.7922.174. Dia does not appear
+in the inventory at all.
+
+The instruction stands and the old reason for it does not. Keep naming `"chrome"`
+because a default is not a guarantee, not because of what the default happens to
+be today — and if `browsers.get()` ever does resolve to something unexpected, read
+the inventory rather than trusting either claim.
 
 `chrome.nameSession(name)` is Chrome-specific and must be called before the
 session opens or claims tabs. The name it sets is what Chrome renders on the tab
@@ -121,6 +182,15 @@ D="$HOME/.codex/plugins/cache/openai-bundled/chrome/latest/scripts"
 
 Exit-code semantics read off the installed scripts (`latest` is a floating version
 directory, so re-read them if a codex upgrade changes behaviour).
+
+**Measured 2026-08-30**: all four ran from inside a `codex exec` run, accepted the
+flags exactly as documented, and exited `0` on a healthy machine — Chrome
+installed (151.0.7922.174) and running, extension installed and enabled in the
+Default profile, native-host manifest correct. Their `--json` output is a full
+object, not a status line, so quote the field that decides rather than the whole
+blob. **Negative exit codes remain unmeasured**: no precondition was deliberately
+broken, so the `1` / `2` / `3` rows above are still read-off-the-source, not
+observed.
 
 **Pass `--check`.** The first two scripts report their finding on stdout but exit
 `0` regardless without it — a run that branches on the exit code alone would read

--- a/browser-e2e/skills/browser-e2e/references/codex.md
+++ b/browser-e2e/skills/browser-e2e/references/codex.md
@@ -1,0 +1,136 @@
+# codex executor — the default path
+
+How a `/browser-e2e <task>` run reaches Chrome. Everything here is the **default**
+branch; the Claude branch is `claude.md`, and neither substitutes for the other
+(SKILL.md, *No fallback*).
+
+## Settings
+
+| Setting | Value | Why fixed |
+|---------|-------|-----------|
+| model | `gpt-5.6-luna` | codex's own registry describes it as a fast, affordable agentic coding model; it is the cost-efficient pick for browser / computer-use runs |
+| reasoning effort | `xhigh` | an E2E flow is a long sequence of stateful steps where a single misread page costs the whole run |
+| sandbox | `workspace-write` with network access | the default; read-only has no network at all in codex |
+
+## Invoking
+
+Write the task to a prompt file, then hand it to `codex exec`. Delegate the run to
+a Bash subagent so codex's banner and step-by-step output stay out of this
+conversation — only the outcome comes back.
+
+```bash
+codex exec --skip-git-repo-check \
+  -m gpt-5.6-luna \
+  --config model_reasoning_effort=xhigh \
+  --sandbox workspace-write \
+  --config sandbox_workspace_write.network_access=true \
+  --output-last-message "$OUT" < "$PROMPT"
+```
+
+codex prints `session id: <uuid>` to stderr. Capture it verbatim — it is the only
+handle for resuming the same flow (`codex exec resume <uuid>`), which matters when
+an E2E run needs a follow-up turn against browser state it already established.
+
+Read `$OUT` for codex's final message rather than relying on the subagent's
+summary; an E2E verdict is exactly the part a summary flattens.
+
+> **Unverified**: the measured operations below were confirmed working headless
+> through `codex exec`, but the sandbox mode in force during that measurement was
+> not recorded. The settings above follow the repo's codex default rather than a
+> measured requirement for browser control specifically.
+
+## The browser handle
+
+```js
+const chrome = agent.browsers.get("chrome");   // explicit, always
+chrome.nameSession("browser-e2e ✅");           // BEFORE opening or claiming tabs
+```
+
+Naming the browser explicitly is not optional bookkeeping. This machine's system
+default browser is Dia, which the plugin does not support, so a `browsers.get()`
+that relies on the default resolves to an unsupported app.
+
+`chrome.nameSession(name)` is Chrome-specific and must be called before the
+session opens or claims tabs. The name it sets is what Chrome renders on the tab
+group, which makes it the on-screen marker the last-resort human ask depends on
+(SKILL.md, preflight step 4) — so choose something recognizable at a glance and
+distinct from any group already open.
+
+## Operations
+
+Shared-set operations, all measured 2026-08-30:
+
+```js
+const tab = chrome.tabs.new();          // default target: a new tab
+chrome.tabs.list();                     // this session's tabs
+tab.goto(url);
+
+tab.playwright.domSnapshot();           // page structure
+const el = tab.playwright.locator(sel);
+el.click();
+el.type(text);
+
+tab.dom_cua.scroll({ x, y });
+tab.screenshot();
+tab.dev.logs({});                       // console
+tab.close();                            // tear down what the run opened
+```
+
+`tab.dev.logs({})` is the **only** member of the `dev` namespace. There is no
+high-level network API on this path at all — `api.json`'s `dev` namespace contains
+`logs()` and nothing else. Response bodies require raw CDP: `codex-privileged.md`.
+
+### Enumerating and claiming beyond this session
+
+```js
+chrome.user.openTabs();      // -> [{ id, lastOpened, providerTabId, tabGroup, title, url }]
+chrome.user.claimTab(entry); // attach; works on a tab this session did not create
+```
+
+Both measured. `claimTab` is the codex-only attach route and is an **exception
+path**, not a default — `attach.md` states when it is warranted.
+
+### Deliverable and handoff markers
+
+```js
+tab.markDeliverable();
+tab.markHandoff();
+```
+
+Both measured as calls. **Unverified**: `markHandoff()`'s lifetime across
+sessions — whether a handoff marked in one codex run remains meaningful to a
+later run, or is scoped to the session that set it, has not been tested. Do not
+build a multi-run flow that depends on a handoff surviving; if a later run needs
+the same tab, re-establish it through `openTabs()` / `claimTab()`.
+
+## Diagnostics
+
+When `agent.browsers.get("chrome")` fails, the bundled chrome plugin ships four
+Node diagnostics. Run them and name **which** precondition is unmet.
+
+```bash
+D="$HOME/.codex/plugins/cache/openai-bundled/chrome/latest/scripts"
+```
+
+| Script | Flags | Exit codes |
+|--------|-------|------------|
+| `installed-browsers.js` | `[--check] [--json]` | `1` = **`--check` only** — no browser installed; `2` = runtime error; `0` otherwise |
+| `chrome-is-running.js` | `[--browser chrome\|edge] [--check] [--json]` | `1` = **`--check` only** — not running; `2` = bad flag / runtime error; `0` otherwise |
+| `check-extension-installed.js` | `[--browser chrome\|edge] [--json]` | `0` installed **and** enabled; `1` installed **not** enabled; `2` not installed; `3` runtime error |
+| `check-native-host-manifest.js` | `[--browser chrome\|edge] [--json]` | `0` manifest correct; `1` missing or incorrect; `2` bad flag / runtime error |
+
+Exit-code semantics read off the installed scripts (`latest` is a floating version
+directory, so re-read them if a codex upgrade changes behaviour).
+
+**Pass `--check`.** The first two scripts report their finding on stdout but exit
+`0` regardless without it — a run that branches on the exit code alone would read
+"no browser installed" as success. The last two carry their finding in the exit
+code unconditionally.
+
+Each accepts `--json`; prefer it, so the failing precondition can be quoted
+precisely to the user rather than paraphrased from a text report.
+
+Reporting shape: *"Chrome is installed and running, but the codex extension is
+installed and not enabled (`check-extension-installed.js` exit 1)."* Naming the
+unmet precondition is the whole point — a generic "browser unavailable" leaves the
+user to re-derive what this already knows.

--- a/browser-e2e/skills/browser-e2e/references/codex.md
+++ b/browser-e2e/skills/browser-e2e/references/codex.md
@@ -21,61 +21,61 @@ second codex inside the first. The nested process died at
 the run then reported that error as the browser path's failure — which it was not.
 Do not remove this table.
 
-## ⛔ Blocker: the CLI never loads the chrome plugin
+## ⚠️ Check which `codex` you are running
 
-**Measured 2026-08-30, codex-cli 0.150.1.** A `codex exec` run's tool inventory
-contains no chrome plugin, no browser plugin, and no JS/Node REPL through which
-`agent.browsers.get("chrome")` could be evaluated. Confirmed three times — from
-the worktree, from the trust-listed parent repository, and once more with a Chrome
-tab open by hand — so it is not a `trust_level`, a sandbox, or a browser-state
-effect. `codex exec --help` offers no flag that enables a plugin for a run.
+**The single most likely reason this path appears broken.** `codex` on `PATH` may
+be a wrapper that redirects `CODEX_HOME` to a project-isolated codex home, and an
+isolated home does not carry the bundled marketplace the chrome plugin lives in.
+Nothing about Chrome, the extension, the sandbox or the model is wrong when this
+happens — the run is simply reading a different codex installation.
 
-### Root cause: the marketplace is not registered
+Check before blaming anything else:
 
-```
-$ codex plugin marketplace list
-MARKETPLACE     ROOT
-openai-curated  …/hermeneutic-assistant/data/opencodex/.codex/.tmp/plugins
+```bash
+command -v codex                    # is this the real binary, or a wrapper?
+codex plugin marketplace list       # openai-bundled must appear
 ```
 
-`openai-curated` is the only registered marketplace. The chrome plugin is
-`chrome@openai-bundled`, and **`openai-bundled` is not registered at all** — so
-`codex plugin list` never lists it and the CLI has no route to load it.
+Measured 2026-08-30 on this machine: `command -v codex` resolved to
+`…/hermeneutic-assistant/data/opencodex/bin/codex`, a two-line shell wrapper that
+sources an `env.sh` setting `CODEX_HOME` to a project-local directory before
+exec'ing `/opt/homebrew/bin/codex`. Under that home, `plugin marketplace list`
+shows only `openai-curated` and no run gets a browser capability. Under the real
+home it lists `openai-bundled` and the capability appears.
 
-Three things point the other way and none of them overrides that:
+The symptom is easy to misread as a browser problem, because it is not one:
 
-| Looks enabled | Actually |
+| What you see | What it means |
 |---|---|
-| `~/.codex/config.toml` has `[plugins."chrome@openai-bundled"] enabled = true` | an enablement flag for a plugin the CLI cannot resolve |
-| `~/.codex/plugins/cache/openai-bundled/chrome/latest/` exists, fully populated | a cache written by something other than this CLI |
-| `codex features list` → `browser_use`, `plugins`, `in_app_browser` all `true` | feature gates, upstream of marketplace resolution |
+| No chrome/browser tool in the run's inventory | wrong `CODEX_HOME`, most likely |
+| All four diagnostics exit 0 | true and irrelevant — they are shell `node` scripts, not plugin tools, so they pass under either home |
+| `config.toml` says `[plugins."chrome@openai-bundled"] enabled = true` | you are reading `~/.codex/config.toml` while the run reads another one |
 
-The likely writer of that cache is the Codex **desktop app** — `config.toml`
-carries `BROWSER_USE_CODEX_APP_VERSION` and a `codex-app-tools@openai-bundled`
-entry, and `codex app` launches it. **Unverified**: whether the desktop app
-exposes the browser API, and whether
-`codex plugin marketplace add openai-bundled …` would make the CLI load it. Both
-are one command away from being known, but the second writes to the user's codex
-config, so it is theirs to authorize.
+That last row is the trap worth naming: reading the real home's config while
+running a wrapper's home makes every check agree that the plugin is enabled while
+every run disagrees. Confirm the two are the same home before drawing any
+conclusion.
 
-### What this means for the operations below
+Run against an explicit home when in doubt:
 
-Everything in *Operations* was measured through **some** codex surface, and the
-provenance of that measurement could not be traced to a surface anyone can name.
-Treat the whole codex column as **unverified-provenance**: evidence that the API
-exists somewhere, not evidence that this skill's documented invocation reaches it.
+```bash
+CODEX_HOME="$HOME/.codex" /opt/homebrew/bin/codex exec …
+```
 
-### What is NOT the cause
+**Ruled out by measurement**, so do not re-check them: the Chrome extension
+(installed and enabled, native host manifest correct, and a probe with a tab open
+by hand changed nothing), sandbox mode, working directory, project trust, and the
+`browser_use` / `plugins` / `in_app_browser` feature flags.
 
-Ruled out by measurement, so a later session need not re-check them:
+## How the JS actually runs
 
-- **The Chrome extension.** Installed and enabled (`check-extension-installed.js`
-  exit 0), native host manifest correct, Chrome running. Opening a tab by hand
-  changed nothing — the plugin is absent before any browser state matters.
-- **Sandbox mode, working directory, project trust, feature flags.**
+The calls in *Operations* are JavaScript, and codex evaluates them through the
+**`mcp__node_repl__js`** tool — the REPL the chrome plugin exposes. Measured
+2026-08-30 under the real `CODEX_HOME`; the tool is absent under the wrapper's
+home, which is what makes its absence the diagnostic signal above.
 
-The four *Diagnostics* below are unaffected: they are plain `node` scripts run
-through the shell, not plugin tools, and ran correctly from inside `codex exec`.
+A prompt that names the operations but not the tool leaves the run to discover
+the mechanism for itself. Name the tool.
 
 ## Settings
 
@@ -91,22 +91,23 @@ through the shell, not plugin tools, and ran correctly from inside `codex exec`.
 > section entirely — see the two-readers table above. Acting on it nests a second
 > codex inside yourself, which has been measured to fail.
 
-> **Unconfirmed as a route to the browser API** — see the blocker above. The flags
-> below are the correct codex invocation and the run starts cleanly; what has not
-> been shown is that the resulting run can reach Chrome.
-
 Write the task to a prompt file, then hand it to `codex exec`. Run it in the
 background with output redirected to a file so codex's banner and step-by-step
 output stay out of this conversation — only the outcome comes back.
 
 ```bash
-codex exec --skip-git-repo-check \
+CODEX_HOME="$HOME/.codex" /opt/homebrew/bin/codex exec --skip-git-repo-check \
   -m gpt-5.6-luna \
   --config model_reasoning_effort=xhigh \
   --sandbox workspace-write \
   --config sandbox_workspace_write.network_access=true \
   --output-last-message "$OUT" < "$PROMPT"
 ```
+
+The explicit home and absolute binary are not belt-and-braces: a bare `codex` may
+resolve to a `PATH` wrapper pointing at a different home, which silently costs the
+run its browser capability (see the check at the top of this file). Drop them only
+once `command -v codex` and `codex plugin marketplace list` have both been read.
 
 codex prints `session id: <uuid>` to stderr. Capture it verbatim — it is the only
 handle for resuming the same flow (`codex exec resume <uuid>`), which matters when
@@ -115,11 +116,12 @@ an E2E run needs a follow-up turn against browser state it already established.
 Read `$OUT` for codex's final message rather than relying on the subagent's
 summary; an E2E verdict is exactly the part a summary flattens.
 
-**Measured 2026-08-30**: this exact invocation starts a run cleanly under
+**Measured 2026-08-30**: this invocation starts a run cleanly under
 `gpt-5.6-luna` / `xhigh` / `workspace-write` with network — the banner reports all
 three back, `--output-last-message` captures the final message, and the
-`session id: <uuid>` line appears on stderr as described. What the run does *not*
-get is the browser API (see the blocker above).
+`session id: <uuid>` line appears on stderr as described. Under the explicit
+`CODEX_HOME` the run also carries `mcp__node_repl__js`, the tool the browser calls
+are evaluated through; without it, it does not.
 
 ## The browser handle
 

--- a/browser-e2e/skills/browser-e2e/references/codex.md
+++ b/browser-e2e/skills/browser-e2e/references/codex.md
@@ -21,30 +21,61 @@ second codex inside the first. The nested process died at
 the run then reported that error as the browser path's failure — which it was not.
 Do not remove this table.
 
-## ⛔ Blocker: `codex exec` does not expose the chrome plugin
+## ⛔ Blocker: the CLI never loads the chrome plugin
 
 **Measured 2026-08-30, codex-cli 0.150.1.** A `codex exec` run's tool inventory
 contains no chrome plugin, no browser plugin, and no JS/Node REPL through which
-`agent.browsers.get("chrome")` could be evaluated. Confirmed twice, from the
-worktree and from the trust-listed parent repository, so it is neither a
-`trust_level` nor a sandbox effect. `codex exec --help` offers no flag that
-enables a plugin for the run.
+`agent.browsers.get("chrome")` could be evaluated. Confirmed three times — from
+the worktree, from the trust-listed parent repository, and once more with a Chrome
+tab open by hand — so it is not a `trust_level`, a sandbox, or a browser-state
+effect. `codex exec --help` offers no flag that enables a plugin for a run.
 
-This holds **even though** `~/.codex/config.toml` carries
-`[plugins."chrome@openai-bundled"]` with `enabled = true`. Config enablement and
-exec-surface exposure are separate things.
+### Root cause: the marketplace is not registered
 
-Everything in *Operations* below was measured through some codex surface, but
-**not through `codex exec`** — the invocation in *Invoking* is therefore
-unconfirmed as a route to the browser API, and the operations are recorded here as
-what that other surface showed. Which surface reaches them (the interactive
-`codex` TUI, the Codex desktop app — `config.toml` carries
-`BROWSER_USE_CODEX_APP_VERSION` and a `codex-app-tools@openai-bundled` plugin — or
-an exec configuration not yet found) is **open**, and is the one thing this path
-needs settled before it can be the default in practice.
+```
+$ codex plugin marketplace list
+MARKETPLACE     ROOT
+openai-curated  …/hermeneutic-assistant/data/opencodex/.codex/.tmp/plugins
+```
 
-The four *Diagnostics* below are unaffected: they are plain `node` scripts and ran
-correctly from inside `codex exec`.
+`openai-curated` is the only registered marketplace. The chrome plugin is
+`chrome@openai-bundled`, and **`openai-bundled` is not registered at all** — so
+`codex plugin list` never lists it and the CLI has no route to load it.
+
+Three things point the other way and none of them overrides that:
+
+| Looks enabled | Actually |
+|---|---|
+| `~/.codex/config.toml` has `[plugins."chrome@openai-bundled"] enabled = true` | an enablement flag for a plugin the CLI cannot resolve |
+| `~/.codex/plugins/cache/openai-bundled/chrome/latest/` exists, fully populated | a cache written by something other than this CLI |
+| `codex features list` → `browser_use`, `plugins`, `in_app_browser` all `true` | feature gates, upstream of marketplace resolution |
+
+The likely writer of that cache is the Codex **desktop app** — `config.toml`
+carries `BROWSER_USE_CODEX_APP_VERSION` and a `codex-app-tools@openai-bundled`
+entry, and `codex app` launches it. **Unverified**: whether the desktop app
+exposes the browser API, and whether
+`codex plugin marketplace add openai-bundled …` would make the CLI load it. Both
+are one command away from being known, but the second writes to the user's codex
+config, so it is theirs to authorize.
+
+### What this means for the operations below
+
+Everything in *Operations* was measured through **some** codex surface, and the
+provenance of that measurement could not be traced to a surface anyone can name.
+Treat the whole codex column as **unverified-provenance**: evidence that the API
+exists somewhere, not evidence that this skill's documented invocation reaches it.
+
+### What is NOT the cause
+
+Ruled out by measurement, so a later session need not re-check them:
+
+- **The Chrome extension.** Installed and enabled (`check-extension-installed.js`
+  exit 0), native host manifest correct, Chrome running. Opening a tab by hand
+  changed nothing — the plugin is absent before any browser state matters.
+- **Sandbox mode, working directory, project trust, feature flags.**
+
+The four *Diagnostics* below are unaffected: they are plain `node` scripts run
+through the shell, not plugin tools, and ran correctly from inside `codex exec`.
 
 ## Settings
 


### PR DESCRIPTION
New plugin for end-to-end browser flows in Chrome, with two executors kept
separate by vendor and selected by the skill argument's first token.

```
/browser-e2e <task>          -> codex, gpt-5.6-luna at xhigh (default)
/browser-e2e claude <task>   -> this session's claude-in-chrome tools
```

`cdp-attach` is untouched — its sunset is a later unit of work.

## The three decisions that shaped the files

**No fallback.** A failure is reported with the failing precondition or step
named; the run never switches executors on its own. Switching would report a
result from a surface the user did not choose, and the user is the one who picks
the executor. The shared operation set exists for *consistency between the
branches*, so both behave identically for the user — not as a fallback substrate.

**One membership test, written down.** An operation is in the shared set when
**both** vendors reach it by an agent call alone; if one vendor needs a human, it
is `references/` material. This is what put `attach` outside the set — not that
codex is weaker there (attach is codex-only), but that the Claude route passes
through a person. The test decides by cost, not by capability, and it is recorded
in SKILL.md so later additions stay consistent.

**A new tab is the default; attach is the exception.** Both paths reach Chrome
through their vendor's extension and native host rather than
`--remote-debugging-port`, so a fresh tab inherits the real profile's auth —
measured: a new tab in a new group loaded github.com already logged in. "The flow
needs me logged in" therefore no longer justifies attach. What remains is in-tab
state a navigation cannot reproduce, enumerated in `references/attach.md`.

## Evidence discipline

Every cell of the shared-set table carries an evidence marker. Measured
(2026-08-30) across the whole codex column; on the Claude side the tab-group and
navigate cycle is measured, and the interaction tools are marked **unmeasured**
rather than asserted, since they are known only from their tool descriptions.

Three open items are carried in the docs as explicitly unverified rather than
inherited as assumptions: the CDP 20-method allowlist (never measured, and
currently blocked by a saved per-origin permission that the local
`approval_mode = "never_ask"` config did not override), the Claude-side
`find` / `computer` / `read_console_messages` / `gif_creator` tools, and
`markHandoff()`'s lifetime across sessions.

## One fact read off disk

The four bundled codex chrome diagnostics were read from the installed scripts
rather than assumed. `installed-browsers.js` and `chrome-is-running.js` exit `0`
regardless unless `--check` is passed — a caller branching on exit status alone
would read "no browser installed" as success — so the documented invocation
passes it. `check-extension-installed.js` (0/1/2/3) and
`check-native-host-manifest.js` (0/1/2) carry their finding unconditionally.

## Naming and frontmatter

Plugin and skill share the name, following `cdp-attach`'s single-skill shape. The
name states the job rather than a mechanism, which is what lets one command carry
two executors.

Frontmatter declares neither `context: fork` nor `model: sonnet`. Not fork: the
routing, precondition diagnosis and last-resort human ask form a coordination
loop that must stay reachable from the conversation — the shape `codex-plus` and
`safe-uninstall` take. Not sonnet: there are no bundled scripts to route, and the
in-set/out-of-set judgment is interpretive.
