### PR TITLE
remote-tmux: spawn 대상이 관리 트리로 가는 것을 막는다

### DIFF
--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are addressable by SendMessage and, on a launch that takes --remote-control, app-reachable (remote-spawn skill), or keep a self-restarting --spawn worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -88,6 +88,15 @@ reads where the command lands and not how it is written. Leave the worktree firs
 from the project directory. The constraint is the launcher's own isolation and not the
 target: spawning into a worktree is what `--worktree` is for, and it stays available.
 
+**Where the `cd` lands is not governed by the destination's own rules.** A path-scoped rule
+binds the session working under that path, while spawning is decided from outside it, so the
+launcher never loads what the destination forbids — the guard fires later, against the
+worker's writes, once the worker is already there. The case that bites is a managed tree:
+`~/.claude/plugins/` is the plugin manager's to populate and is read-only across sessions, so
+a worker spawned there writes into it and `--worktree` leaves a registered worktree for the
+next update to contend with. Spawn into the project's own development checkout — for a
+marketplace, the repository the clone was made from rather than the clone.
+
 **The `--` is what ends option parsing.** Without it the brief is parsed as options and
 consumed silently — no error, no transcript, and a worker sits there idle having been told
 nothing. A brief that starts with a dash hits this on any launch. `--remote-control` opens a


### PR DESCRIPTION
워커를 `~/.claude/plugins/marketplaces/epistemic-protocols` 에 띄웠습니다. 그 경로는 `plugins-readonly` 규칙이 세션을 가로질러 읽기 전용으로 두는 곳이고, 개발 체크아웃은 `~/github/jongwony/epistemic-protocols` 로 따로 있었습니다. 워커는 거기서 쓰고 커밋했고, `--worktree` 가 관리 클론 안에 등록된 워크트리를 남겼습니다.

## 원인은 규칙 부재가 아닙니다

규칙은 살아 있고 옳고 강제도 됩니다 — 같은 경로를 대상으로 한 **정리 명령을 분류기가 막았습니다.**

실패한 것은 **도달**입니다.

- 경로 범위 규칙(`paths: ~/.claude/plugins/**`)은 **그 경로에서 일하는 세션**에 걸립니다
- 그런데 **그 경로로 세션을 보내는 결정**은 바깥에서 내려집니다
- 결정하는 쪽은 정의상 범위 밖이라 규칙을 로드하지 않습니다

`premise/instruction-authoring.md` 의 `Audience Reach` 가 이 실패를 이름 붙입니다 — *원칙은 대상 독자가 실제로 받는 출력에 구조적으로 심겼을 때만 행동에 영향을 준다.*

## 그래서 수리를 보내는 쪽에 붙였습니다

목적지 규칙이 아니라 spawn 결정 지점입니다. 독자가 실제로 서 있는 자리입니다.

절도 새로 만들지 않고 `The cd is what picks the project` 에 붙였습니다 — 그 절이 `cd` 가 어디로 가는지의 계약을 이미 소유합니다.

## 함께 적은 것

- **기제** — 가드가 없어서 통과한 게 아니라 **나중에 워커의 쓰기에 대고** 발화하기 때문이고, 그때는 워커가 이미 그 안에 있습니다. 이걸 안 적으면 다음 독자가 "막히지 않았으니 괜찮다"로 읽습니다
- **양성 지시를 앞세움** — 금지가 아니라 "개발 체크아웃으로 띄우라". 마켓플레이스는 클론이 아니라 클론을 뜬 저장소

## 피해

갇혔습니다 — 중복 플러그인 등록 없음, 작업물은 origin 에 있음. 남은 것은 관리 클론 안의 잠긴 워크트리와 로컬 브랜치이고, 그 정리는 **같은 규칙이 막고 있어** 사용자 몫입니다.

## 변경

`remote-tmux/skills/remote-spawn/SKILL.md` +9줄, 버전 `5.3.1` → `5.3.2`.
