### PR TITLE
codex-plus: default to gpt-6-astra at medium, re-point the prompting guide

### DIFF
--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/scripts/codex-run.sh
+++ b/codex-plus/scripts/codex-run.sh
@@ -12,12 +12,20 @@ set -euo pipefail
 CDPATH=
 
 # Defaults
-readonly DEFAULT_MODEL="gpt-5.6-sol"
-# high is a floor, not a ceiling. Raising effort is a per-call judgment made
-# from the task in front of the caller; a default cannot read the task, so
-# pinning the top of the ladder here spends it on every run that never
-# needed it. Callers escalate to xhigh or max deliberately.
-readonly DEFAULT_EFFORT="high"
+readonly DEFAULT_MODEL="gpt-6-astra"
+# medium is a starting point, not a ceiling. Raising effort is a per-call
+# judgment made from the task in front of the caller; a default cannot read the
+# task, so pinning the top of the ladder here spends it on every run that never
+# needed it. OpenAI's own guidance for the current generation is to start at
+# medium and compare against neighbours on representative work rather than
+# assume the highest effort wins. astra is a more capable model than the sol
+# default it replaced, so the same work lands at a lower rung than it used to.
+# Callers escalate to high, xhigh or max deliberately.
+#
+# astra's ladder is low|medium|high|xhigh|max. It has no `none` rung, unlike
+# the gpt-5.6 family — passing one is codex's error to report, not this
+# script's to pre-empt.
+readonly DEFAULT_EFFORT="medium"
 # workspace-write, not read-only, for one reason: the network. codex exposes no
 # network switch under read-only — the toggle lives in the
 # sandbox_workspace_write table and does nothing while the mode is read-only
@@ -40,9 +48,10 @@ usage() {
 Usage: codex-run.sh [options] <prompt_file>
 
 Options:
-  -m, --model MODEL      Model name (default: gpt-5.6-sol)
-  -r, --effort EFFORT    Reasoning effort: medium|high|xhigh|max (default: high,
-                         a floor rather than a ceiling — escalate per task)
+  -m, --model MODEL      Model name (default: gpt-6-astra)
+  -r, --effort EFFORT    Reasoning effort: low|medium|high|xhigh|max (default:
+                         medium, a starting point rather than a ceiling —
+                         escalate per task. astra has no `none` rung)
   -s, --sandbox SANDBOX  Sandbox: read-only|workspace-write|danger-full-access
                          (default: workspace-write, which this wrapper always
                          runs with network access enabled, and which already
@@ -67,7 +76,7 @@ no most-recent fallback, so it is never a race under parallel sessions.
 
 Examples (<scratchpad> = the calling session's scratchpad directory):
   codex-run.sh <scratchpad>/codex_prompt_a3f9.txt
-  codex-run.sh -m gpt-5.6-terra -r xhigh <scratchpad>/codex_prompt_a3f9.txt
+  codex-run.sh -m gpt-5.6-sol -r xhigh <scratchpad>/codex_prompt_a3f9.txt
   codex-run.sh -S 019e3eff-c191-7401-bffb-bb8c31ac37c7 <scratchpad>/codex_prompt_a3f9.txt
 USAGE
   exit "${1:-0}"

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -71,16 +71,17 @@ When the delegated task is image generation or image editing:
 - Use `references/image-gen-models-prompting-guide.ipynb` only as the backing reference for model choice, prompt structure, text rendering, edits, and multi-image workflows.
 
 ## Running a Task
-1. Run on `gpt-5.6-sol` at `high` unless the caller named otherwise. Designation normally arrives upstream, in the request itself, so a model or effort already named there IS the answer — do not re-ask it.
+1. Run on `gpt-6-astra` at `medium` unless the caller named otherwise. Designation normally arrives upstream, in the request itself, so a model or effort already named there IS the answer — do not re-ask it.
 
    Ask (via `AskUserQuestion`, a **single prompt with two questions**; model selection is **multi-select**, so several models can run in parallel) only where the choice is genuinely open: neither model nor effort was named, and the task's shape does not settle them.
 
    Models:
-   - `gpt-5.6-sol` — the default, used whenever no model was named.
-   - `gpt-5.6-terra` — balanced 5.6 variant; lighter usage, faster than Sol, same effort ladder.
+   - `gpt-6-astra` — the default, used whenever no model was named. OpenAI's most capable model, for complex and demanding end-to-end work. It is also what `~/.codex/config.toml` already selects for interactive codex, so a run through this wrapper and a run the user starts by hand now land on the same model.
+   - `gpt-5.6-sol` — the previous default; a reliable agentic workhorse for everyday tasks. The pick when capability is not what the task is short of, and astra's per-token cost is not worth paying.
+   - `gpt-5.6-terra` — balanced agentic coding model; lighter usage, faster than Sol, same effort ladder.
    - `gpt-5.6-luna` — a "Fast and affordable agentic coding model" in codex's own registry; the cost-efficient pick for browser / computer-use E2E runs and implementation work that writes a lot of code, usually at `xhigh`.
 
-   Reasoning effort is selected once and applied identically to all chosen models. `high` is the wrapper's default and the floor here — raise it to `xhigh` or `max` where the task's reasoning depth warrants, and do not go below `high`.
+   Reasoning effort is selected once and applied identically to all chosen models. `medium` is the wrapper's default and the starting point here — raise it to `high`, `xhigh` or `max` where the task's reasoning depth warrants. astra's ladder is `low|medium|high|xhigh|max` and has no `none` rung. `low` exists but is for latency-bound work; runs from this skill are unattended, where a cheap wrong answer costs a resume rather than saving time.
 
 2. Select sandbox mode. Omitting `-s` gives `workspace-write` **with network access** — codex offers no network under `read-only` at all, so this is the only mode short of full access that has any. Pass `-s read-only` when a run must neither touch the tree nor reach off-machine; `-s danger-full-access` only when it must write outside the workspace. Because the default already permits writes, what bounds a run that is meant to only read is the role its prompt declares — state it.
 3. Craft prompt per Context Classification and Prompt Template — classify context, write to `<scratchpad>/codex_prompt_<suffix>.txt`.
@@ -104,7 +105,7 @@ Base patterns:
 
 Modifiers, added to any base pattern above:
 - Different working directory — `-C <DIR>`; pass it again on resume (step 6)
-- Model and effort — `-m gpt-5.6-terra`, `-r xhigh` (effort defaults to `high`; `-r` raises it)
+- Model and effort — `-m gpt-5.6-sol`, `-r xhigh` (effort defaults to `medium`; `-r` raises it)
 - Capture the answer to a file — `-o <FILE>` writes codex's final message to FILE deterministically
 
 ## Following Up
@@ -117,22 +118,24 @@ After `codex` completes, use `AskUserQuestion` to confirm next steps. Restate mo
 
 ## Reference Guide
 
-Read the reference when detailed GPT-5.4 prompting guidance is needed.
+Read the reference before writing a prompt for `gpt-6-astra`, and again whenever a
+run came back having stopped early or asked a question instead of deciding.
 
-**File**: `references/gpt-5-4_prompting_guide.md`
+**File**: `references/gpt-6-astra_prompting_guide.md`
 
 Key sections (grep patterns for navigation):
-- `Where GPT-5.4 is strongest` - Strengths: tone adherence, agentic robustness, evidence-rich synthesis, long-context analysis
-- `Where explicit prompting still helps` - Weak spots: low-context tool routing, dependency-aware workflows, reasoning effort selection
-- `Keep outputs compact` - Token efficiency via `<output_contract>` and `<verbosity_controls>` blocks
-- `tool_persistence_rules` - Persistent tool use, dependency checks, parallel tool calling
-- `completeness_contract` - Long-horizon task coverage and `<empty_result_recovery>` fallback
-- `verification_loop` - Pre-commit verification, missing context gating, action safety
-- `research_mode` - 3-pass research (plan → retrieve → synthesize) with citation rules
-- `Prompting patterns for coding tasks` - Autonomy, persistence, intermediary updates, formatting, frontend tasks
-- `Treat reasoning effort as a last-mile knob` - reasoning_effort selection: none/low/medium/high/xhigh guidance
-- `phase` - Responses API phase parameter for long-running agents
-- `Compaction` - Extended context management via `/responses/compact` endpoint
+- `## Model facts` - effort ladder, context window, knowledge cutoff, price, parameters to stop sending
+- `## Autonomy and stop conditions` - astra asks non-blocking questions by default; what an unattended `codex exec` prompt has to state in place of that
+- `## Instruction priority` - astra weighs in-context material more heavily, and conflicting guidance in a skill file stops work early
+- `## Context discipline` - why this skill's pointer-over-copy rule matters more under astra rather than less
+- `## Reconcile before switching` - what to send when astra's answer contradicts evidence already in hand
+- `## Choosing an effort rung` - reading the rung off the task instead of off habit
+- `## Subagents` - what a spawned agent inherits, and how to override it
+
+**Historical**: `references/gpt-5-4_prompting_guide.md` is the GPT-5.4-era guide,
+kept for provenance. Do not prompt against it — it describes a model this skill no
+longer runs, and its migration table stops two generations back. Read it only to
+see what a pattern used to say.
 
 Read the image reference when the delegated task involves image generation, image editing, slides, diagrams, ads, UI mockups, in-image text, or image prompt tuning.
 

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -78,7 +78,7 @@ When the delegated task is image generation or image editing:
    Models:
    - `gpt-6-astra` — the default, used whenever no model was named. OpenAI's most capable model, for complex and demanding end-to-end work. It is also what `~/.codex/config.toml` already selects for interactive codex, so a run through this wrapper and a run the user starts by hand now land on the same model.
    - `gpt-5.6-sol` — the previous default; a reliable agentic workhorse for everyday tasks. The pick when capability is not what the task is short of, and astra's per-token cost is not worth paying.
-   - `gpt-5.6-terra` — balanced agentic coding model; lighter usage, faster than Sol, same effort ladder.
+   - `gpt-5.6-terra` — balances intelligence and cost: half sol's price ($2/$12 against $4/$20) one reasoning tier below it, with the same effort ladder and the same 1.05M context. Both model cards rate speed "Fast", so reach for terra to spend less, not to finish sooner.
    - `gpt-5.6-luna` — a "Fast and affordable agentic coding model" in codex's own registry; the cost-efficient pick for browser / computer-use E2E runs and implementation work that writes a lot of code, usually at `xhigh`.
 
    Reasoning effort is selected once and applied identically to all chosen models. `medium` is the wrapper's default and the starting point here — raise it to `high`, `xhigh` or `max` where the task's reasoning depth warrants. astra's ladder is `low|medium|high|xhigh|max` and has no `none` rung. `low` exists but is for latency-bound work; runs from this skill are unattended, where a cheap wrong answer costs a resume rather than saving time.

--- a/codex-plus/skills/codex/references/gpt-6-astra_prompting_guide.md
+++ b/codex-plus/skills/codex/references/gpt-6-astra_prompting_guide.md
@@ -5,20 +5,29 @@ Operative notes for prompts this skill sends to `gpt-6-astra` through
 tool-holding** run — the shape `codex-run.sh` produces. General prompt craft
 that did not change with the generation is not repeated here.
 
-Sourced from OpenAI's model guidance (`developers.openai.com/api/docs/guides/latest-model`,
-section "Using GPT-6 Astra"), the API docs index, the Codex subagents page, and
-the reasoning guide. Claims that could not be read off an OpenAI page are marked
-`[secondary]`.
+Sources, and how each line is marked:
+
+- **Unmarked** — read off an OpenAI page: the model card
+  (`developers.openai.com/api/docs/models/gpt-6-astra`), the model guidance
+  (`.../guides/latest-model`, section "Using GPT-6 Astra"), or the Codex
+  subagents page (`developers.openai.com/codex/subagents`).
+- **`[secondary]`** — not found on an OpenAI page; taken from third-party
+  write-ups. Treat as a lead, not a citation.
+- **`[applied]`** — extended from an OpenAI statement to this skill's situation.
+  The source carries the general claim; the consequence drawn for an unattended
+  `codex exec` run is drawn here and is not in the source.
 
 ## Model facts
 
-- Effort ladder: `low` `medium` `high` `xhigh` `max`. **No `none` rung** — the
-  gpt-5.6 family has one, astra does not. `[secondary]`
-- Context window ~1,050,000 tokens; max output ~128,000 tokens. `[secondary]`
+- Effort ladder: `low` `medium` `high` `xhigh` `max`. **No `none` rung** — sol,
+  terra and luna each support `none` and default to `medium`; astra drops it.
+- Context window 1,050,000 tokens; max output 128,000 tokens.
 - Knowledge cutoff 2026-04-30 — anything later needs retrieval, and the prompt
-  should say so rather than assuming the model will notice. `[secondary]`
-- Price ~$10 in / ~$50 out per 1M tokens. Materially above the gpt-5.6 tiers, so
-  a run that only needs a workhorse belongs on `gpt-5.6-sol`. `[secondary]`
+  says so rather than assuming the model will notice.
+- Price per 1M tokens: $10 in, $1 cached in, $12.50 cache writes, $50 out —
+  2.5x sol on both ends, so a run that only needs a workhorse belongs on
+  `gpt-5.6-sol`. Prompts over 272K input tokens bill at 2x input and 1.5x output
+  for the whole request.
 - Stop sending `temperature`, `top_p`, `top_logprobs`. `codex-run.sh` never sent
   them, so nothing in this skill changes — recorded so a future flag is not
   added. `[secondary]`
@@ -95,5 +104,7 @@ the reasoning guide. Claims that could not be read off an OpenAI page are marked
   model and tool work. Ask for them when the work genuinely splits.
 - A prompt that asks for subagents says how to divide the work, whether codex
   waits for all of them before continuing, and what each returns.
-- Fast scans belong on a cheaper model (`gpt-5.6-terra`) even when the parent is
-  astra.
+- Fast scans belong on a cheaper model; the page's own example is
+  `gpt-5.6-terra`. `[applied]` — that example contrasts terra with a
+  higher-effort `gpt-5.6` config and predates astra, so its holding with astra as
+  the parent is drawn here rather than stated there.

--- a/codex-plus/skills/codex/references/gpt-6-astra_prompting_guide.md
+++ b/codex-plus/skills/codex/references/gpt-6-astra_prompting_guide.md
@@ -1,0 +1,99 @@
+# Prompting gpt-6-astra from codex-plus
+
+Operative notes for prompts this skill sends to `gpt-6-astra` through
+`codex exec`. Scoped to what changes for an **unattended, file-delivered,
+tool-holding** run — the shape `codex-run.sh` produces. General prompt craft
+that did not change with the generation is not repeated here.
+
+Sourced from OpenAI's model guidance (`developers.openai.com/api/docs/guides/latest-model`,
+section "Using GPT-6 Astra"), the API docs index, the Codex subagents page, and
+the reasoning guide. Claims that could not be read off an OpenAI page are marked
+`[secondary]`.
+
+## Model facts
+
+- Effort ladder: `low` `medium` `high` `xhigh` `max`. **No `none` rung** — the
+  gpt-5.6 family has one, astra does not. `[secondary]`
+- Context window ~1,050,000 tokens; max output ~128,000 tokens. `[secondary]`
+- Knowledge cutoff 2026-04-30 — anything later needs retrieval, and the prompt
+  should say so rather than assuming the model will notice. `[secondary]`
+- Price ~$10 in / ~$50 out per 1M tokens. Materially above the gpt-5.6 tiers, so
+  a run that only needs a workhorse belongs on `gpt-5.6-sol`. `[secondary]`
+- Stop sending `temperature`, `top_p`, `top_logprobs`. `codex-run.sh` never sent
+  them, so nothing in this skill changes — recorded so a future flag is not
+  added. `[secondary]`
+- Supports the gpt-5.6 API surface: computer use, Structured Outputs, streaming,
+  Programmatic Tool Calling, multi-agent orchestration, prompt caching, persisted
+  reasoning, compaction, pro mode.
+
+## Autonomy and stop conditions
+
+- **astra asks non-blocking questions while working, by default.** OpenAI's
+  guidance is to adjust the prompt to the autonomy level the application needs.
+- Runs from this skill are headless: `codex exec` has no approval step and no one
+  to answer mid-run. A question therefore lands in the final message, and the
+  answer costs a `-S` resume.
+- So every prompt states, in the `## Task` section: how far to go without
+  checking back, and what "done" is.
+- Where a question is unavoidable, direct astra to **carry on under a stated
+  assumption and name the assumption in its answer**, rather than stopping. The
+  user resolves it on resume with the work already advanced.
+- A genuine consult inverts this: a question is a legitimate deliverable there,
+  and the reviewing role the prompt declares already says so.
+
+## Instruction priority
+
+- astra follows longer instructions better than prior models but is **more
+  sensitive to information in context**. Unclear or conflicting guidance in a
+  skill file can make it pause and block work early.
+- State the priority of instructions explicitly when the prompt carries more than
+  one source of rules (user request vs. repo conventions vs. a linked doc).
+- Say each rule once. Repeating "ask first" / "do not mutate" / "wait for
+  approval" drives unnecessary approval requests for actions that were in scope.
+- Before sending, reread the prompt for two rules that pull opposite ways. Under
+  astra that is a stall, not a tie-break.
+
+## Context discipline
+
+- The skill's Context Classification rule — pointers for anything codex can
+  re-derive, copy only what it cannot — **matters more under astra, not less**.
+  Greater in-context sensitivity means copied material carries more weight, so a
+  copied-in summary competes harder with what the tools would have found.
+- Keep giving astra the tree (`-C DIR`) and the search hints. A model that can
+  look is worth more than a transcript of a previous look.
+- Long sessions amplify repeated prompt and tool content; on resume, add only the
+  new instruction rather than restating the original task.
+
+## Reconcile before switching
+
+- When astra's answer contradicts evidence already collected, **do not silently
+  adopt it**. Resume the same session and put the conflict itself: what was
+  found, what astra proposed, and which constraint decides.
+- astra saw the pointers but may have weighed them lightly. One reconcile turn is
+  cheaper than committing to the wrong branch and is the whole reason resume is
+  by explicit session id.
+
+## Choosing an effort rung
+
+- `medium` is the wrapper default and the starting point. OpenAI's guidance is to
+  compare a rung against its neighbours on representative work rather than assume
+  the highest wins.
+- Raise to `high`/`xhigh`/`max` for reasoning depth, not for task size. A long
+  mechanical task does not need a higher rung; a short load-bearing judgment may.
+- `low` is for latency-bound work. Runs here are unattended, so a cheap wrong
+  answer costs a resume instead of saving time.
+- astra is more capable than the `gpt-5.6-sol` default it replaced, so work that
+  needed `high` there often lands at `medium` here. Verify on the task rather
+  than carrying the old rung across.
+
+## Subagents
+
+- A codex subagent inherits the parent's model and `model_reasoning_effort`
+  unless the spawn request, an `[agents]` default in `config.toml`, or the custom
+  agent file sets them.
+- Subagent runs cost more than a comparable single-agent run — each does its own
+  model and tool work. Ask for them when the work genuinely splits.
+- A prompt that asks for subagents says how to divide the work, whether codex
+  waits for all of them before continuing, and what each returns.
+- Fast scans belong on a cheaper model (`gpt-5.6-terra`) even when the parent is
+  astra.


### PR DESCRIPTION
Moves `codex-plus` onto `gpt-6-astra` and replaces the two-generations-stale prompting reference.

## What changed

| File | Change |
|---|---|
| `scripts/codex-run.sh` | default model `gpt-5.6-sol` → `gpt-6-astra`; default effort `high` → `medium`; `-h` ladder gains `low`, drops the "floor" framing; example slides to `gpt-5.6-sol` |
| `skills/codex/SKILL.md` | step 1 defaults to astra/medium; picker gains astra, sol demoted to "previous default, everyday workhorse" (terra/luna unchanged); quick-ref example slides to sol; Reference Guide re-pointed |
| `skills/codex/references/gpt-6-astra_prompting_guide.md` | **new** — written, not vendored |
| `.claude-plugin/plugin.json` | `2.13.0` → `2.14.0` |

Untouched on purpose: the `codex-session` skill and its extractor (model-neutral), the Chrome references (no model ids), `marketplace.json`, `kimi-plus`.

## Why the effort default moved too

The old comment argued `high` as a floor because a default cannot read the task. That argument survives — but its floor was set against **sol**. astra is the more capable model, so the same work lands a rung lower, and OpenAI's guidance for the current generation is to start at `medium` and compare neighbours rather than assume the top wins.

`SKILL.md`'s "do not go below `high`" had to go with it. Left in place it would have contradicted the wrapper it documents, and under astra that is not a tie-break but a stall — the new guide's own point that *conflicting guidance in a skill file may cause the model to pause and block work early*.

## A divergence this closes

`~/.codex/config.toml` already had `model = "gpt-6-astra"`, while the wrapper passed `-m` unconditionally on the non-resume path. Interactive codex ran astra; every delegation ran sol; nothing but the run banner said so. The wrapper still passes `-m` explicitly — the value now agrees with the config, so reproducibility and agreement hold together instead of trading off.

## The new reference

Written rather than vendored, and scoped to what actually changes for an **unattended, file-delivered, tool-holding** run — the shape `codex-run.sh` produces. Seven sections, each reachable by the grep anchors `SKILL.md` lists:

- **Autonomy and stop conditions** — astra asks non-blocking questions by default; a headless `codex exec` has nobody to answer, so prompts state how far to go and direct astra to proceed under a *named* assumption rather than stop.
- **Instruction priority / Context discipline** — astra weighs in-context material more heavily, which makes this skill's existing pointer-over-copy rule *more* load-bearing, not less.
- **Reconcile before switching** — when astra contradicts evidence already in hand, resume the session with the conflict rather than silently adopting the answer.
- Plus model facts, effort-rung selection, and subagent inheritance.

`references/gpt-5-4_prompting_guide.md` is **kept** and marked historical, at your direction. Noting for the record only: CLAUDE.md's northstar ("fidelity to present understanding outranks artifact continuity", git history as the preservation channel) would have sent it to `git rm` — your call stands.

## Verified

```
$ bash -n codex-plus/scripts/codex-run.sh            # exit 0
$ codex-run.sh -s read-only <prompt>                 # no -m, no -r
model: gpt-6-astra
reasoning effort: medium
session id: 01a06fe9-d56a-71d3-8f96-17ec609c0fa2
stdout: OK, exit 0
```

`SKILL.md`'s seven grep anchors diffed against the reference's headings — exact match.

## Not verified

The astra facts marked `[secondary]` in the new reference (ladder rungs, 1,050K context, 2026-04-30 cutoff, $10/$50, dropped `temperature`/`top_p`/`top_logprobs`). Tavily kept serving the GPT-5.6 slice of the rotating `latest-model` page, so the Astra section was read through search snippets and third-party write-ups rather than fetched whole. The ladder is the only one the code depends on, and the smoke run confirms `medium` is accepted; the rest are labelled in the file itself.

## Follow-ups, not in this PR

- `epistemic-protocols`: `review-loop/references/source-adapter-codex.md:46` and `goal-research/SKILL.md:62` still pin `gpt-5.6-sol`. Both are reasoning-shaped workloads that fit astra's lane.
- `image-companion`'s `gpt-5.5` pin stays put — slated to move into cc-plugin later.
- `codex-session-extract.py` surfaces `model_provider` but not `turn_context.model`, so a session's own model is invisible in lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
