### PR TITLE
voice-dictation: 삭제된 cwd 상속으로 인한 whisper-cli abort + 토글 거짓 STARTED 수정

### DIFF
--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/.claude-plugin/plugin.json
+++ b/voice-dictation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-dictation",
   "description": "Push-to-talk voice dictation daemon — whisper.cpp transcription pasted into the active window",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/voice-dictation/README.md
+++ b/voice-dictation/README.md
@@ -5,10 +5,13 @@ Push-to-talk voice dictation for Claude Code, powered by whisper.cpp.
 - Hold **Right Option (⌥)** to record; release to transcribe and paste into the active window
 - 엔진: whisper.cpp `large-v3-turbo` (`whisper-cli`), 녹음은 `rec`
 - 받아쓴 텍스트는 클립보드 + `Cmd+V`로 frontmost 앱에 붙여넣기
-- 토글: 실행 중인 데몬을 스크립트 경로 시그니처(`dictation_daemon.py`)로 `pgrep` 탐지해 on/off
+- 토글: 실행 중인 데몬을 flock 보유자(`$TMPDIR/voice_dictation.lock`)로 탐지해 on/off
 - 로그: `/tmp/voice-dictation.log`
 
-> `uv run`은 자식 python 프로세스로 재분리되어 런처 PID가 stale 포인터가 되므로, PID 파일 대신 on-disk 스크립트 경로 시그니처로 `pgrep`/`pkill` 합니다 (clawd-toggle과 동일).
+> `uv run`은 자식 python 프로세스로 재분리되어 런처 PID가 stale 포인터가 되므로 PID 파일을 쓸 수 없습니다.
+> 대신 데몬이 기동 즉시 잡아 수명 내내 쥐고 있는 배타 flock 의 보유자를 `lsof` 로 조회합니다 — 종료·크래시
+> 시 커널이 락을 해제하므로 stale 상태가 없고, 설치 경로와 무관하게 같은 데몬을 가리킵니다. 경로 시그니처
+> `pgrep` 은 설치본이 둘이면 상대를 못 봐 거짓 `STARTED` 를 냅니다(옛 데몬은 계속 실행).
 
 ## Requirements (CLI)
 

--- a/voice-dictation/scripts/dictation_daemon.py
+++ b/voice-dictation/scripts/dictation_daemon.py
@@ -561,6 +561,16 @@ def _acquire_singleton_lock():
 
 def main():
     global DEBUG, KEEP_DIR, WAV, LOCK, TRIGGER
+    # 데몬을 띄운 셸의 cwd 를 상속한 채로 살지 않는다. 이 데몬 자신은 모델·WAV·락을
+    # 전부 절대경로로 들고 있어 cwd 가 사라져도 멀쩡하지만, cwd 를 물려받는 *자식* 은
+    # 그렇지 않다 — whisper-cli 는 기동 시 백엔드 dylib 를 찾느라
+    # std::filesystem::current_path() 를 부르고, 삭제된 cwd 에서는 getcwd 가 ENOENT 로
+    # 실패해 잡히지 않은 예외로 abort 한다(SIGABRT). 워크트리나 임시 디렉터리 안에서
+    # 토글을 눌렀다가 그 디렉터리가 나중에 정리되면, 데몬은 살아 있는데 전사만 매번
+    # 죽는 비대칭 상태가 된다. 기동 시점에 사라지지 않는 루트로 한 번 옮겨 두면 이후
+    # 모든 자식(rec·whisper-cli·osascript·pbcopy)이 온전한 cwd 를 상속한다 — 자식마다
+    # cwd= 를 붙이는 국소 처치와 달리 나중에 추가되는 자식까지 자동으로 덮는다.
+    os.chdir("/")
     parser = argparse.ArgumentParser(description="voice-dictation 데몬 (push-to-talk 받아쓰기)")
     parser.add_argument("--debug", action="store_true",
                         help="디버그 하네스: 오른쪽 Command(⌘) 트리거, WAV+전사를 ~/voice-dictation-debug 에 보존, 붙여넣기 생략 (프로덕션 데몬과 공존)")

--- a/voice-dictation/scripts/toggle.sh
+++ b/voice-dictation/scripts/toggle.sh
@@ -2,28 +2,53 @@
 # Toggle the voice-dictation push-to-talk daemon as a background process.
 # Output: STARTED or STOPPED
 #
-# Signature-based (not PID-based): `uv run` re-parents into a child python
-# process, so the uv launcher PID is a dead pointer. We pgrep/pkill by the
-# on-disk daemon script path signature instead, matching clawd-toggle.
+# Lock-based (not a PID file, not an argv signature): the daemon takes an
+# exclusive flock on $LOCK before doing anything else and holds it for its whole
+# lifetime, so "is a daemon running" is answered by asking who holds that lock —
+# the daemon's own exclusion primitive, read at its authoritative source. The
+# flock is released by the kernel on exit or crash, so there is no stale state to
+# reap, which is also why a PID file was never an option here (`uv run` re-parents
+# into a child python process, leaving the launcher PID a dead pointer).
+#
+# An argv path signature answers a *different* question — "is a process running
+# from this install path" — and the two answers diverge as soon as a second
+# install exists. With a daemon up from another plugin cache, pgrep finds
+# nothing, this script reports STARTED, and the daemon it spawns dies on the
+# flock a moment later: a false STARTED with the stale daemon still running and
+# nothing in the output to say so. Reading the lock cannot produce that gap,
+# since whoever holds it is found regardless of the path it was started from.
+#
+# The lock path is per-mode, so toggling production leaves a `--debug` daemon
+# (its own lock path) running — the coexistence the debug harness intends, which
+# the shared script path could not distinguish.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DAEMON="$SCRIPT_DIR/dictation_daemon.py"
-# Full-path signature (matches clawd-toggle): the absolute $DAEMON path appears
-# in the `uv run "$DAEMON"` argv, so pgrep/pkill -f tracks exactly this plugin's
-# daemon and won't match an unrelated process that merely shares the basename.
-SIG="$DAEMON"
+# Must match LOCK in dictation_daemon.py: os.path.join(tempfile.gettempdir(), …).
+# gettempdir() honours $TMPDIR, which on macOS is the per-user /var/folders/…/T
+# directory — not /tmp. $TMPDIR carries a trailing slash that gettempdir() drops,
+# so strip it here to name the same path.
+LOCK="${TMPDIR:-/tmp}"
+LOCK="${LOCK%/}/voice_dictation.lock"
 LOGFILE="/tmp/voice-dictation.log"
 
-if pgrep -f "$SIG" >/dev/null 2>&1; then
-  pkill -TERM -f "$SIG" 2>/dev/null
+# The lock holder is the python daemon itself; its `uv` parent exits once the
+# child is gone, so the daemon PID is the only one worth signalling.
+daemon_pids() { lsof -t "$LOCK" 2>/dev/null; }
+
+PIDS="$(daemon_pids)"
+if [[ -n "$PIDS" ]]; then
+  kill -TERM $PIDS 2>/dev/null
   sleep 1
-  pkill -KILL -f "$SIG" 2>/dev/null
-  # The daemon spawns `rec` as a child writing voice_dictation.wav; that child's
-  # argv carries the WAV path, not $SIG, so reap it explicitly — otherwise it
-  # keeps holding the mic if the daemon is toggled off mid-recording. Send SIGINT
-  # (not SIGTERM/KILL) first so sox closes the CoreAudio input device cleanly and
-  # releases the mic — an abruptly killed recorder leaves the orange mic indicator
-  # stuck on. SIGKILL only as a fallback for a straggler that ignored SIGINT.
+  PIDS="$(daemon_pids)"
+  [[ -n "$PIDS" ]] && kill -KILL $PIDS 2>/dev/null
+  # The daemon spawns `rec` as a child writing voice_dictation.wav; that child
+  # holds no lock and outlives a SIGKILLed parent, so reap it explicitly —
+  # otherwise it keeps holding the mic if the daemon is toggled off mid-recording.
+  # Send SIGINT (not SIGTERM/KILL) first so sox closes the CoreAudio input device
+  # cleanly and releases the mic — an abruptly killed recorder leaves the orange
+  # mic indicator stuck on. SIGKILL only as a fallback for a straggler that
+  # ignored SIGINT.
   pkill -INT -f "voice_dictation.wav" 2>/dev/null
   sleep 0.3
   pkill -KILL -f "voice_dictation.wav" 2>/dev/null


### PR DESCRIPTION
voice-dictation 데몬에서 관찰된 두 결함을 고칩니다. 증상은 하나로 겹쳐 있었습니다 — 데몬은 살아 있는데 전사가 매번 실패하고, 토글로 되살리려 해도 `STARTED` 만 나올 뿐 아무것도 바뀌지 않는 상태.

## 1. 자식 프로세스가 삭제된 cwd 를 상속해 abort (`os.chdir("/")`)

`whisper-cli` 가 SIGABRT 로 죽고 백트레이스가 `main → ggml_backend_load_all_from_path → ggml_backend_load_best → std::filesystem::__current_path → __cxa_rethrow → terminate` 로 끝났습니다.

`whisper-cli` 는 기동 시 백엔드 dylib 탐색 경로를 만들려고 `current_path()` 를 부릅니다. cwd 가 삭제돼 있으면 `getcwd` 가 ENOENT 로 실패하고, `filesystem_error` 가 아무 데서도 잡히지 않아 terminate 로 갑니다.

```
$ d=$(mktemp -d); cd "$d" && rmdir "$d" && whisper-cli --help
libc++abi: terminating due to uncaught exception of type std::__fs::filesystem::filesystem_error:
  filesystem error: in current_path: call to getcwd failed: No such file or directory   (exit 134)
```

데몬 자신은 모델·WAV·락을 전부 절대경로로 들고 있어 cwd 가 사라져도 멀쩡합니다. 깨지는 건 cwd 를 상속하는 *자식* 뿐이라 "데몬 정상 / 전사만 죽음" 이라는 비대칭 증상으로 나타났고, 그래서 원인이 늦게 드러났습니다. 실제로는 워크트리 안에서 토글을 누른 뒤 그 워크트리가 정리되면서 데몬의 cwd 가 유령이 된 상황이었습니다.

**수정**: `main()` 초입에서 `os.chdir("/")`. 자식마다 `cwd=` 를 넘기는 국소 처치 대신 프로세스 cwd 자체를 옮깁니다 — `rec`·`whisper-cli`·`osascript`·`pbcopy` 가 한 번에 덮이고 이후 추가되는 자식도 자동으로 안전합니다. `/` 는 사라지지 않고, 쓰기도 하지 않으며, ggml 이 cwd 에서 찾는 `ggml-*.dylib` 도 없습니다.

**검증**: 삭제된 cwd 에서 `whisper-cli` exit = -6 (SIGABRT) → `os.chdir("/")` 이후 exit = 0.

## 2. 토글의 거짓 `STARTED` (판정 근거를 flock 보유자로 이전)

`toggle.sh` 는 데몬 존재를 스크립트 절대경로 argv 시그니처로 `pgrep` 했습니다. 이것은 "데몬이 도는가" 가 아니라 **"이 설치 경로에서 도는 프로세스가 있는가"** 에 답합니다. 설치본이 둘이면(프로젝트-로컬 config 디렉터리 + `~/.claude`) 두 답이 갈라집니다 — `pgrep` 이 상대를 못 봐 else 분기로 가고, 새로 띄운 데몬은 곧바로 flock 에 막혀 조용히 죽는데, 출력에는 그 사실이 남지 않습니다.

재현 (데몬은 다른 경로에서 실행 중):

```
$ bash ~/.claude/plugins/cache/cc-plugin/voice-dictation/1.1.8/scripts/toggle.sh
STARTED
$ cat /tmp/voice-dictation.log
이미 실행 중인 voice-dictation 데몬이 있습니다 — 중복 기동 취소.
$ lsof -t $TMPDIR/voice_dictation.lock
3618        ← 옛 데몬 그대로
```

**수정**: 데몬이 기동 즉시 잡아 수명 내내 쥐는 배타 flock 의 보유자를 `lsof` 로 조회합니다. 데몬 자신의 배타 제어 프리미티브를 권위 있는 소스에서 그대로 읽으므로 설치 경로와 무관하게 같은 데몬을 가리키고, 거짓 `STARTED` 가 구조적으로 생길 수 없습니다(락을 쥔 쪽이 있으면 항상 STOPPED 분기). 커널이 종료·크래시 시 락을 풀어 stale 상태도 없습니다.

PID 파일을 못 쓰는 이유(`uv run` 재분리로 런처 PID 가 stale)는 그대로 유효하지만, 그 대안이 경로 시그니처일 필요는 없었습니다 — 회피 대상은 PID *파일* 이지 PID 자체가 아니었습니다.

**부수 효과**: 락 경로가 모드별이라 프로덕션 토글이 `--debug` 데몬을 더 이상 죽이지 않습니다. 공유 스크립트 경로로는 구분할 수 없어 디버그 하네스가 문서상 표방하던 '공존' 이 실은 깨져 있었습니다.

**검증**: 워크트리의 `toggle.sh` 가 `~/.claude` 설치본에서 뜬 데몬을 `STOPPED` 로 정확히 포착(구버전은 같은 상황에서 거짓 `STARTED`). 기동 경로도 확인 — 워크트리 디렉터리에서 토글한 데몬의 cwd 가 `/`.

## 변경 파일

- `voice-dictation/scripts/dictation_daemon.py` — `main()` 에 `os.chdir("/")`
- `voice-dictation/scripts/toggle.sh` — 판정/종료 근거를 flock 보유자로 이전
- `voice-dictation/README.md` — 토글 동작 설명 갱신
- `voice-dictation/.claude-plugin/plugin.json` — 1.1.8 → 1.1.10 (커밋당 1회 범프)
