### PR TITLE
폭 예산 규칙을 공식만 남기고, 체인의 지그재그 연결선을 바로잡는다

### DIFF
--- a/text-diagram/.claude-plugin/plugin.json
+++ b/text-diagram/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "text-diagram",
   "description": "Draw directed graphs — DAGs, workflows, pipelines, dependency trees — as layered box-art you read directly in the terminal",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/text-diagram/.claude-plugin/plugin.json
+++ b/text-diagram/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "text-diagram",
   "description": "Draw directed graphs — DAGs, workflows, pipelines, dependency trees — as layered box-art you read directly in the terminal",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/text-diagram/skills/text-diagram/SKILL.md
+++ b/text-diagram/skills/text-diagram/SKILL.md
@@ -27,10 +27,9 @@ Four checks, in order. The first two decide *whether* to draw; the last two deci
    where `W` is the reading terminal's width. The terminal hard-wraps anything past it and
    a wrapped drawing is unreadable, so this is the one hard constraint. `render.py` reads
    `W` at invocation and warns past it, falling back to 80 only when the width cannot be
-   detected. At `W = 80` that works out to roughly 6 siblings for 6-character labels,
-   4 for 10-character, 3 for 15-character — and those numbers move with `W`, so read them
-   as the 80-column case rather than as the rule. Label length eats the budget as fast as
-   sibling count does; shortening names is usually the cheaper fix.
+   detected. Label length eats the budget as fast as sibling count does, so shortening
+   names is usually the cheaper fix — read that off the formula rather than off a table
+   of sibling counts, which would only be true at one `W`.
 
    When the skill runs the script on the user's behalf, the detected width is the tool's
    own pty rather than the user's window — usually narrower, so the check errs

--- a/text-diagram/skills/text-diagram/scripts/render.py
+++ b/text-diagram/skills/text-diagram/scripts/render.py
@@ -126,8 +126,15 @@ def render(nodes, edges, ascii_mode=False, gutter=3, focus=(), width_budget=None
 
     # assign absolute column of each box's left edge, then its center
     left, center = {}, {}
+    axis = canvas_w // 2
     for r in rows:
-        x = (canvas_w - line_w(r)) // 2
+        if len(r) == 1:
+            # Put a lone box's centre ON the shared axis. Centring each layer's SPAN
+            # instead lets integer division land neighbouring centres a column apart,
+            # and a chain of lone boxes then zigzags for no structural reason.
+            x = axis - bw[r[0]] // 2
+        else:
+            x = (canvas_w - line_w(r)) // 2
         for n in r:
             left[n] = x
             center[n] = x + bw[n] // 2


### PR DESCRIPTION
개밥먹기에서 나온 두 가지를 함께 담습니다.

## 1. 폭 예산 규칙에서 형제 수 표 제거

예산을 호출 시점 터미널 폭으로 바꾼 뒤에도 SKILL.md에 `W=80`일 때만 참인 표("6자 라벨이면 형제 6개…")가 남아 있었습니다. 공식보다 표가 먼저 읽히는 자리라, 규칙이 아닌 것이 규칙처럼 보입니다. 공식 `Σ(라벨) + 4n + 3(n−1) ≤ W` 하나만 남겼습니다.

## 2. 단일 노드 계층의 지그재그 연결선

계층마다 박스 **구간**을 가운데 정렬하다 보니, 폭의 홀짝이 다른 단일 노드가 연달아 오면 정수 나눗셈에서 중심이 한 칸씩 어긋났습니다. 연결선이 매 계층 꺾이는데, 그 꺾임은 그래프의 구조가 아니라 반올림 자국입니다.

```
현재                          수정 후
┌────────┐                   ┌────────┐
│ design │                   │ design │
└────────┘                   └────────┘
    ┌┘     ← 꺾임                 │
    │                            │
┌───────┐                    ┌───────┐
│ build │                    │ build │
└───────┘                    └───────┘
```

단일 노드 계층은 구간이 아니라 박스 중심을 공통 축에 올립니다. 다중 노드 계층은 종전대로.

## 검증

설치본 `0.4.0`으로 케이스 7종을 돌리고 터미널 스크린샷으로 확인했습니다 — 팬아웃/팬인, 선형 체인, 다층 빌드, 순환(CI 재시도), cross-layer, `--focus` 강조, 폭 초과 경고.

- 다층·순환 출력은 수정 전후 md5 동일 — 회귀 없음
- `--focus`의 굵은 테두리가 실제 렌더에서 초점으로 읽히는 것 확인
- 폭 경고가 98열에서 정상 발화

#150 후속.