### PR TITLE
text-diagram: drop the --ascii opt-in, rewrite SKILL.md agent-facing

### DIFF
--- a/text-diagram/.claude-plugin/plugin.json
+++ b/text-diagram/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "text-diagram",
   "description": "Draw directed graphs — DAGs, workflows, pipelines, dependency trees — as layered box-art you read directly in the terminal",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/text-diagram/.claude-plugin/plugin.json
+++ b/text-diagram/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "text-diagram",
   "description": "Draw directed graphs — DAGs, workflows, pipelines, dependency trees — as layered box-art you read directly in the terminal",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/text-diagram/skills/text-diagram/SKILL.md
+++ b/text-diagram/skills/text-diagram/SKILL.md
@@ -10,76 +10,39 @@ description: |
 
 # Text Diagram
 
-Turn a directed graph — most often a workflow or DAG — into a layered box-art diagram you
-can read straight in the terminal. The whole point is to make a branching process *legible
-at a glance* without reaching for an image renderer or a browser.
+Render a directed graph as a layered box-art diagram read directly in the terminal.
 
-## Before you draw
+## Before drawing
 
-Four checks, in order. The first two decide *whether* to draw; the last two decide *how big*.
+- Reader must hold several relationships at once → draw. A three-node chain → write the sentence instead.
+- Two nodes that always appear and disappear together → one node with a compound name.
+- Widest layer must satisfy `Σ(label lengths) + 4n + 3(n−1) ≤ W`, where `W` is the reading
+  terminal's width. Over budget → shorten labels first, then split the graph. `render.py`
+  reads `W` at invocation and warns past it, falling back to 80 when it cannot be detected.
+- Running the script on the user's behalf → the detected width is the tool's own pty, not the
+  user's window. Real reading width known → pass `--width N`.
+- Fix the detail level before drawing; above a ceiling it is two diagrams:
+  - `faithful` — ≤24 nodes, split into stages; the reader will check the picture against the real system.
+  - `balanced` — ≤12 nodes; default; explaining how something works.
+  - `simplified` — ≤7 nodes; the shape is the point.
 
-1. **Would a well-written sentence beat this picture?** A three-node chain is a sentence.
-   Draw when the reader has to hold several relationships at once — that is what prose is
-   bad at and a picture is good at.
-2. **Merge nodes that always travel together.** Two boxes that appear and disappear as a
-   pair are one box with a compound name. Every node should stand for a distinct idea.
-3. **Fit the width budget: `Σ(label lengths) + 4n + 3(n−1) ≤ W` for the widest layer,**
-   where `W` is the reading terminal's width. The terminal hard-wraps anything past it and
-   a wrapped drawing is unreadable, so this is the one hard constraint. `render.py` reads
-   `W` at invocation and warns past it, falling back to 80 only when the width cannot be
-   detected. Label length eats the budget as fast as sibling count does, so shortening
-   names is usually the cheaper fix — read that off the formula rather than off a table
-   of sibling counts, which would only be true at one `W`.
+## Emphasis
 
-   When the skill runs the script on the user's behalf, the detected width is the tool's
-   own pty rather than the user's window — usually narrower, so the check errs
-   conservative. Pass `--width` when you know the real reading width.
-4. **Pick a detail level before drawing, not after.**
-
-   | Level | Node ceiling | Use when |
-   |---|---|---|
-   | `faithful` | ≤24, split into stages | The reader will check the picture against the real system |
-   | `balanced` (default) | ≤12 | Explaining how something works |
-   | `simplified` | ≤7 | The shape is the point and details would distract |
-
-   Above the ceiling it is two diagrams, not one crowded one.
-
-## Emphasis: strokes, because there is no colour
-
-Assistant output reaches the terminal as plain characters — escape sequences are consumed
-before they become cells, so **no colour is available to mark a focal node**. Emphasis is
-carried by stroke weight instead: `--focus <node>` draws that box with `┏━┓┃┗┛`.
-
-**Use one focal node.** Heavy strokes contrast far less than colour would, so the signal
-dies faster: mark five of six boxes and "focus" stops meaning anything. If two things
-genuinely compete for the reader's eye, that is usually a sign the graph should be split.
+- Colour does not survive to the terminal, so emphasis is stroke weight: `--focus <node>`
+  draws that box with `┏━┓┃┗┛`.
+- One focal node per diagram. Two nodes genuinely competing for the eye → split the graph.
 
 ## Choosing a rendering path
 
-There are three ways to render, in priority order. The first works on any machine and is
-the default; the others are situational. Prefer the bundled script unless you have a
-specific reason not to — it is environment-neutral, which matters because a teammate
-running this skill may not have graph-easy installed (cc-plugin's Environment-neutrality
-principle: a skill must work even when an optional external tool is absent).
+- Default → bundled `render.py`. Stdlib via uv, no external packages; lays the graph out
+  top-to-bottom by longest-path layers; fits the fan-out / fan-in workflow shape.
+- Graph is a tangle rather than a hierarchy and `command -v graph-easy` succeeds →
+  `graph-easy --as_boxart`.
+- Same tangle and graph-easy absent → name the install cost (`cpanm Graph::Easy`, or
+  `apt install libgraph-easy-perl`) and let the user choose. Simple graph → stay on `render.py`.
+- Three or four nodes, used once → write the boxes by hand in a `cat <<'EOF'` block.
 
-1. **Bundled `render.py` (default).** Pure Python stdlib via uv — no external packages.
-   Lays a graph out top-to-bottom by longest-path layers. Best for the common workflow
-   shape: one source fanning out to N parallel stages that fan back into one.
-
-2. **graph-easy (optional upgrade).** If `graph-easy` is on PATH, it produces nicer
-   automatic routing for dense or heavily-crossing graphs. Detect it first
-   (`command -v graph-easy`); only suggest installing it when the graph is genuinely too
-   tangled for the layered renderer (see *Limits* below). It is a Perl module
-   (`cpanm Graph::Easy`, or `apt install libgraph-easy-perl`), so installation is a real
-   cost — do not push it for simple graphs.
-
-3. **Hand-drawn heredoc (one-off).** For a three- or four-node sketch you will never reuse,
-   just write the boxes by hand in a `cat <<'EOF'` block. Faster than any tool when the
-   graph is trivial and disposable.
-
-## Default path: render.py
-
-Feed it an edge list on stdin (or pass a file path):
+## Running render.py
 
 ```bash
 uv run ${CLAUDE_PLUGIN_ROOT}/skills/text-diagram/scripts/render.py <<'EOF'
@@ -89,136 +52,66 @@ verify -> Synthesize -> report
 EOF
 ```
 
-### Input grammar
+A file path as a positional arg replaces stdin.
 
-One edge statement per line. The grammar is deliberately small so it is quick to type and
-also tolerant of pasted DOT.
+### Edge grammar
+
+One statement per line.
 
 - `A -> B` — a single edge.
 - `A -> B -> C` — a chain; expands to `A->B` and `B->C`.
-- `A, B -> C` — comma groups on either side; expands to the cross product (`A->C`, `B->C`).
-- `LoneNode` — a bare token with no arrow declares an isolated node.
-- DOT noise is stripped: surrounding quotes, a trailing `;`, `[label=...]` attribute
-  blocks, and `digraph foo {` / `}` wrappers are all ignored, so you can paste a `.dot`
-  body directly.
+- `A, B -> C` — comma groups on either side; expands to the cross product.
+- `LoneNode` — a bare token declares an isolated node.
+- Surrounding quotes, a trailing `;`, `[label=...]` blocks, and `digraph foo {` / `}` on their
+  own lines are stripped, so a `.dot` body pastes in directly.
 - Blank lines and `#` comments are ignored.
 
 ### Flags
 
-| Flag | Effect |
-|------|--------|
-| `--gutter N` | Horizontal space between sibling boxes (default `3`). Widen it if labels look cramped. |
-| `--focus A[,B]` | Draw the named node(s) with heavy strokes. Keep it to one — see *Emphasis* above. |
-| `--width N` | Column budget to warn past. Defaults to the detected terminal width (80 when undetectable); `0` disables the check. |
-
-### What the output looks like
-
-The fan-out / fan-in example above renders as:
-
-```
-                ┌───────────┐
-                │ diff/fate │
-                └───────────┘
-      ┌────────────┬──┴───────┬──────────┐
-      │            │          │          │
-┌──────────┐   ┌──────┐   ┌───────┐   ┌─────┐
-│ Category │   │ Type │   │ OpSem │   │ Gap │
-└──────────┘   └──────┘   └───────┘   └─────┘
-      └────────────┴──┬───────┴──────────┘
-                      │
-                 ┌────────┐
-                 │ verify │
-                 └────────┘
-                      │
-               ┌────────────┐
-               │ Synthesize │
-               └────────────┘
-                      │
-                 ┌────────┐
-                 │ report │
-                 └────────┘
-```
+- `--gutter N` — horizontal space between sibling boxes, default `3`; widen when labels look cramped.
+- `--focus A[,B]` — heavy strokes on the named node(s); keep it to one.
+- `--width N` — column budget to warn past; defaults to the detected terminal width (80 when
+  undetectable), `0` disables the check.
 
 ## Translating a Workflow script into an edge list
 
-A frequent use is picturing the control flow of a `Workflow` script (the `pipeline()` /
-`parallel()` orchestration primitives). Map the primitives to edges like this, then pipe
-the result into `render.py`:
-
-- **`pipeline(items, stageA, stageB, ...)`** is a chain per item: `item -> stageA -> stageB`.
-  When every item flows through the same named stages, collapse to one chain of stage names.
-- **`parallel([f1, f2, f3])`** is a fan-out from the node that spawned it to each thunk, then
-  (if the results are later combined) a fan-in to the consuming node.
-- A **barrier** (results awaited together before the next stage) is a fan-in: `s1, s2, s3 -> next`.
-- Name nodes after what they *do* (`review:bugs`, `verify`, `synthesize`), not the variable
-  that holds them — the picture is for a human.
-
-Read the script's `phase()` calls and the shape of its `parallel`/`pipeline` calls, write the
-edges, and render. This recovers the fan-out → verify → fan-in skeleton that the prose of a
-script hides.
+- `pipeline(items, stageA, stageB, ...)` → a chain per item, `item -> stageA -> stageB`. Every
+  item flowing through the same named stages → collapse to one chain of stage names.
+- `parallel([f1, f2, f3])` → a fan-out from the spawning node to each thunk; results later
+  combined → a fan-in to the consuming node.
+- Results awaited together before the next stage → a fan-in, `s1, s2, s3 -> next`.
+- Node names come from what the step does (`review:bugs`, `verify`), not from the variable holding it.
+- Read the shape off the script's `phase()` calls and the nesting of its `parallel` / `pipeline` calls.
 
 ## Delivering the drawing
 
-Emit the diagram **inside a fenced code block with no language tag**. Three separate things
-go wrong otherwise:
-
-- In prose, `*`, `_` and `|` are eaten as inline markdown, and a line indented four spaces
-  silently becomes a code block of its own.
-- A language tag routes the content through the syntax highlighter, which recolours box
-  characters. No tag means the highlighter runs a grammar that assigns nothing, so the
-  drawing comes out uniform.
-- Inside a table cell the content is still markdown, so backticks pick up inline-code
-  styling. Never wrap diagram characters in backticks.
-
-The fence buys verbatim indentation and immunity from inline markdown. It does **not** buy
-overflow protection — every line is still hard-wrapped at the terminal's width, which is
-why the width budget above is the constraint that actually matters.
+- Emit the drawing in a fenced code block with no language tag.
+- Block level only: a drawing is never a table cell's content and never an inline-code span.
+- The fence buys verbatim indentation, not overflow protection — the width budget above is the
+  constraint that binds.
 
 ## Limits — and when to escalate
 
-The layered renderer optimises for hub-style graphs. Two honest limitations, surfaced rather
-than hidden:
-
-- **Cross-layer edges are listed, not drawn.** An edge that skips a layer (e.g. `start -> end`
-  when `end` is three layers down) is printed in a `cross-layer edges (not drawn above)` note
-  beneath the diagram. This keeps the picture truthful instead of routing a misleading line.
-- **Dense crossings are approximate.** Between two layers the connectors are drawn as a single
-  shared bus, which is exactly right for fan-out/fan-in but only indicative when many edges
-  cross each other. If the graph is a tangle rather than a hierarchy, switch to graph-easy
-  (`graph-easy --as_boxart`) or graphviz (`dot -Tplain` rasterised, or just `dot -Tpng` for an
-  image) — both do real edge routing.
-
-If a graph has cycles, the renderer still lays it out (back-edges are treated as layer-0
-contributions) but the result reads better as a tree than as a faithful cyclic graph; note
-this to the user and offer graph-easy.
-
-Every limit on this page is rendered as a worked case in [`references/catalog.md`](references/catalog.md) — the over-budget notice, the
-shared connector bus, the undrawn cross-layer edge, the cycle laid out as a tree,
-and the CJK misalignment below. Read a case there rather than picturing it from
-the prose; `uv run scripts/catalog.py --check` is what keeps it true.
+- Edge skipping a layer → listed under `cross-layer edges (not drawn above)` beneath the diagram
+  rather than routed.
+- Many edges crossing each other → the shared connector bus is indicative only; tangle rather than
+  hierarchy → `graph-easy --as_boxart`, or graphviz (`dot -Tpng`).
+- Graph has cycles → it still lays out, back edges contributing layer 0, and reads as a tree; say
+  so to the user and offer graph-easy.
+- Every limit above is a worked case in [`references/catalog.md`](references/catalog.md) — read the
+  case there. `uv run scripts/catalog.py --check` is what keeps those cases true.
 
 ### Input envelope
 
-The renderer targets graphs small enough to read in a terminal — the kind you can specify
-inline — so a few input boundaries are accepted rather than engineered around:
-
-- **Labels are measured by character count, not display width, and this is deliberate.**
-  Box width is `len(label) + 4`, so CJK and emoji labels overflow their boxes and the
-  connectors drift. Measuring display width instead would put a third measurer alongside
-  the harness and the terminal, which already disagree in edge cases — so the renderer
-  stays with one simple rule and documents the limit rather than chasing agreement it
-  cannot guarantee. Use single-cell Latin labels when alignment matters.
-- **Very deep chains recurse.** Layering is computed recursively, so a single chain longer
-  than Python's recursion limit (~1000 nodes) raises `RecursionError`. Graphs that fit in a
-  terminal never approach this; for machine-scale DAGs, use graphviz.
-- **DOT wrappers must be multi-line.** `digraph foo {` and `}` are stripped only when each is
-  on its own line; a one-line `digraph G { A -> B }` is parsed literally and yields junk nodes.
-  Split the wrapper across lines, or drop it and feed the bare edges.
+- Box width is `len(label) + 4` measured in characters, so CJK and emoji labels overflow their
+  boxes and the connectors drift → use single-cell Latin labels when alignment matters.
+- Single chain longer than Python's recursion limit (~1000 nodes) → `RecursionError`;
+  machine-scale DAGs → graphviz.
+- `digraph foo {` and `}` are stripped only when each is on its own line; a one-line
+  `digraph G { A -> B }` yields junk nodes → split the wrapper across lines, or feed the bare edges.
 
 ## Files
 
-| File | Purpose |
-|------|---------|
-| `scripts/render.py` | Layered box-art renderer. Stdlib-only, runs via `uv run`. Reads an edge list from stdin or a file. |
-| `scripts/catalog.py` | Regenerates the rendering catalog from its own scenario list. `--write` to rebuild, `--check` to fail on drift. |
-| `references/catalog.md` | Every catalogued scenario rendered at 80 columns — generated, not hand-written. |
+- `scripts/render.py` — the renderer; stdlib-only, runs via `uv run`, reads an edge list from stdin or a file.
+- `scripts/catalog.py` — regenerates the catalog from its own scenario list; `--write` rebuilds, `--check` fails on drift.
+- `references/catalog.md` — every catalogued scenario rendered at 80 columns; generated, not hand-written.

--- a/text-diagram/skills/text-diagram/SKILL.md
+++ b/text-diagram/skills/text-diagram/SKILL.md
@@ -48,8 +48,7 @@ Four checks, in order. The first two decide *whether* to draw; the last two deci
 
 Assistant output reaches the terminal as plain characters — escape sequences are consumed
 before they become cells, so **no colour is available to mark a focal node**. Emphasis is
-carried by stroke weight instead: `--focus <node>` draws that box with `┏━┓┃┗┛` (`=` under
-`--ascii`).
+carried by stroke weight instead: `--focus <node>` draws that box with `┏━┓┃┗┛`.
 
 **Use one focal node.** Heavy strokes contrast far less than colour would, so the signal
 dies faster: mark five of six boxes and "focus" stops meaning anything. If two things
@@ -74,7 +73,7 @@ principle: a skill must work even when an optional external tool is absent).
    (`cpanm Graph::Easy`, or `apt install libgraph-easy-perl`), so installation is a real
    cost — do not push it for simple graphs.
 
-3. **Hand-ASCII heredoc (one-off).** For a three- or four-node sketch you will never reuse,
+3. **Hand-drawn heredoc (one-off).** For a three- or four-node sketch you will never reuse,
    just write the boxes by hand in a `cat <<'EOF'` block. Faster than any tool when the
    graph is trivial and disposable.
 
@@ -108,7 +107,6 @@ also tolerant of pasted DOT.
 
 | Flag | Effect |
 |------|--------|
-| `--ascii` | Use `+ - |` instead of unicode box characters — for terminals that mangle UTF-8. |
 | `--gutter N` | Horizontal space between sibling boxes (default `3`). Widen it if labels look cramped. |
 | `--focus A[,B]` | Draw the named node(s) with heavy strokes. Keep it to one — see *Emphasis* above. |
 | `--width N` | Column budget to warn past. Defaults to the detected terminal width (80 when undetectable); `0` disables the check. |
@@ -209,7 +207,7 @@ inline — so a few input boundaries are accepted rather than engineered around:
   connectors drift. Measuring display width instead would put a third measurer alongside
   the harness and the terminal, which already disagree in edge cases — so the renderer
   stays with one simple rule and documents the limit rather than chasing agreement it
-  cannot guarantee. Use ASCII/Latin labels when alignment matters.
+  cannot guarantee. Use single-cell Latin labels when alignment matters.
 - **Very deep chains recurse.** Layering is computed recursively, so a single chain longer
   than Python's recursion limit (~1000 nodes) raises `RecursionError`. Graphs that fit in a
   terminal never approach this; for machine-scale DAGs, use graphviz.
@@ -221,6 +219,6 @@ inline — so a few input boundaries are accepted rather than engineered around:
 
 | File | Purpose |
 |------|---------|
-| `scripts/render.py` | Layered box-art / ASCII renderer. Stdlib-only, runs via `uv run`. Reads an edge list from stdin or a file. |
+| `scripts/render.py` | Layered box-art renderer. Stdlib-only, runs via `uv run`. Reads an edge list from stdin or a file. |
 | `scripts/catalog.py` | Regenerates the rendering catalog from its own scenario list. `--write` to rebuild, `--check` to fail on drift. |
 | `references/catalog.md` | Every catalogued scenario rendered at 80 columns — generated, not hand-written. |

--- a/text-diagram/skills/text-diagram/references/catalog.md
+++ b/text-diagram/skills/text-diagram/references/catalog.md
@@ -18,9 +18,8 @@ renderer change has moved any output.
 | 7 | [Edge that skips a layer](#cross-layer) | `start -> end` jumps past the middle. |
 | 8 | [Back edge](#cycle) | Layering is cycle-safe (back edges contribute 0), so this lays out — but it reads as a tree, not as a loop. |
 | 9 | [One focal node](#focus) | Heavy strokes carry emphasis because assistant output reaches the terminal as plain characters and no colour survives. |
-| 10 | [ASCII fallback](#ascii) | Same graph with `--ascii`, for terminals that mangle UTF-8 box characters. |
-| 11 | [CJK labels misalign — a known limit](#cjk) | Box width is len(label) + 4, and CJK characters occupy two terminal cells, so these boxes come out narrower than their contents and the connectors drift. |
-| 12 | [Pasted DOT body](#dot-paste) | Quotes, trailing semicolons, `[label=. |
+| 10 | [CJK labels misalign — a known limit](#cjk) | Box width is len(label) + 4, and CJK characters occupy two terminal cells, so these boxes come out narrower than their contents and the connectors drift. |
+| 11 | [Pasted DOT body](#dot-paste) | Quotes, trailing semicolons, `[label=. |
 
 <a id="fan"></a>
 
@@ -278,31 +277,6 @@ plan -> build, test, ship
 ┌───────┐   ┏━━━━━━┓   ┌──────┐
 │ build │   ┃ test ┃   │ ship │
 └───────┘   ┗━━━━━━┛   └──────┘
-```
-
-<a id="ascii"></a>
-
-## ASCII fallback
-
-Same graph with `--ascii`, for terminals that mangle UTF-8 box characters.
-
-**Input** — `--ascii`
-
-```
-plan -> build, test, ship
-```
-
-**Output**
-
-```
-           +------+
-           | plan |
-           +------+
-    +----------++----------+
-    |           |          |
-+-------+   +------+   +------+
-| build |   | test |   | ship |
-+-------+   +------+   +------+
 ```
 
 <a id="cjk"></a>

--- a/text-diagram/skills/text-diagram/scripts/catalog.py
+++ b/text-diagram/skills/text-diagram/scripts/catalog.py
@@ -108,13 +108,6 @@ SCENARIOS = [
         {"focus": {"test"}},
     ),
     (
-        "ascii",
-        "ASCII fallback",
-        "Same graph with `--ascii`, for terminals that mangle UTF-8 box characters.",
-        "plan -> build, test, ship",
-        {"ascii_mode": True},
-    ),
-    (
         "cjk",
         "CJK labels misalign — a known limit",
         "Box width is len(label) + 4, and CJK characters occupy two terminal cells, "
@@ -160,8 +153,6 @@ def build():
         nodes, edges = parse_edges(text)
         drawing = render(nodes, edges, width_budget=WIDTH, **kw)
         flags = []
-        if kw.get("ascii_mode"):
-            flags.append("--ascii")
         if kw.get("focus"):
             flags.append("--focus " + ",".join(sorted(kw["focus"])))
         out += [

--- a/text-diagram/skills/text-diagram/scripts/render.py
+++ b/text-diagram/skills/text-diagram/scripts/render.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.8"
 # dependencies = []
 # ///
-"""Render a directed graph (DAG) as a layered box-art / ASCII diagram in the terminal.
+"""Render a directed graph (DAG) as a layered box-art diagram in the terminal.
 
 Zero external dependencies — pure stdlib, so it works on any machine with uv/python.
 Best for hub-style fan-out / fan-in (the common workflow shape: one source feeding N
@@ -23,7 +23,6 @@ blocks, and `digraph foo {` / `}` wrappers are stripped. Blank lines and `#` com
 are ignored.
 
 Flags:
-    --ascii     use +-|  instead of unicode box characters (for non-UTF8 terminals)
     --gutter N  horizontal space between sibling boxes (default 3)
 """
 import sys
@@ -90,13 +89,7 @@ def compute_layers(nodes, edges):
     return layer
 
 
-def junction(up, down, left, right, ascii_mode):
-    if ascii_mode:
-        if not up and not down:
-            return "-"
-        if not left and not right:
-            return "|"
-        return "+"
+def junction(up, down, left, right):
     return {
         (1, 0, 1, 1): "┴", (1, 0, 1, 0): "┘", (1, 0, 0, 1): "└",
         (0, 1, 1, 1): "┬", (0, 1, 1, 0): "┐", (0, 1, 0, 1): "┌",
@@ -106,7 +99,7 @@ def junction(up, down, left, right, ascii_mode):
     }.get((up, down, left, right), "┼")
 
 
-def render(nodes, edges, ascii_mode=False, gutter=3, focus=(), width_budget=None):
+def render(nodes, edges, gutter=3, focus=(), width_budget=None):
     if not nodes:
         return "(empty graph)"
     layer = compute_layers(nodes, edges)
@@ -151,11 +144,11 @@ def render(nodes, edges, ascii_mode=False, gutter=3, focus=(), width_budget=None
     top_row = lambda L: L * (BOX_H + BAND_H)
 
     # draw boxes
-    h, v = ("-", "|") if ascii_mode else ("─", "│")
+    v = "│"
     # Heavy strokes are the only emphasis channel: assistant output reaches the
     # terminal as plain characters, so no colour is available to mark a focus.
-    light = ("-", "|", "+", "+", "+", "+") if ascii_mode else ("─", "│", "┌", "┐", "└", "┘")
-    heavy = ("=", "|", "+", "+", "+", "+") if ascii_mode else ("━", "┃", "┏", "┓", "┗", "┛")
+    light = ("─", "│", "┌", "┐", "└", "┘")
+    heavy = ("━", "┃", "┏", "┓", "┗", "┛")
     for L, r in enumerate(rows):
         t = top_row(L)
         for n in r:
@@ -188,14 +181,13 @@ def render(nodes, edges, ascii_mode=False, gutter=3, focus=(), width_budget=None
         for c in range(lo, hi + 1):
             up = c in parents
             down = c in children
-            grid[bus][c] = junction(up, down, c > lo, c < hi, ascii_mode)
+            grid[bus][c] = junction(up, down, c > lo, c < hi)
         for c in children:
             put(drop, c, v)
 
     out = "\n".join("".join(row).rstrip() for row in grid)
     if cross:
-        arrow = "-->" if ascii_mode else "⇢"
-        note = "\n".join(f"  {a} {arrow} {b}" for a, b in cross)
+        note = "\n".join(f"  {a} ⇢ {b}" for a, b in cross)
         out += f"\n\ncross-layer edges (not drawn above):\n{note}"
     if width_budget and canvas_w > width_budget:
         widest = max(rows, key=line_w)
@@ -209,9 +201,8 @@ def render(nodes, edges, ascii_mode=False, gutter=3, focus=(), width_budget=None
 
 
 def main():
-    ap = argparse.ArgumentParser(description="Render a DAG as layered box-art ASCII.")
+    ap = argparse.ArgumentParser(description="Render a DAG as layered box-art.")
     ap.add_argument("file", nargs="?", help="edge-list file (default: stdin)")
-    ap.add_argument("--ascii", action="store_true", help="use +-| instead of box chars")
     ap.add_argument("--gutter", type=int, default=3, help="space between sibling boxes")
     ap.add_argument("--focus", default="",
                     help="comma-separated node(s) to draw with heavy strokes; keep it to one")
@@ -225,7 +216,7 @@ def main():
     # Read the budget at invocation: the terminal's own width is the constraint,
     # and 80 is only what to fall back to when it cannot be read.
     width = args.width if args.width is not None else shutil.get_terminal_size((80, 24)).columns
-    print(render(nodes, edges, ascii_mode=args.ascii, gutter=args.gutter,
+    print(render(nodes, edges, gutter=args.gutter,
                  focus=focus, width_budget=width))
 
 


### PR DESCRIPTION
Two commits on one branch: the `--ascii` removal, then the SKILL.md rewrite the global Externalization rule asks for.

---

## 1. Drop the `--ascii` opt-in (`64df655`)

The renderer draws unicode box characters unconditionally; the flag is now rejected by argparse.

- `scripts/render.py` — `--ascii` flag gone, `ascii_mode` threaded out of `render()` / `junction()`, `+ - |` and `=` stroke sets gone, cross-layer arrow is `⇢` outright.
- `scripts/catalog.py` — scenario 10 "ASCII fallback" removed; 12 cases → 11.
- `references/catalog.md` — regenerated by `catalog.py --write`.
- `SKILL.md` — flag row, the `(= under --ascii)` aside on `--focus`, "Hand-ASCII heredoc" → "Hand-drawn heredoc".

**Why.** An opt-in flag is an instruction the model reads on every invocation. `--ascii` carried its own trigger condition — *"for terminals that mangle UTF-8"* — on a surface the model sees, about a terminal the model cannot inspect. The white bear followed: the flag's presence kept degraded `+ - |` output a live option in sessions where box-art rendered fine. Narrowing the condition does not help, because the option stays visible; a *"do not use unless"* note restates the bear. Removing the option is the repair that holds.

**Kept deliberately** — the two `"ASCII"` strings in the skill `description`. Those are quoted **user** utterances used for activation matching, not a mode the model selects; someone asking to "render as ASCII" means "draw it in the terminal".

## 2. Rewrite SKILL.md to the agent-facing form (`bb636ce`)

224 lines → 117, operative content unchanged.

The global Externalization rule makes a skill directory agent-facing everywhere except `README.md`, and an agent-facing surface carries one bullet per condition or moment — state, trigger, and the command or reference it resolves to — with no narrative, no diagrams, no tables whose cells hold sentences, and rationale routed to the ledger. SKILL.md was written the other way: an opening paragraph on what the skill is for, three sentence-celled tables (detail levels, flags, files), a rendered sample diagram, and about half its length explaining why each rule holds.

Every command, threshold, formula and escalation trigger survives verbatim — the width budget and its pty caveat, `--width/--gutter/--focus`, the detail-level ceilings, `command -v graph-easy`, `graph-easy --as_boxart`, the install cost, `RecursionError`, the one-line-`digraph` junk-node case, the fence rule, the catalog pointer and `catalog.py --check`.

**Three real subtractions**, each retiring something rather than reformatting it:

- The "What the output looks like" sample drawing — `references/catalog.md` renders that exact fan-out/fan-in case and ten others, and the page already told the reader to go there instead of picturing it from prose.
- The environment-neutrality justification for preferring the bundled renderer — the preference stays; the reason moved to the ledger.
- `dot -Tplain` as a second graphviz escalation — one command per limit is what the decision point needs.

**Left in place deliberately** — `catalog.py`'s per-scenario `why` captions, which reach `references/catalog.md`. Those are an on-demand reference's captions, not a loaded instruction, and Inscription Economics scales strictness with read frequency. Tightening them is a separate judgment about a generated file.

## Verification

- `uv run scripts/catalog.py --check` → `catalog up to date (11 cases)`
- `render.py --focus test --width 80` → box-art with heavy strokes, unchanged
- `render.py --ascii` → `error: unrecognized arguments: --ascii`
- `.githooks/check-version-bump.sh` → exit 0 at each commit (0.5.0 → 0.6.0 → 0.6.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5qfkifNhhNMBkSibigX4y
