### PR TITLE
codex-plus: codex 쪽 Chrome 경로를 참조 한 장으로 접기 (#149 대체)

### DIFF
--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.10.4",
+  "version": "2.11.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.12.2",
+  "version": "2.13.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.11.3",
+  "version": "2.12.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -139,3 +139,15 @@ Read the image reference when the delegated task involves image generation, imag
 **File**: `references/image-gen-models-prompting-guide.ipynb`
 
 Use the notebook directly instead of duplicating its per-use-case guidance here.
+
+Read the Chrome reference **before** delegating a browser or computer-use task.
+Driving Chrome from codex needs a bootstrap and a tool name that are not
+discoverable from the task, and the most common failure — `codex` on `PATH`
+resolving to a wrapper with its own `CODEX_HOME` — presents as a browser problem
+while all four bundled diagnostics still exit `0`.
+
+**File**: `references/chrome.md`
+
+Its first half is the setup and the operation surface; the second half is
+diagnosis-time material indexed by symptom, worth reading only when a run
+misbehaves.

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -148,6 +148,9 @@ while all four bundled diagnostics still exit `0`.
 
 **File**: `references/chrome.md`
 
-Its first half is the setup and the operation surface; the second half is
-diagnosis-time material indexed by symptom, worth reading only when a run
-misbehaves.
+It carries the setup, the operation surface, and a symptom table. Do not read the
+troubleshooting reference up front — the symptom table says when to load it.
+
+**File**: `references/chrome-troubleshooting.md`
+
+Load it only after a browser run has actually failed, matching the symptom first.

--- a/codex-plus/skills/codex/references/chrome-troubleshooting.md
+++ b/codex-plus/skills/codex/references/chrome-troubleshooting.md
@@ -59,20 +59,31 @@ The call returns the success shape either way, so **a flow that scrolls and then
 asserts can read a stale page as a real one.** Read `scrollY` back rather than
 trusting the return whenever the page does anything of its own with scrolling.
 
-## `type()` right after `goto()` → `Detached while handling command`
+## `Detached while handling command` on `type()`
 
-The locator resolved against the pre-navigation document and the navigation
-invalidated it. `waitForLoadState({ state: "load" })` does not prevent it, and
-`networkidle` is unsupported. The wait alone is not the fix — re-targeting is:
+**The cause is not a stale locator, and the wait-then-retarget recipe does not
+work.** Both were disproven 2026-09-01 on
+`https://the-internet.herokuapp.com/login`:
 
-```js
-tab.goto(url);
-tab.playwright.waitForTimeout(500);
-tab.playwright.locator("#username").type("…");   // fresh locator, after the wait
-```
+- In a **pristine tab**, with a locator built fresh *after* the wait, `type()`
+  failed at both 500 ms and 2000 ms.
+- The locator was not the problem. Diagnostics reported
+  `{"kind":"action_failed","matchCount":1,"visibleCount":1}` — it matched exactly
+  one visible `<input>` — and the field read back `""`.
+- Running it first in a tab that had already failed once changes only the
+  diagnostic (`no_matches` instead of `action_failed`), not the outcome.
 
-Treat every navigation as invalidating every locator held across it. A `click()`
-that triggers navigation is the same hazard for whatever comes next.
+The same recipe was reported working on 2026-08-30. It did not reproduce.
+
+So the honest state is: **`playwright.locator().type()` did not enter text on the
+one page measured, and no wait length repairs it.** Do not spend turns on waits or
+re-targeting — that path is already measured out. Report the failing step with the
+locator diagnostics.
+
+Two things this does *not* establish, and one of them has already caught us once:
+the failure may be specific to this page, exactly as the `scroll()` failure turned
+out to be. And the other input namespaces on the tab (`cua`, `dom_cua`) were never
+tried. Before concluding that typing is broken, try one on a different page.
 
 ## `browsers.get("chrome")` fails → name the unmet precondition
 

--- a/codex-plus/skills/codex/references/chrome-troubleshooting.md
+++ b/codex-plus/skills/codex/references/chrome-troubleshooting.md
@@ -1,101 +1,60 @@
 # codex + Chrome — when it misbehaves
 
-Load this only after a codex browser run has actually failed. Setup, the
-operation surface and the symptom index are in `chrome.md`; nothing here is
-needed to start a run.
+Load this after a browser run has failed. Setup, the operation surface and the
+symptom index are in `chrome.md`.
 
-Each entry is a failure whose signal points somewhere other than its cause.
+Each entry is a failure that reports a cause other than its own.
 
 ## No browser tool in the run's inventory → wrong `CODEX_HOME`
 
 The most likely reason this path looks broken, and it is not a browser problem.
 `codex` on `PATH` may be a wrapper that redirects `CODEX_HOME` to a
-project-isolated home, and an isolated home carries no bundled marketplace — so
-the chrome plugin never loads and no run gets a browser capability.
-`scripts/codex-run.sh` resolves the binary with `command -v codex` and pins no
-home, so it inherits whatever the caller's `PATH` gives it. **The check is the
-caller's, before the run:**
+project-isolated home, which carries no bundled marketplace — so the chrome plugin
+never loads. `scripts/codex-run.sh` resolves the binary with `command -v codex`
+and pins no home, so **the check is the caller's, before the run**:
 
 ```bash
 command -v codex                 # a wrapper, or the real binary?
 codex plugin marketplace list    # openai-bundled must appear
 ```
 
-Measured 2026-08-30: `command -v codex` resolved to a two-line shell wrapper that
-sourced an `env.sh` setting a project-local `CODEX_HOME`; under that home
-`plugin marketplace list` showed only `openai-curated`, and no run got a browser
-capability. Under the real home it lists `openai-bundled` and the capability
-appears.
+Two signals mislead here:
 
-Two things make this hard to see:
+- **All four diagnostics still exit `0`.** They are shell `node` scripts, not
+  plugin tools, so they pass under either home.
+- **`config.toml` says the plugin is enabled.** You are reading
+  `~/.codex/config.toml` while the run reads another one.
 
-- **All four diagnostics still exit `0`** — true and irrelevant. They are shell
-  `node` scripts, not plugin tools, so they pass under either home.
-- **`config.toml` says the plugin is enabled** — you are reading
-  `~/.codex/config.toml` while the run reads another one. Confirm both are the
-  same home before drawing any conclusion.
-
-Ruled out by measurement, so do not re-check them: the Chrome extension
-(installed, enabled, native-host manifest correct), sandbox mode, working
-directory, project trust, and the `browser_use` / `plugins` / `in_app_browser`
-feature flags.
-
-Three probes all reporting "no browser capability" is one fault reproduced three
-times when every probe goes through the same `PATH` wrapper. Vary what sits
-*below* the suspected cause, not beside it.
+Do not re-check these — they are ruled out: the Chrome extension, its native-host
+manifest, sandbox mode, working directory, project trust, and the `browser_use` /
+`plugins` / `in_app_browser` flags.
 
 ## `scroll()` returned success and the page did not move
 
-**Not an API defect.** Measured 2026-09-01 on a plain static document
-(`scrollHeight: 145039`): `tab.dom_cua.scroll({x: 0, y: 600})` moved `scrollY`
-from `0` to `600`, and `y: -600` restored it. The call works.
-
-What fails is a page that manages its own scroll position. The earlier
-measurement (2026-08-30) used an infinite-scroll page, where the same call
-returned `undefined` while `scrollY` stayed `0` and screenshots and snapshots
-were unchanged, in both directions.
-
-The call returns the success shape either way, so **a flow that scrolls and then
-asserts can read a stale page as a real one.** Read `scrollY` back rather than
-trusting the return whenever the page does anything of its own with scrolling.
+A page that manages its own scroll position can swallow the scroll while the call
+still returns the success shape. Read `scrollY` back rather than trusting the
+return.
 
 ## `Detached while handling command` on an input
 
-**Page-specific, not an API defect** — the same shape the `scroll()` failure
-turned out to have. Measured 2026-09-01, fresh tab and a 2000 ms wait in every
-cell:
+Page-specific, not an API defect — ordinary form pages take input fine. On a page
+that does this, **every input path fails the same way**: `locator.type`,
+`locator.fill`, `locator.pressSequentially`, `cua.type`, `cua.keypress`,
+`dom_cua.type`, `dom_cua.keypress`. Coordinate focus still succeeds, so the field
+is reachable; the write is what fails. No wait length repairs it, and the locator
+is not stale — diagnostics report a match on one visible input.
 
-| Page | `playwright.locator(sel).type()` |
-|---|---|
-| `httpbin.org/forms/post` | text entered, read back |
-| `the-internet.herokuapp.com/inputs` | text entered, read back |
-| `the-internet.herokuapp.com/login` | `Detached while handling command`, value `""` |
+`locator.press()` is the one to watch: it can return **no error** and still leave
+the field empty. A call completing is not evidence that anything landed.
 
-**Do not vary the input path — that axis is measured out.** On the failing page,
-all eight of these detached with the same diagnostics and left the field empty:
-`locator.type`, `locator.fill`, `locator.pressSequentially`, `cua.type`,
-`cua.keypress`, `dom_cua.type`, `dom_cua.keypress`. Coordinate focus succeeded
-first in every case, so the field was reachable; the write is what failed.
-
-`locator.press("P")` is the one to watch: it returned **no error at all** and the
-value still read back `""`. On a page in this state, a call completing is not
-evidence that anything landed.
-
-Two earlier claims are withdrawn. A stale locator is not the cause — diagnostics
-reported `action_failed` with `matchCount: 1`, `visibleCount: 1`, so the locator
-matched one visible `<input>`. And no wait length repairs it: 500 ms and 2000 ms
-failed identically, as did retrying in a tab that had never failed before.
-
-So when this appears: the page is doing something the runtime cannot write
-through. Report it with the locator diagnostics and solve the flow another way
-rather than spending turns on the input call.
+Report it with the locator diagnostics and solve the flow another way rather than
+spending turns on the input call.
 
 ## `browsers.get("chrome")` fails → name the unmet precondition
 
-Four bundled diagnostics say which one it is. **Pass `--check` to the first two**:
-they report their finding on stdout but exit `0` regardless without it, so a run
-branching on the exit code alone reads "no browser installed" as success. The last
-two carry their finding in the exit code unconditionally.
+Four bundled diagnostics say which one. **Pass `--check` to the first two** — they
+report on stdout but exit `0` regardless without it, so branching on the exit code
+alone reads "no browser installed" as success.
 
 ```bash
 D="$HOME/.codex/plugins/cache/openai-bundled/chrome/latest/scripts"
@@ -105,11 +64,9 @@ node "$D/check-extension-installed.js"         --json   # 1 = installed not enab
 node "$D/check-native-host-manifest.js"        --json   # 1 = manifest missing or incorrect
 ```
 
-Report which precondition is unmet, quoting the `--json` field that decides it — a
+Report which precondition is unmet, quoting the `--json` field that decides it. A
 generic "browser unavailable" leaves the user to re-derive what this already
 knows.
 
-Exit-code semantics were read off the installed scripts under `latest`, a floating
-version directory: re-read them after a codex upgrade. The non-zero rows are
-read-off-the-source rather than observed — no precondition was deliberately broken
-when they were measured.
+`latest` is a floating version directory — re-read the exit codes off the scripts
+after a codex upgrade.

--- a/codex-plus/skills/codex/references/chrome-troubleshooting.md
+++ b/codex-plus/skills/codex/references/chrome-troubleshooting.md
@@ -59,31 +59,36 @@ The call returns the success shape either way, so **a flow that scrolls and then
 asserts can read a stale page as a real one.** Read `scrollY` back rather than
 trusting the return whenever the page does anything of its own with scrolling.
 
-## `Detached while handling command` on `type()`
+## `Detached while handling command` on an input
 
-**The cause is not a stale locator, and the wait-then-retarget recipe does not
-work.** Both were disproven 2026-09-01 on
-`https://the-internet.herokuapp.com/login`:
+**Page-specific, not an API defect** — the same shape the `scroll()` failure
+turned out to have. Measured 2026-09-01, fresh tab and a 2000 ms wait in every
+cell:
 
-- In a **pristine tab**, with a locator built fresh *after* the wait, `type()`
-  failed at both 500 ms and 2000 ms.
-- The locator was not the problem. Diagnostics reported
-  `{"kind":"action_failed","matchCount":1,"visibleCount":1}` — it matched exactly
-  one visible `<input>` — and the field read back `""`.
-- Running it first in a tab that had already failed once changes only the
-  diagnostic (`no_matches` instead of `action_failed`), not the outcome.
+| Page | `playwright.locator(sel).type()` |
+|---|---|
+| `httpbin.org/forms/post` | text entered, read back |
+| `the-internet.herokuapp.com/inputs` | text entered, read back |
+| `the-internet.herokuapp.com/login` | `Detached while handling command`, value `""` |
 
-The same recipe was reported working on 2026-08-30. It did not reproduce.
+**Do not vary the input path — that axis is measured out.** On the failing page,
+all eight of these detached with the same diagnostics and left the field empty:
+`locator.type`, `locator.fill`, `locator.pressSequentially`, `cua.type`,
+`cua.keypress`, `dom_cua.type`, `dom_cua.keypress`. Coordinate focus succeeded
+first in every case, so the field was reachable; the write is what failed.
 
-So the honest state is: **`playwright.locator().type()` did not enter text on the
-one page measured, and no wait length repairs it.** Do not spend turns on waits or
-re-targeting — that path is already measured out. Report the failing step with the
-locator diagnostics.
+`locator.press("P")` is the one to watch: it returned **no error at all** and the
+value still read back `""`. On a page in this state, a call completing is not
+evidence that anything landed.
 
-Two things this does *not* establish, and one of them has already caught us once:
-the failure may be specific to this page, exactly as the `scroll()` failure turned
-out to be. And the other input namespaces on the tab (`cua`, `dom_cua`) were never
-tried. Before concluding that typing is broken, try one on a different page.
+Two earlier claims are withdrawn. A stale locator is not the cause — diagnostics
+reported `action_failed` with `matchCount: 1`, `visibleCount: 1`, so the locator
+matched one visible `<input>`. And no wait length repairs it: 500 ms and 2000 ms
+failed identically, as did retrying in a tab that had never failed before.
+
+So when this appears: the page is doing something the runtime cannot write
+through. Report it with the locator diagnostics and solve the flow another way
+rather than spending turns on the input call.
 
 ## `browsers.get("chrome")` fails → name the unmet precondition
 

--- a/codex-plus/skills/codex/references/chrome-troubleshooting.md
+++ b/codex-plus/skills/codex/references/chrome-troubleshooting.md
@@ -1,0 +1,96 @@
+# codex + Chrome — when it misbehaves
+
+Load this only after a codex browser run has actually failed. Setup, the
+operation surface and the symptom index are in `chrome.md`; nothing here is
+needed to start a run.
+
+Each entry is a failure whose signal points somewhere other than its cause.
+
+## No browser tool in the run's inventory → wrong `CODEX_HOME`
+
+The most likely reason this path looks broken, and it is not a browser problem.
+`codex` on `PATH` may be a wrapper that redirects `CODEX_HOME` to a
+project-isolated home, and an isolated home carries no bundled marketplace — so
+the chrome plugin never loads and no run gets a browser capability.
+`scripts/codex-run.sh` resolves the binary with `command -v codex` and pins no
+home, so it inherits whatever the caller's `PATH` gives it. **The check is the
+caller's, before the run:**
+
+```bash
+command -v codex                 # a wrapper, or the real binary?
+codex plugin marketplace list    # openai-bundled must appear
+```
+
+Measured 2026-08-30: `command -v codex` resolved to a two-line shell wrapper that
+sourced an `env.sh` setting a project-local `CODEX_HOME`; under that home
+`plugin marketplace list` showed only `openai-curated`, and no run got a browser
+capability. Under the real home it lists `openai-bundled` and the capability
+appears.
+
+Two things make this hard to see:
+
+- **All four diagnostics still exit `0`** — true and irrelevant. They are shell
+  `node` scripts, not plugin tools, so they pass under either home.
+- **`config.toml` says the plugin is enabled** — you are reading
+  `~/.codex/config.toml` while the run reads another one. Confirm both are the
+  same home before drawing any conclusion.
+
+Ruled out by measurement, so do not re-check them: the Chrome extension
+(installed, enabled, native-host manifest correct), sandbox mode, working
+directory, project trust, and the `browser_use` / `plugins` / `in_app_browser`
+feature flags.
+
+Three probes all reporting "no browser capability" is one fault reproduced three
+times when every probe goes through the same `PATH` wrapper. Vary what sits
+*below* the suspected cause, not beside it.
+
+## `scroll()` reports success and does not scroll
+
+`tab.dom_cua.scroll({x, y})` returns `undefined` — the success shape — while
+`scrollY` stays `0` and screenshots and snapshots are unchanged. Measured
+2026-08-30 with both positive and negative values. Because the call reports
+success, **a flow that scrolls and then asserts will read a stale page as a real
+one**: read `scrollY` back rather than trusting the return.
+
+Still open: that run used an infinite-scroll page whose own JS may interact with
+the call. One re-test on a plain long document decides whether this is a defect or
+a page interaction.
+
+## `type()` right after `goto()` → `Detached while handling command`
+
+The locator resolved against the pre-navigation document and the navigation
+invalidated it. `waitForLoadState({ state: "load" })` does not prevent it, and
+`networkidle` is unsupported. The wait alone is not the fix — re-targeting is:
+
+```js
+tab.goto(url);
+tab.playwright.waitForTimeout(500);
+tab.playwright.locator("#username").type("…");   // fresh locator, after the wait
+```
+
+Treat every navigation as invalidating every locator held across it. A `click()`
+that triggers navigation is the same hazard for whatever comes next.
+
+## `browsers.get("chrome")` fails → name the unmet precondition
+
+Four bundled diagnostics say which one it is. **Pass `--check` to the first two**:
+they report their finding on stdout but exit `0` regardless without it, so a run
+branching on the exit code alone reads "no browser installed" as success. The last
+two carry their finding in the exit code unconditionally.
+
+```bash
+D="$HOME/.codex/plugins/cache/openai-bundled/chrome/latest/scripts"
+node "$D/installed-browsers.js"        --check --json   # 1 = no browser installed
+node "$D/chrome-is-running.js"         --check --json   # 1 = Chrome not running
+node "$D/check-extension-installed.js"         --json   # 1 = installed not enabled; 2 = not installed
+node "$D/check-native-host-manifest.js"        --json   # 1 = manifest missing or incorrect
+```
+
+Report which precondition is unmet, quoting the `--json` field that decides it — a
+generic "browser unavailable" leaves the user to re-derive what this already
+knows.
+
+Exit-code semantics were read off the installed scripts under `latest`, a floating
+version directory: re-read them after a codex upgrade. The non-zero rows are
+read-off-the-source rather than observed — no precondition was deliberately broken
+when they were measured.

--- a/codex-plus/skills/codex/references/chrome-troubleshooting.md
+++ b/codex-plus/skills/codex/references/chrome-troubleshooting.md
@@ -44,17 +44,20 @@ Three probes all reporting "no browser capability" is one fault reproduced three
 times when every probe goes through the same `PATH` wrapper. Vary what sits
 *below* the suspected cause, not beside it.
 
-## `scroll()` reports success and does not scroll
+## `scroll()` returned success and the page did not move
 
-`tab.dom_cua.scroll({x, y})` returns `undefined` — the success shape — while
-`scrollY` stays `0` and screenshots and snapshots are unchanged. Measured
-2026-08-30 with both positive and negative values. Because the call reports
-success, **a flow that scrolls and then asserts will read a stale page as a real
-one**: read `scrollY` back rather than trusting the return.
+**Not an API defect.** Measured 2026-09-01 on a plain static document
+(`scrollHeight: 145039`): `tab.dom_cua.scroll({x: 0, y: 600})` moved `scrollY`
+from `0` to `600`, and `y: -600` restored it. The call works.
 
-Still open: that run used an infinite-scroll page whose own JS may interact with
-the call. One re-test on a plain long document decides whether this is a defect or
-a page interaction.
+What fails is a page that manages its own scroll position. The earlier
+measurement (2026-08-30) used an infinite-scroll page, where the same call
+returned `undefined` while `scrollY` stayed `0` and screenshots and snapshots
+were unchanged, in both directions.
+
+The call returns the success shape either way, so **a flow that scrolls and then
+asserts can read a stale page as a real one.** Read `scrollY` back rather than
+trusting the return whenever the page does anything of its own with scrolling.
 
 ## `type()` right after `goto()` → `Detached while handling command`
 

--- a/codex-plus/skills/codex/references/chrome.md
+++ b/codex-plus/skills/codex/references/chrome.md
@@ -40,28 +40,49 @@ const tab = await chrome.tabs.new();      // default target: a new tab
 await chrome.tabs.list();                 // this session only; [{ id, title, url }]
 await tab.goto(url);
 
-await tab.playwright.domSnapshot();       // -> string; size scales with the page
+await tab.dom_cua.get_visible_dom();      // visible nodes; the default page read
+await tab.playwright.evaluate(js);        // read anything specific; also how you verify an effect
+await tab.playwright.domSnapshot();       // semantic outline; scales with the document
 await tab.playwright.locator(sel).click();
 await tab.playwright.locator(sel).type(text);
 await tab.dom_cua.scroll({ x: 0, y: 600 });
 await tab.screenshot();                   // -> Uint8Array of image bytes, not a path
 await tab.dev.logs({});                   // -> [{ level, message, timestamp, url }]
-await tab.playwright.evaluate(js);        // -> the value; how you verify an effect
 await tab.close();
 ```
 
-- **`domSnapshot()` is not small.** It is accessibility text rather than a DOM
-  dump, but size tracks the page and can pass 800k chars. Do not call it blind on
-  an unknown page.
-- **`screenshot()` returns image bytes, JPEG as observed.** Sniff the header
-  rather than assuming a format. Takes `{ fullPage, clip }`.
-- Anything not listed above as returning data returns `undefined` and is used for
-  effect. Verify with `evaluate` or by listing tabs; do not test the return.
+**Read the DOM; a screenshot is the visual fallback, not the page-reading path.**
+Three readers, in the order to reach for them:
+
+- `dom_cua.get_visible_dom()` — visible nodes carrying `node_id`, and it stays
+  bounded: a book-length page comes back around 3k characters where
+  `domSnapshot()` gives 805k. Start here when the question is what can be
+  interacted with.
+- `playwright.evaluate(js)` — arbitrary reads, scoped to what you ask for. The
+  cheapest way to get one element:
+
+  ```js
+  await tab.playwright.evaluate(
+    `document.querySelector(${JSON.stringify(sel)})?.value ??
+     document.querySelector(${JSON.stringify(sel)})?.textContent ?? null`
+  );
+  ```
+
+- `domSnapshot()` — accessibility outline. Good for semantic structure, but size
+  tracks the document. Do not call it blind on an unknown page.
+
+`screenshot()` returns image bytes, JPEG as observed — sniff the header rather
+than assuming a format. It takes `{ fullPage, clip }`.
+
+Anything not named above as returning data returns `undefined` and is used for
+effect. Verify with `evaluate` or by listing tabs; do not test the return.
 
 `logs` is the only member of `dev` — no network API here, and response bodies need
 raw CDP. `playwright` mirrors Playwright's own surface plus `elementInfo`,
-`elementScreenshot` and `expectNavigation`. `cua` and `dom_cua` carry alternate
-input paths (`click`, `type`, `keypress`, `scroll`, `drag`).
+`elementScreenshot` and `expectNavigation`. `cua` and `dom_cua` carry the input
+paths (`click`, `type`, `keypress`, `scroll`, `drag`). There is no `tab.ax`, and
+`tab.content` only exports Google Workspace and YouTube pages — neither is a route
+to the DOM.
 
 `chrome.user.openTabs()` lists the whole profile, unlike session-scoped
 `tabs.list()`, and `chrome.user.claimTab(entry)` attaches to a tab this session
@@ -71,20 +92,28 @@ login does not justify it.
 
 ## When something fails
 
-Match the observed string. Rows marked → need
+Match the observed string, then act. The last four need
 [`chrome-troubleshooting.md`](chrome-troubleshooting.md); the rest are fixed here.
 
-| Observed | Cause | Do |
-|---|---|---|
-| `ReferenceError: agent is not defined` | client never imported | Setup step 2 |
-| `TypeError: <promise>.goto is not a function` | missing `await` | add `await` |
-| `Browser use requires a trusted Node REPL browser service` | not running under `mcp__node_repl__js` | use that tool |
-| a browser other than Chrome | `browsers.get()` called without a name | pass `"chrome"` |
-| no browser tool in the inventory; four diagnostics exit `0` | `PATH` wrapper with its own `CODEX_HOME` | → |
-| `browsers.get("chrome")` throws | one of four preconditions unmet | → |
-| `Detached while handling command` on an input | page rejects every input path | → |
-| `scrollY` unchanged after `scroll()` returned | page manages its own scroll position | → |
-| a call returned cleanly and the effect is absent | most calls return `undefined` | verify with `evaluate` |
+- **`ReferenceError: agent is not defined`** — the client was never imported. Go
+  back to Setup step 2 and bind what `setupBrowserRuntime()` returns.
+- **`TypeError: <promise>.goto is not a function`** — a missing `await`, not a
+  wrong API. Add it.
+- **`Browser use requires a trusted Node REPL browser service`** — the code is not
+  running under `mcp__node_repl__js`. Nothing else can evaluate these calls.
+- **A browser other than Chrome answered** — `browsers.get()` was called without a
+  name. Always pass `"chrome"`.
+- **A call returned cleanly and the effect is absent** — expected: most calls
+  return `undefined` and are used for effect. Confirm with `evaluate` rather than
+  reading the return.
+- **No browser tool in the run's inventory, and all four diagnostics exit `0`** —
+  `codex` on `PATH` is a wrapper carrying its own `CODEX_HOME`.
+- **`browsers.get("chrome")` throws** — one of four preconditions is unmet; the
+  bundled diagnostics name which.
+- **`Detached while handling command` on an input** — the page refuses every input
+  path there is. Do not try the others.
+- **`scrollY` unchanged after `scroll()` returned** — the page manages its own
+  scroll position, and the call reports success either way.
 
-Not listed: report the failing step with its evidence rather than working around
-it.
+Anything else: report the failing step with its evidence rather than working
+around it.

--- a/codex-plus/skills/codex/references/chrome.md
+++ b/codex-plus/skills/codex/references/chrome.md
@@ -9,8 +9,7 @@ Two steps, in order. Name both in the prompt; neither is discoverable from the
 task.
 
 **1. The browser calls are JavaScript, evaluated through `mcp__node_repl__js`.**
-The client throws `Browser use requires a trusted Node REPL browser service`
-without it, so that tool is required, not preferred.
+That tool is required, not preferred.
 
 **2. `setupBrowserRuntime()` returns the agent — it creates no global.** A fresh
 REPL exposes only `nodeRepl`, and `agent.browsers…` raises
@@ -33,9 +32,8 @@ only marker a person can act on if the run has to ask for help.
 
 ## Operations
 
-**Every `await` below is load-bearing.** Drop it on `tabs.new()` and the next line
-fails as `TypeError: <promise>.goto is not a function`, which reads like a wrong
-API rather than a missing keyword.
+**Every `await` below is load-bearing** — omitting one surfaces as a wrong-API
+error rather than a missing keyword.
 
 ```js
 const tab = await chrome.tabs.new();      // default target: a new tab
@@ -73,16 +71,20 @@ login does not justify it.
 
 ## When something fails
 
-Match the symptom, then load
-[`chrome-troubleshooting.md`](chrome-troubleshooting.md). Nothing in it is needed
-to start a run.
+Match the observed string. Rows marked → need
+[`chrome-troubleshooting.md`](chrome-troubleshooting.md); the rest are fixed here.
 
-| Symptom | Actually |
-|---|---|
-| No browser tool in the run's inventory; the four diagnostics all exit `0` | `codex` on `PATH` is a wrapper with its own `CODEX_HOME` |
-| Scrolled, then asserted, and the page looks unchanged | the page manages its own scroll position |
-| `Detached while handling command` on an input | page-specific; every input path fails on that page |
-| `browsers.get("chrome")` fails | one of four preconditions; the diagnostics name which |
+| Observed | Cause | Do |
+|---|---|---|
+| `ReferenceError: agent is not defined` | client never imported | Setup step 2 |
+| `TypeError: <promise>.goto is not a function` | missing `await` | add `await` |
+| `Browser use requires a trusted Node REPL browser service` | not running under `mcp__node_repl__js` | use that tool |
+| a browser other than Chrome | `browsers.get()` called without a name | pass `"chrome"` |
+| no browser tool in the inventory; four diagnostics exit `0` | `PATH` wrapper with its own `CODEX_HOME` | → |
+| `browsers.get("chrome")` throws | one of four preconditions unmet | → |
+| `Detached while handling command` on an input | page rejects every input path | → |
+| `scrollY` unchanged after `scroll()` returned | page manages its own scroll position | → |
+| a call returned cleanly and the effect is absent | most calls return `undefined` | verify with `evaluate` |
 
-Anything else: report the failing step with its evidence rather than working
-around it.
+Not listed: report the failing step with its evidence rather than working around
+it.

--- a/codex-plus/skills/codex/references/chrome.md
+++ b/codex-plus/skills/codex/references/chrome.md
@@ -1,0 +1,157 @@
+# codex + Chrome
+
+Read this before delegating a browser or computer-use task to codex. It covers
+the codex side only — this session's own `mcp__claude-in-chrome__*` tools need no
+reference and are not described here.
+
+Run on `gpt-5.6-luna` at `xhigh` (SKILL.md, *Running a Task* step 1).
+
+## Setup
+
+Two steps, in order. Neither is discoverable from the task, so name both in the
+prompt.
+
+**1. The browser calls are JavaScript, evaluated through `mcp__node_repl__js`** —
+the REPL the bundled `chrome` plugin exposes. A run given only the operations has
+to rediscover the mechanism for itself.
+
+**2. `agent` does not exist until the client is imported.** A fresh REPL exposes
+only `nodeRepl`; reaching for `agent.browsers…` raises
+`ReferenceError: agent is not defined`. Import the plugin's browser client and
+call `setupBrowserRuntime()` before anything else:
+
+```
+$HOME/.codex/plugins/cache/openai-bundled/chrome/latest/scripts/browser-client.mjs
+```
+
+Then, in this order — `nameSession` must precede opening or claiming any tab:
+
+```js
+const chrome = await agent.browsers.get("chrome");   // always by name
+await chrome.nameSession("codex ✅");                 // BEFORE any tab
+```
+
+Name the browser explicitly because a system default is machine state that
+changes underneath the caller, not because of what the default happens to be.
+Give the session a name that reads well on screen: Chrome renders it on the tab
+group, and it is the only marker a person can act on if the run has to ask for
+help.
+
+## Operations
+
+Everything is async. A dropped `await` surfaces later as an unrelated-looking
+failure.
+
+```js
+const tab = chrome.tabs.new();          // default target: a new tab
+chrome.tabs.list();                     // this session's tabs only
+tab.goto(url);
+
+tab.playwright.domSnapshot();           // -> string; compact, not a DOM dump
+tab.playwright.locator(sel).click();
+tab.playwright.locator(sel).type(text); // see the detachment race below
+tab.screenshot();                       // -> Uint8Array of PNG bytes, not a path
+tab.dev.logs({});                       // -> [{ level, message, timestamp, url }]
+tab.close();
+```
+
+`logs` is the **only** member of `dev` — there is no network API on this path, and
+response bodies need raw CDP. Every other call returns `undefined` and is used for
+effect: do not test the return for success, verify by reading the page back or
+listing the tabs.
+
+`chrome.user.openTabs()` lists the whole profile (unlike session-scoped
+`tabs.list()`) and `chrome.user.claimTab(entry)` attaches to a tab this session
+did not open. Both are an exception path: claiming takes over a tab the user is
+browsing, and it stays unmeasured for that reason. A fresh tab inherits the real
+profile's auth, so "the flow needs me logged in" does not justify claiming.
+
+## When it misbehaves
+
+Read this section only when something is wrong. Each entry is a failure whose
+signal points somewhere other than its cause.
+
+### No browser tool in the run's inventory → wrong `CODEX_HOME`
+
+The most likely reason this path looks broken, and it is not a browser problem.
+`codex` on `PATH` may be a wrapper that redirects `CODEX_HOME` to a
+project-isolated home, and an isolated home carries no bundled marketplace — so
+the chrome plugin never loads and no run gets a browser capability.
+`scripts/codex-run.sh` resolves the binary with `command -v codex` and pins no
+home, so it inherits whatever the caller's `PATH` gives it. **The check is the
+caller's, before the run:**
+
+```bash
+command -v codex                 # a wrapper, or the real binary?
+codex plugin marketplace list    # openai-bundled must appear
+```
+
+Measured 2026-08-30: `command -v codex` resolved to a two-line shell wrapper that
+sourced an `env.sh` setting a project-local `CODEX_HOME`; under that home
+`plugin marketplace list` showed only `openai-curated`, and no run got a browser
+capability. Under the real home it lists `openai-bundled` and the capability
+appears.
+
+Two things make this hard to see:
+
+- **All four diagnostics still exit `0`** — true and irrelevant. They are shell
+  `node` scripts, not plugin tools, so they pass under either home.
+- **`config.toml` says the plugin is enabled** — you are reading
+  `~/.codex/config.toml` while the run reads another one. Confirm both are the
+  same home before drawing any conclusion.
+
+Ruled out by measurement, so do not re-check them: the Chrome extension
+(installed, enabled, native-host manifest correct), sandbox mode, working
+directory, project trust, and the `browser_use` / `plugins` / `in_app_browser`
+feature flags.
+
+### `scroll()` reports success and does not scroll
+
+`tab.dom_cua.scroll({x, y})` returns `undefined` — the success shape — while
+`scrollY` stays `0` and screenshots and snapshots are unchanged. Measured
+2026-08-30 with both positive and negative values. Because the call reports
+success, **a flow that scrolls and then asserts will read a stale page as a real
+one**: read `scrollY` back rather than trusting the return.
+
+Still open: that run used an infinite-scroll page whose own JS may interact with
+the call. One re-test on a plain long document decides whether this is a defect or
+a page interaction.
+
+### `type()` right after `goto()` → `Detached while handling command`
+
+The locator resolved against the pre-navigation document and the navigation
+invalidated it. `waitForLoadState({ state: "load" })` does not prevent it, and
+`networkidle` is unsupported. The wait alone is not the fix — re-targeting is:
+
+```js
+tab.goto(url);
+tab.playwright.waitForTimeout(500);
+tab.playwright.locator("#username").type("…");   // fresh locator, after the wait
+```
+
+Treat every navigation as invalidating every locator held across it. A `click()`
+that triggers navigation is the same hazard for whatever comes next.
+
+### `browsers.get("chrome")` fails → name the unmet precondition
+
+Four bundled diagnostics say which one it is. **Pass `--check` to the first two**:
+they report their finding on stdout but exit `0` regardless without it, so a run
+branching on the exit code alone reads "no browser installed" as success. The last
+two carry their finding in the exit code unconditionally.
+
+```bash
+D="$HOME/.codex/plugins/cache/openai-bundled/chrome/latest/scripts"
+node "$D/installed-browsers.js"        --check --json   # 1 = no browser installed
+node "$D/chrome-is-running.js"         --check --json   # 1 = Chrome not running
+node "$D/check-extension-installed.js"         --json   # 1 = installed not enabled; 2 = not installed
+node "$D/check-native-host-manifest.js"        --json   # 1 = manifest missing or incorrect
+```
+
+Report which precondition is unmet, quoting the `--json` field that decides it — a
+generic "browser unavailable" leaves the user to re-derive what this already
+knows.
+
+Exit-code semantics were read off the installed scripts under `latest`, a floating
+version directory: re-read them after a codex upgrade. The non-zero rows are
+read-off-the-source rather than observed — no precondition was deliberately broken
+when they were measured.

--- a/codex-plus/skills/codex/references/chrome.md
+++ b/codex-plus/skills/codex/references/chrome.md
@@ -1,23 +1,21 @@
 # codex + Chrome
 
-Read this before delegating a browser or computer-use task to codex. It covers
-the codex side only — this session's own `mcp__claude-in-chrome__*` tools need no
-reference and are not described here.
+Read this before delegating a browser or computer-use task to codex. Codex side
+only — this session's own `mcp__claude-in-chrome__*` tools need no reference.
 
 ## Setup
 
-Two steps, in order. Neither is discoverable from the task, so name both in the
-prompt.
+Two steps, in order. Name both in the prompt; neither is discoverable from the
+task.
 
-**1. The browser calls are JavaScript, evaluated through `mcp__node_repl__js`** —
-the REPL the bundled `chrome` plugin exposes. The client throws
-`Browser use requires a trusted Node REPL browser service` when `globalThis.nodeRepl`
-is missing, so that tool is the required channel, not a preference.
+**1. The browser calls are JavaScript, evaluated through `mcp__node_repl__js`.**
+The client throws `Browser use requires a trusted Node REPL browser service`
+without it, so that tool is required, not preferred.
 
-**2. `setupBrowserRuntime()` *returns* the agent — it creates no global.** A fresh
-REPL exposes only `nodeRepl`, and reaching for `agent.browsers…` raises
+**2. `setupBrowserRuntime()` returns the agent — it creates no global.** A fresh
+REPL exposes only `nodeRepl`, and `agent.browsers…` raises
 `ReferenceError: agent is not defined`. Import the client (its only export) and
-bind what it hands back:
+bind what it returns:
 
 ```js
 const { setupBrowserRuntime } = await import(
@@ -29,17 +27,15 @@ const chrome = await agent.browsers.get("chrome");   // always by name
 await chrome.nameSession("codex ✅");                 // BEFORE any tab
 ```
 
-Name the browser explicitly because a system default is machine state that
-changes underneath the caller, not because of what the default happens to be.
-Give the session a name that reads well on screen: Chrome renders it on the tab
-group, and it is the only marker a person can act on if the run has to ask for
-help.
+Pass `"chrome"` explicitly: a system default is machine state. Give the session a
+name that reads well on screen — Chrome renders it on the tab group, which is the
+only marker a person can act on if the run has to ask for help.
 
 ## Operations
 
-**Every call is async, and the `await` below is load-bearing** — omit it on
-`tabs.new()` and the next line fails as `TypeError: <promise>.goto is not a
-function`, which reads like a wrong API rather than a missing keyword.
+**Every `await` below is load-bearing.** Drop it on `tabs.new()` and the next line
+fails as `TypeError: <promise>.goto is not a function`, which reads like a wrong
+API rather than a missing keyword.
 
 ```js
 const tab = await chrome.tabs.new();      // default target: a new tab
@@ -49,52 +45,43 @@ await tab.goto(url);
 await tab.playwright.domSnapshot();       // -> string; size scales with the page
 await tab.playwright.locator(sel).click();
 await tab.playwright.locator(sel).type(text);
-await tab.dom_cua.scroll({ x: 0, y: 600 });     // verify by reading scrollY back
+await tab.dom_cua.scroll({ x: 0, y: 600 });
 await tab.screenshot();                   // -> Uint8Array of image bytes, not a path
 await tab.dev.logs({});                   // -> [{ level, message, timestamp, url }]
-await tab.playwright.evaluate(js);        // -> the value; this is how you verify an effect
+await tab.playwright.evaluate(js);        // -> the value; how you verify an effect
 await tab.close();
 ```
 
-Two return shapes are worth knowing before you call them:
+- **`domSnapshot()` is not small.** It is accessibility text rather than a DOM
+  dump, but size tracks the page and can pass 800k chars. Do not call it blind on
+  an unknown page.
+- **`screenshot()` returns image bytes, JPEG as observed.** Sniff the header
+  rather than assuming a format. Takes `{ fullPage, clip }`.
+- Anything not listed above as returning data returns `undefined` and is used for
+  effect. Verify with `evaluate` or by listing tabs; do not test the return.
 
-- **`domSnapshot()` is not small.** 232 chars on `example.com`, but 805,388 chars
-  across 4,545 lines on a book-length page (measured 2026-09-01). "Accessibility
-  text, not a DOM dump" describes its *form*, not its size — do not call it blind
-  on an unknown page. `tab.ax` and `tab.content` are separate namespaces on the
-  same tab and may be cheaper; both are unmeasured.
-- **`screenshot()` returned JPEG, not PNG** — header `FF D8 FF E0`, 179,736 bytes
-  (measured 2026-09-01). Sniff the header rather than assuming a format, and note
-  it takes `{ fullPage, clip }` options.
+`logs` is the only member of `dev` — no network API here, and response bodies need
+raw CDP. `playwright` mirrors Playwright's own surface plus `elementInfo`,
+`elementScreenshot` and `expectNavigation`. `cua` and `dom_cua` carry alternate
+input paths (`click`, `type`, `keypress`, `scroll`, `drag`).
 
-`playwright` mirrors Playwright's own surface — `locator`, the `getBy*` family,
-the `waitFor*` family, `evaluate` — plus `elementInfo`, `elementScreenshot` and
-`expectNavigation`. `cua` and `dom_cua` are the alternate input paths
-(`click`, `type`, `keypress`, `scroll`, `drag`); reach for them only when the
-`playwright` path has actually failed, since they are not cheaper.
-
-`logs` is the **only** member of `dev` — there is no network API on this path, and
-response bodies need raw CDP. Every call that is not listed above as returning
-data returns `undefined` and is used for effect: do not test the return for
-success, verify by reading the page back or listing the tabs.
-
-`chrome.user.openTabs()` lists the whole profile (unlike session-scoped
-`tabs.list()`) and `chrome.user.claimTab(entry)` attaches to a tab this session
-did not open. Both are an exception path: claiming takes over a tab the user is
-browsing, and it stays unmeasured for that reason. A fresh tab inherits the real
-profile's auth, so "the flow needs me logged in" does not justify claiming.
+`chrome.user.openTabs()` lists the whole profile, unlike session-scoped
+`tabs.list()`, and `chrome.user.claimTab(entry)` attaches to a tab this session
+did not open. Claiming takes over a tab the user is browsing, so it is an
+exception path — and a fresh tab inherits the real profile's auth, so needing a
+login does not justify it.
 
 ## When something fails
 
-Four known failures report a cause other than their own. Match the symptom, then
-load [`chrome-troubleshooting.md`](chrome-troubleshooting.md) — it is diagnosis
-material and nothing in it is needed to start a run.
+Match the symptom, then load
+[`chrome-troubleshooting.md`](chrome-troubleshooting.md). Nothing in it is needed
+to start a run.
 
 | Symptom | Actually |
 |---|---|
 | No browser tool in the run's inventory; the four diagnostics all exit `0` | `codex` on `PATH` is a wrapper with its own `CODEX_HOME` |
-| Scrolled, then asserted, and the page looks unchanged | the page manages its own scrolling; `scroll()` returns the success shape either way |
-| `Detached while handling command` on an input | page-specific; every input path fails on that page, and no wait repairs it |
+| Scrolled, then asserted, and the page looks unchanged | the page manages its own scroll position |
+| `Detached while handling command` on an input | page-specific; every input path fails on that page |
 | `browsers.get("chrome")` fails | one of four preconditions; the diagnostics name which |
 
 Anything else: report the failing step with its evidence rather than working

--- a/codex-plus/skills/codex/references/chrome.md
+++ b/codex-plus/skills/codex/references/chrome.md
@@ -4,29 +4,27 @@ Read this before delegating a browser or computer-use task to codex. It covers
 the codex side only — this session's own `mcp__claude-in-chrome__*` tools need no
 reference and are not described here.
 
-Run on `gpt-5.6-luna` at `xhigh` (SKILL.md, *Running a Task* step 1).
-
 ## Setup
 
 Two steps, in order. Neither is discoverable from the task, so name both in the
 prompt.
 
 **1. The browser calls are JavaScript, evaluated through `mcp__node_repl__js`** —
-the REPL the bundled `chrome` plugin exposes. A run given only the operations has
-to rediscover the mechanism for itself.
+the REPL the bundled `chrome` plugin exposes. The client throws
+`Browser use requires a trusted Node REPL browser service` when `globalThis.nodeRepl`
+is missing, so that tool is the required channel, not a preference.
 
-**2. `agent` does not exist until the client is imported.** A fresh REPL exposes
-only `nodeRepl`; reaching for `agent.browsers…` raises
-`ReferenceError: agent is not defined`. Import the plugin's browser client and
-call `setupBrowserRuntime()` before anything else:
-
-```
-$HOME/.codex/plugins/cache/openai-bundled/chrome/latest/scripts/browser-client.mjs
-```
-
-Then, in this order — `nameSession` must precede opening or claiming any tab:
+**2. `setupBrowserRuntime()` *returns* the agent — it creates no global.** A fresh
+REPL exposes only `nodeRepl`, and reaching for `agent.browsers…` raises
+`ReferenceError: agent is not defined`. Import the client (its only export) and
+bind what it hands back:
 
 ```js
+const { setupBrowserRuntime } = await import(
+  `${process.env.HOME}/.codex/plugins/cache/openai-bundled/chrome/latest/scripts/browser-client.mjs`
+);
+const agent = await setupBrowserRuntime();
+
 const chrome = await agent.browsers.get("chrome");   // always by name
 await chrome.nameSession("codex ✅");                 // BEFORE any tab
 ```
@@ -39,26 +37,39 @@ help.
 
 ## Operations
 
-Everything is async. A dropped `await` surfaces later as an unrelated-looking
-failure.
+**Every call is async, and the `await` below is load-bearing** — omit it on
+`tabs.new()` and the next line fails as `TypeError: <promise>.goto is not a
+function`, which reads like a wrong API rather than a missing keyword.
 
 ```js
-const tab = chrome.tabs.new();          // default target: a new tab
-chrome.tabs.list();                     // this session's tabs only
-tab.goto(url);
+const tab = await chrome.tabs.new();      // default target: a new tab
+await chrome.tabs.list();                 // this session only; [{ id, title, url }]
+await tab.goto(url);
 
-tab.playwright.domSnapshot();           // -> string; compact, not a DOM dump
-tab.playwright.locator(sel).click();
-tab.playwright.locator(sel).type(text); // rebuild the locator after any navigation
-tab.screenshot();                       // -> Uint8Array of PNG bytes, not a path
-tab.dev.logs({});                       // -> [{ level, message, timestamp, url }]
-tab.close();
+await tab.playwright.domSnapshot();       // -> string; size scales with the page
+await tab.playwright.locator(sel).click();
+await tab.playwright.locator(sel).type(text);   // rebuild the locator after any navigation
+await tab.dom_cua.scroll({ x: 0, y: 600 });     // verify by reading scrollY back
+await tab.screenshot();                   // -> Uint8Array of image bytes, not a path
+await tab.dev.logs({});                   // -> [{ level, message, timestamp, url }]
+await tab.close();
 ```
 
+Two return shapes are worth knowing before you call them:
+
+- **`domSnapshot()` is not small.** 232 chars on `example.com`, but 805,388 chars
+  across 4,545 lines on a book-length page (measured 2026-09-01). "Accessibility
+  text, not a DOM dump" describes its *form*, not its size — do not call it blind
+  on an unknown page. `tab.ax` and `tab.content` are separate namespaces on the
+  same tab and may be cheaper; both are unmeasured.
+- **`screenshot()` returned JPEG, not PNG** — header `FF D8 FF E0`, 179,736 bytes
+  (measured 2026-09-01). Sniff the header rather than assuming a format, and note
+  it takes `{ fullPage, clip }` options.
+
 `logs` is the **only** member of `dev` — there is no network API on this path, and
-response bodies need raw CDP. Every other call returns `undefined` and is used for
-effect: do not test the return for success, verify by reading the page back or
-listing the tabs.
+response bodies need raw CDP. Every call that is not listed above as returning
+data returns `undefined` and is used for effect: do not test the return for
+success, verify by reading the page back or listing the tabs.
 
 `chrome.user.openTabs()` lists the whole profile (unlike session-scoped
 `tabs.list()`) and `chrome.user.claimTab(entry)` attaches to a tab this session
@@ -75,8 +86,8 @@ material and nothing in it is needed to start a run.
 | Symptom | Actually |
 |---|---|
 | No browser tool in the run's inventory; the four diagnostics all exit `0` | `codex` on `PATH` is a wrapper with its own `CODEX_HOME` |
-| Scrolled, then asserted, and the page looks unchanged | `dom_cua.scroll()` returns the success shape without scrolling |
-| `Detached while handling command` on `type()` or `click()` | a navigation invalidated the locator; waiting does not fix it |
+| Scrolled, then asserted, and the page looks unchanged | the page manages its own scrolling; `scroll()` returns the success shape either way |
+| `Detached while handling command` on `type()` or `click()` | a navigation invalidated the locator |
 | `browsers.get("chrome")` fails | one of four preconditions; the diagnostics name which |
 
 Anything else: report the failing step with its evidence rather than working

--- a/codex-plus/skills/codex/references/chrome.md
+++ b/codex-plus/skills/codex/references/chrome.md
@@ -49,7 +49,7 @@ tab.goto(url);
 
 tab.playwright.domSnapshot();           // -> string; compact, not a DOM dump
 tab.playwright.locator(sel).click();
-tab.playwright.locator(sel).type(text); // see the detachment race below
+tab.playwright.locator(sel).type(text); // rebuild the locator after any navigation
 tab.screenshot();                       // -> Uint8Array of PNG bytes, not a path
 tab.dev.logs({});                       // -> [{ level, message, timestamp, url }]
 tab.close();
@@ -66,92 +66,18 @@ did not open. Both are an exception path: claiming takes over a tab the user is
 browsing, and it stays unmeasured for that reason. A fresh tab inherits the real
 profile's auth, so "the flow needs me logged in" does not justify claiming.
 
-## When it misbehaves
+## When something fails
 
-Read this section only when something is wrong. Each entry is a failure whose
-signal points somewhere other than its cause.
+Four known failures report a cause other than their own. Match the symptom, then
+load [`chrome-troubleshooting.md`](chrome-troubleshooting.md) — it is diagnosis
+material and nothing in it is needed to start a run.
 
-### No browser tool in the run's inventory → wrong `CODEX_HOME`
+| Symptom | Actually |
+|---|---|
+| No browser tool in the run's inventory; the four diagnostics all exit `0` | `codex` on `PATH` is a wrapper with its own `CODEX_HOME` |
+| Scrolled, then asserted, and the page looks unchanged | `dom_cua.scroll()` returns the success shape without scrolling |
+| `Detached while handling command` on `type()` or `click()` | a navigation invalidated the locator; waiting does not fix it |
+| `browsers.get("chrome")` fails | one of four preconditions; the diagnostics name which |
 
-The most likely reason this path looks broken, and it is not a browser problem.
-`codex` on `PATH` may be a wrapper that redirects `CODEX_HOME` to a
-project-isolated home, and an isolated home carries no bundled marketplace — so
-the chrome plugin never loads and no run gets a browser capability.
-`scripts/codex-run.sh` resolves the binary with `command -v codex` and pins no
-home, so it inherits whatever the caller's `PATH` gives it. **The check is the
-caller's, before the run:**
-
-```bash
-command -v codex                 # a wrapper, or the real binary?
-codex plugin marketplace list    # openai-bundled must appear
-```
-
-Measured 2026-08-30: `command -v codex` resolved to a two-line shell wrapper that
-sourced an `env.sh` setting a project-local `CODEX_HOME`; under that home
-`plugin marketplace list` showed only `openai-curated`, and no run got a browser
-capability. Under the real home it lists `openai-bundled` and the capability
-appears.
-
-Two things make this hard to see:
-
-- **All four diagnostics still exit `0`** — true and irrelevant. They are shell
-  `node` scripts, not plugin tools, so they pass under either home.
-- **`config.toml` says the plugin is enabled** — you are reading
-  `~/.codex/config.toml` while the run reads another one. Confirm both are the
-  same home before drawing any conclusion.
-
-Ruled out by measurement, so do not re-check them: the Chrome extension
-(installed, enabled, native-host manifest correct), sandbox mode, working
-directory, project trust, and the `browser_use` / `plugins` / `in_app_browser`
-feature flags.
-
-### `scroll()` reports success and does not scroll
-
-`tab.dom_cua.scroll({x, y})` returns `undefined` — the success shape — while
-`scrollY` stays `0` and screenshots and snapshots are unchanged. Measured
-2026-08-30 with both positive and negative values. Because the call reports
-success, **a flow that scrolls and then asserts will read a stale page as a real
-one**: read `scrollY` back rather than trusting the return.
-
-Still open: that run used an infinite-scroll page whose own JS may interact with
-the call. One re-test on a plain long document decides whether this is a defect or
-a page interaction.
-
-### `type()` right after `goto()` → `Detached while handling command`
-
-The locator resolved against the pre-navigation document and the navigation
-invalidated it. `waitForLoadState({ state: "load" })` does not prevent it, and
-`networkidle` is unsupported. The wait alone is not the fix — re-targeting is:
-
-```js
-tab.goto(url);
-tab.playwright.waitForTimeout(500);
-tab.playwright.locator("#username").type("…");   // fresh locator, after the wait
-```
-
-Treat every navigation as invalidating every locator held across it. A `click()`
-that triggers navigation is the same hazard for whatever comes next.
-
-### `browsers.get("chrome")` fails → name the unmet precondition
-
-Four bundled diagnostics say which one it is. **Pass `--check` to the first two**:
-they report their finding on stdout but exit `0` regardless without it, so a run
-branching on the exit code alone reads "no browser installed" as success. The last
-two carry their finding in the exit code unconditionally.
-
-```bash
-D="$HOME/.codex/plugins/cache/openai-bundled/chrome/latest/scripts"
-node "$D/installed-browsers.js"        --check --json   # 1 = no browser installed
-node "$D/chrome-is-running.js"         --check --json   # 1 = Chrome not running
-node "$D/check-extension-installed.js"         --json   # 1 = installed not enabled; 2 = not installed
-node "$D/check-native-host-manifest.js"        --json   # 1 = manifest missing or incorrect
-```
-
-Report which precondition is unmet, quoting the `--json` field that decides it — a
-generic "browser unavailable" leaves the user to re-derive what this already
-knows.
-
-Exit-code semantics were read off the installed scripts under `latest`, a floating
-version directory: re-read them after a codex upgrade. The non-zero rows are
-read-off-the-source rather than observed — no precondition was deliberately broken
-when they were measured.
+Anything else: report the failing step with its evidence rather than working
+around it.

--- a/codex-plus/skills/codex/references/chrome.md
+++ b/codex-plus/skills/codex/references/chrome.md
@@ -48,7 +48,7 @@ await tab.goto(url);
 
 await tab.playwright.domSnapshot();       // -> string; size scales with the page
 await tab.playwright.locator(sel).click();
-await tab.playwright.locator(sel).type(text);   // rebuild the locator after any navigation
+await tab.playwright.locator(sel).type(text);   // measured failing on one page; see the symptom table
 await tab.dom_cua.scroll({ x: 0, y: 600 });     // verify by reading scrollY back
 await tab.screenshot();                   // -> Uint8Array of image bytes, not a path
 await tab.dev.logs({});                   // -> [{ level, message, timestamp, url }]
@@ -87,7 +87,7 @@ material and nothing in it is needed to start a run.
 |---|---|
 | No browser tool in the run's inventory; the four diagnostics all exit `0` | `codex` on `PATH` is a wrapper with its own `CODEX_HOME` |
 | Scrolled, then asserted, and the page looks unchanged | the page manages its own scrolling; `scroll()` returns the success shape either way |
-| `Detached while handling command` on `type()` or `click()` | a navigation invalidated the locator |
+| `Detached while handling command` on `type()` | cause unknown; a stale locator is disproven, and no wait length repairs it |
 | `browsers.get("chrome")` fails | one of four preconditions; the diagnostics name which |
 
 Anything else: report the failing step with its evidence rather than working

--- a/codex-plus/skills/codex/references/chrome.md
+++ b/codex-plus/skills/codex/references/chrome.md
@@ -48,10 +48,11 @@ await tab.goto(url);
 
 await tab.playwright.domSnapshot();       // -> string; size scales with the page
 await tab.playwright.locator(sel).click();
-await tab.playwright.locator(sel).type(text);   // measured failing on one page; see the symptom table
+await tab.playwright.locator(sel).type(text);
 await tab.dom_cua.scroll({ x: 0, y: 600 });     // verify by reading scrollY back
 await tab.screenshot();                   // -> Uint8Array of image bytes, not a path
 await tab.dev.logs({});                   // -> [{ level, message, timestamp, url }]
+await tab.playwright.evaluate(js);        // -> the value; this is how you verify an effect
 await tab.close();
 ```
 
@@ -65,6 +66,12 @@ Two return shapes are worth knowing before you call them:
 - **`screenshot()` returned JPEG, not PNG** — header `FF D8 FF E0`, 179,736 bytes
   (measured 2026-09-01). Sniff the header rather than assuming a format, and note
   it takes `{ fullPage, clip }` options.
+
+`playwright` mirrors Playwright's own surface — `locator`, the `getBy*` family,
+the `waitFor*` family, `evaluate` — plus `elementInfo`, `elementScreenshot` and
+`expectNavigation`. `cua` and `dom_cua` are the alternate input paths
+(`click`, `type`, `keypress`, `scroll`, `drag`); reach for them only when the
+`playwright` path has actually failed, since they are not cheaper.
 
 `logs` is the **only** member of `dev` — there is no network API on this path, and
 response bodies need raw CDP. Every call that is not listed above as returning
@@ -87,7 +94,7 @@ material and nothing in it is needed to start a run.
 |---|---|
 | No browser tool in the run's inventory; the four diagnostics all exit `0` | `codex` on `PATH` is a wrapper with its own `CODEX_HOME` |
 | Scrolled, then asserted, and the page looks unchanged | the page manages its own scrolling; `scroll()` returns the success shape either way |
-| `Detached while handling command` on `type()` | cause unknown; a stale locator is disproven, and no wait length repairs it |
+| `Detached while handling command` on an input | page-specific; every input path fails on that page, and no wait repairs it |
 | `browsers.get("chrome")` fails | one of four preconditions; the diagnostics name which |
 
 Anything else: report the failing step with its evidence rather than working


### PR DESCRIPTION
PR #149(`browser-e2e` 플러그인, 8파일 898줄)가 담으려던 것을 `codex-plus/skills/codex/references/chrome.md` 157줄로 대체합니다. 별도 플러그인을 만들지 않고, #149는 이 PR과 함께 닫습니다.

## 왜 접었나

#149의 Claude 분기가 담은 다섯 블록이 전부 하네스가 `claude-in-chrome` 지침으로 이미 주는 내용이었습니다.

| 하네스가 이미 말하는 것 | #149에서 다시 말하던 곳 |
|---|---|
| ToolSearch 한 호출로 묶어 로드 (select 목록까지 동일) | `references/claude.md` |
| alert/confirm/prompt 금지 — 걸리면 사람이 직접 해제 | `claude.md` "Do not open a dialog" |
| 세션 시작 시 `tabs_context_mcp` 선행, 이전 tabId 재사용 금지, 새 탭이 기본 | `SKILL.md` 프리플라이트 2·3 |
| 2~3회 실패하면 멈추고 물어보라 | "No fallback" (부분 중첩) |
| GIF는 전후 프레임 여유 있게, 파일명은 의미 있게 | `claude-only.md` — 거의 축자 일치 |

실제 세션 궤적도 같은 방향을 가리켰습니다. HTML 브리핑을 만든 세션에서 `file://` navigate 거부는 루프백 서버로 자체 복구했고, 낱개 호출 → `browser_batch` 전환도 지적 한 번으로 끝났습니다. **시끄러운 실패에서는 지침이 순손실입니다** — 호출마다 컨텍스트를 쓰면서 이미 일어날 행동을 사는 것이기 때문입니다.

그래서 남길 기준을 하나로 잡았습니다.

> **모델에게 신호가 안 오거나, 신호가 원인을 틀리게 가리키는 자리만 적는다.**

이 기준으로 거르면 남는 항목이 전부 codex 쪽이고, **하나도 절차가 아니라 사실**입니다. #149가 "how to run an E2E"라는 형식을 택한 게 문제였지 분량이 문제였던 게 아닙니다 — 그 형식이 사실을 절차 사이에 흩어 놓았고, 절차가 부피의 대부분을 차지했습니다.

## 남긴 것

- **부트스트랩** — `mcp__node_repl__js` 경유, `browser-client.mjs` import 후 `setupBrowserRuntime()`. 안 하면 `ReferenceError: agent is not defined`
- **연산 표면** — `chrome.tabs` / `playwright` / `dev.logs` / `screenshot`. 독자 API라 유추 불가
- **`CODEX_HOME` 래퍼 함정** — 이 경로가 고장 나 보이는 1순위 원인인데 증상은 브라우저 문제로 읽힙니다
- **`scroll()`** — `undefined`(성공 모양)를 반환하면서 `scrollY`는 `0`. 스크롤 후 단언하는 흐름이 낡은 페이지를 진짜로 읽습니다
- **`type()` detach** — navigation이 로케이터를 무효화하므로 대기가 아니라 재생성이 답
- **진단 4종** — 앞의 둘은 `--check` 없이 `exit 0`으로 위장

## 버린 것

- **공유 연산 집합 표, No fallback, executor 분기, Claude 프리플라이트** — 벤더 대칭 전제와 함께 소멸. 그 표의 Claude 열은 12행 중 7행이 미측정(ᵁ)이었고, 근거 없이 열을 채운 것 자체가 대칭 요구의 산물이었습니다
- **"두 독자" 표와 중첩 codex 사건** — 파일 전체를 codex 런에 넘겼기 때문에 생긴 위험입니다. 짧아져 프롬프트에 인라인되면 원인이 사라지므로 경고도 함께 뺐습니다
- **Dia 서술과 그 정정 15줄** → `"chrome"` 명시 한 줄
- **`markDeliverable`/`markHandoff`** — 관측 효과 없음 + 세션 간 수명 미검증. 널 결과
- **ᴹ/ᵁ 증거 표기** — 벤더 대칭을 변호하던 장치. 벤더가 하나면 불필요합니다. 날짜는 썩을 수 있는 두 곳(`latest` 부동 디렉터리, 재측정 대기 중인 `scroll`)에만 남겼습니다

## 프로그레시브 디스클로저 두 층

브라우저를 쓰지 않는 `/codex` 호출에 상시로 딸려 오는 비용은 **SKILL.md 포인터 12줄**뿐입니다.

1. **`SKILL.md`** — 언제 읽을지 + 왜 읽어야 하는지 한 문장 + 경로
2. **`chrome.md` 앞부분** — Setup / Operations. 실행할 때 필요한 것
3. **`chrome.md` 뒷부분** — `When it misbehaves`. 증상별 색인, 잘못됐을 때만 읽으라고 명시

## 작업 중 나온 사실 하나

`codex-plus/scripts/codex-run.sh:133`이 `CODEX_BIN="$(command -v codex)"`로 PATH를 타고 `CODEX_HOME`을 고정하지 않습니다. **`CODEX_HOME` 함정이 이 저장소의 공인 진입점에 살아 있다**는 뜻입니다. 문서에는 "확인 책임이 호출자에게 있다"로 적었고 래퍼 자체는 이 PR에서 건드리지 않았습니다 — `-H/--codex-home` 플래그 추가는 별도 단위로 봅니다.

## 대안과 기각 이유

- **`codex-plus`에 새 스킬(`skills/codex-chrome/`)** — 호출 한 번을 더 요구하는데, 브라우저 작업은 언제나 codex 위임의 일부라 진입점이 이미 `/codex`입니다
- **`browser-e2e` 플러그인 유지, 내용만 교체** — 코덱스 전용이 된 내용에 벤더 중립 이름이 남습니다

뾰족한 E2E 사례가 생기면 그때 스킬로 세웁니다.

## 미검증

- `scroll()`이 결함인지 페이지 상호작용인지 — 평범한 긴 문서에서 한 번 재측정하면 결정됩니다
- 진단 4종의 non-zero exit 코드 — 전제를 일부러 깨 본 적이 없어 소스에서 읽은 값입니다
