### PR TITLE
scripts: 마켓플레이스 플러그인을 한 줄로 설치하는 install.sh 추가 (macOS 전용은 opt-in)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,9 @@ curl -fsSL https://raw.githubusercontent.com/jongwony/cc-plugin/main/scripts/ins
 
 `scripts/install.sh` reads the plugin list from `.claude-plugin/marketplace.json`,
 so adding or retiring a plugin needs no edit to it, and re-running it is safe.
-Each plugin installs whether or not its prerequisite is present.
+Each plugin installs whether or not its prerequisite is present. The macOS-only
+plugins are opt-in: the script names them in `SKIP_PLUGINS`, checks that list
+against the manifest on every run, and prints the install command for each.
 
 ## Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,18 @@ against the merge-base with the PR base. A later commit on a branch therefore
 needs its own bump to pass the hook after CI is already satisfied by an earlier
 one, so such a branch carries one bump per such commit.
 
+## Install
+
+Every plugin in the marketplace, in one line:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jongwony/cc-plugin/main/scripts/install.sh | bash
+```
+
+`scripts/install.sh` reads the plugin list from `.claude-plugin/marketplace.json`,
+so adding or retiring a plugin needs no edit to it, and re-running it is safe.
+Each plugin installs whether or not its prerequisite is present.
+
 ## Workflow
 
 Test inside Claude Code: `/plugin marketplace add <repo>`, then `/plugin install

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Install every plugin in the cc-plugin marketplace for Claude Code.
+# macOS-only plugins are opt-in — see SKIP_PLUGINS below.
 # The plugin list is derived from the marketplace manifest, so adding or
-# retiring a plugin needs no edit here.
+# retiring a plugin needs no edit here beyond that list.
 # Idempotent: safe to re-run when new plugins are added.
 #
 # Usage:
@@ -13,6 +14,15 @@ REPO="jongwony/cc-plugin"
 MARKETPLACE="cc-plugin"
 MANIFEST_URL="https://raw.githubusercontent.com/$REPO/main/.claude-plugin/marketplace.json"
 
+# Opt-in plugins the default installer leaves out: each drives a macOS-only
+# facility (pmset, Apple Notes, the macOS uninstall surface, an iOS/Android
+# device attach, a whisper.cpp paste daemon). Install one deliberately:
+#   claude plugin install <name>@cc-plugin
+# The plugin list itself comes from the manifest; this is the one
+# hand-maintained exclusion, and every name here is checked against the
+# fetched manifest below so a retired plugin cannot linger in it.
+SKIP_PLUGINS="caffeinate safe-uninstall handwriting voice-dictation agent-device-preflight"
+
 command -v claude >/dev/null 2>&1 || { echo "Error: claude CLI not found. Install Claude Code first." >&2; exit 1; }
 command -v python3 >/dev/null 2>&1 || { echo "Error: python3 not found." >&2; exit 1; }
 
@@ -23,10 +33,20 @@ echo "Fetching plugin list..."
 plugins=$(curl -fsSL "$MANIFEST_URL" \
   | python3 -c "import json,sys; [print(p['name']) for p in json.load(sys.stdin)['plugins']]")
 
+for s in $SKIP_PLUGINS; do
+  [[ " ${plugins//$'\n'/ } " == *" $s "* ]] \
+    || { echo "Error: SKIP_PLUGINS names '$s', which is not in the marketplace manifest. Remove it from scripts/install.sh." >&2; exit 1; }
+done
+
 installed=0
 skipped=0
+opted_out=""
 
 for p in $plugins; do
+  if [[ " $SKIP_PLUGINS " == *" $p "* ]]; then
+    opted_out="$opted_out $p"
+    continue
+  fi
   if claude plugin install "$p@$MARKETPLACE" < /dev/null 2>/dev/null; then
     installed=$((installed + 1))
     # Install does not guarantee activation: a plugin that was already
@@ -43,4 +63,7 @@ done
 echo ""
 echo "Installed $installed plugin(s)."
 [[ $skipped -gt 0 ]] && echo "$skipped skipped (already installed or unavailable)."
+for p in $opted_out; do
+  echo "Not installed (macOS-only, opt-in): $p — add it with: claude plugin install $p@$MARKETPLACE"
+done
 echo "Each plugin's SKILL.md states the prerequisite it needs, if any."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Install every plugin in the cc-plugin marketplace for Claude Code.
+# The plugin list is derived from the marketplace manifest, so adding or
+# retiring a plugin needs no edit here.
+# Idempotent: safe to re-run when new plugins are added.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/jongwony/cc-plugin/main/scripts/install.sh | bash
+
+set -eo pipefail
+
+REPO="jongwony/cc-plugin"
+MARKETPLACE="cc-plugin"
+MANIFEST_URL="https://raw.githubusercontent.com/$REPO/main/.claude-plugin/marketplace.json"
+
+command -v claude >/dev/null 2>&1 || { echo "Error: claude CLI not found. Install Claude Code first." >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "Error: python3 not found." >&2; exit 1; }
+
+echo "Adding marketplace..."
+claude plugin marketplace add "https://github.com/$REPO" < /dev/null 2>/dev/null || true
+
+echo "Fetching plugin list..."
+plugins=$(curl -fsSL "$MANIFEST_URL" \
+  | python3 -c "import json,sys; [print(p['name']) for p in json.load(sys.stdin)['plugins']]")
+
+installed=0
+skipped=0
+
+for p in $plugins; do
+  if claude plugin install "$p@$MARKETPLACE" < /dev/null 2>/dev/null; then
+    installed=$((installed + 1))
+    # Install does not guarantee activation: a plugin that was already
+    # installed and later disabled reports "already installed" and stays off.
+    # `enable` auto-detects the scope that disabled it; it exits non-zero
+    # when the plugin is already enabled, which is the common case.
+    claude plugin enable "$p@$MARKETPLACE" < /dev/null 2>/dev/null || true
+  else
+    echo "  Skipped: $p"
+    skipped=$((skipped + 1))
+  fi
+done
+
+echo ""
+echo "Installed $installed plugin(s)."
+[[ $skipped -gt 0 ]] && echo "$skipped skipped (already installed or unavailable)."
+echo "Each plugin's SKILL.md states the prerequisite it needs, if any."


### PR DESCRIPTION
## 요약

epistemic-protocols의 `scripts/install.sh`와 같은 원라이너를 cc-plugin에도 둔다.

```bash
curl -fsSL https://raw.githubusercontent.com/jongwony/cc-plugin/main/scripts/install.sh | bash
```

## 변경

- `scripts/install.sh` (신규): 마켓플레이스를 add한 뒤 `.claude-plugin/marketplace.json`에서 플러그인 목록을 읽어 install하고 enable한다. 목록을 실행 시점에 manifest에서 파생하므로 플러그인을 추가하거나 retire해도 `SKIP_PLUGINS` 외에는 손대지 않는다. 재실행 안전.
- `CLAUDE.md`: `## Workflow` 앞에 `## Install` 절을 추가했다. README.md는 CLAUDE.md의 심링크라 함께 반영된다.

## 결정 사항

- **macOS 전용 다섯 개는 opt-in.** caffeinate, safe-uninstall, handwriting, voice-dictation, agent-device-preflight는 macOS에만 있는 기능(pmset, Apple Notes, 언인스톨 표면, 기기 attach, whisper.cpp paste 데몬)을 구동하므로 `SKIP_PLUGINS`에 두고, 각각의 설치 명령을 출력한다. 외부 CLI나 API 키가 필요한 나머지는 설치 자체가 무해하므로 기본 집합에 남긴다.
- **스킵 목록 가드는 스크립트 안에.** `SKIP_PLUGINS`의 이름은 매 실행마다 가져온 manifest와 대조하고, manifest에 없는 이름이 있으면 fail-closed로 멈춘다. epistemic-protocols는 같은 가드를 `package.test.js`에 두지만 cc-plugin에는 테스트 러너가 없고, 이 목록이 실제로 쓰이는 순간은 인스톨러 실행뿐이라 그 자리에 두었다.
- **bash.** CLAUDE.md의 Python-by-default 관례는 플러그인 helper script에 대한 것이고, 인스톨러는 uv를 포함한 어떤 전제 조건도 아직 없는 부트스트랩 시점에 `curl | bash`로 실행된다.
- **버전 범프 없음.** 변경 파일이 모두 플러그인 디렉터리 밖이라 `check-version-bump.sh`가 세지 않는다 (로컬 훅 통과 확인).

## 검증

- `bash -n scripts/install.sh` 통과
- 로컬 manifest에 대해 가드 실행: 다섯 이름 모두 통과, retire된 `make-deck`을 넣으면 실패함을 확인
- `.githooks/check-version-bump.sh` 통과
- 실제 `claude plugin install` 실행은 샌드박스에서 하지 않았음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188XTdZYwedQH3tvnwaYkcj