### PR TITLE
remote-tmux: 워크트리 격리 세션에서 spawn 이 막히는 것을 지침에 세운다

### DIFF
--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are addressable by SendMessage and, on a launch that takes --remote-control, app-reachable (remote-spawn skill), or keep a self-restarting --spawn worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -79,6 +79,15 @@ inherits the launching shell's working directory. `--worktree` additionally requ
 directory to be inside a git repo. Keep the `cd` inside a subshell so the caller's own
 working directory survives the spawn.
 
+That `cd` is also what a **worktree-isolated launching session** cannot do. Such a session
+refuses a command whose target it cannot verify stays inside its own worktree, and this one
+lands in another repository by construction — the `cd` leaves, and `--worktree` makes the
+line read as a git operation once it arrives. The refusal is loud rather than silent, so
+nothing is lost but the attempt; what it does not admit is rephrasing, because the guard
+reads where the command lands and not how it is written. Leave the worktree first and spawn
+from the project directory. The constraint is the launcher's own isolation and not the
+target: spawning into a worktree is what `--worktree` is for, and it stays available.
+
 **The `--` is what ends option parsing.** Without it the brief is parsed as options and
 consumed silently — no error, no transcript, and a worker sits there idle having been told
 nothing. A brief that starts with a dash hits this on any launch. `--remote-control` opens a


### PR DESCRIPTION
워크트리 격리 세션에서 정규 spawn 명령이 거부되는데, 지침에 그 전제조건이 없었습니다.

## 관측

```
This session is isolated in the worktree /Users/choi/github/jongwony/cc-plugin/.claude/worktrees/...
but this command is too complex to verify that it stays inside the worktree.
Refusing to run it
```

두 번 시도해 두 번 다 같은 거부. 세 번째는 `ExitWorktree` 직후였고, **글자 하나 바꾸지 않고 성공**했습니다. 바뀐 변수는 실행 세션의 격리 여부 하나뿐입니다.

## 기제

정규 명령의 `cd`가 자기 워크트리를 떠나고, `--worktree`가 도착한 자리에서 그 줄을 git 연산으로 읽히게 만듭니다. 격리 가드는 **명령이 어디에 떨어지는지**를 보므로 표현을 바꿔 우회할 수 없습니다.

## 수리 위치

새 절을 만들지 않고 `The cd is what picks the project` 절에 붙였습니다. 그 절이 이미 `cd`의 계약을 소유하고 있고, 빠져 있던 것은 그 계약의 **전제조건**입니다 — 결함이 눈에 띈 자리(spawn 명령 블록)가 아니라 기원입니다.

## 함께 적은 것

- **제약의 방향** — 막는 것은 띄우는 쪽의 격리이지 대상이 아닙니다. 워크트리로 spawn 하는 것은 `--worktree`의 용도 그대로 남습니다. 이걸 안 적으면 다음 독자가 `--worktree`를 통째로 피하는 쪽으로 읽습니다
- **거부가 조용하지 않다는 것** — 이 파일의 다른 항목들(`--` 누락, 이름 따옴표 누락)은 조용히 실패하는 것들이라, 독자가 실패 양식을 구별할 수 있어야 합니다

## 변경

`remote-tmux/skills/remote-spawn/SKILL.md` +9줄, 버전 `5.3.0` → `5.3.1`.
