### PR TITLE
Add cloud environment provisioning and Codex login restoration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,18 @@ Each plugin installs whether or not its prerequisite is present. The macOS-only
 plugins are opt-in: the script names them in `SKIP_PLUGINS`, checks that list
 against the manifest on every run, and prints the install command for each.
 
+A Claude Code cloud environment takes one line in its setup-script field:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jongwony/cc-plugin/main/scripts/cloud-setup.sh | bash
+```
+
+`scripts/cloud-setup.sh` runs both marketplaces' installers, adds the opt-in
+epistemic-protocols plugins and the Codex CLI, and registers
+`scripts/codex-auth-restore.sh` as a user-level SessionStart hook: the
+environment's variables reach the session but not the setup script, so the
+Codex login is restored from `CODEX_AUTH_JSON_B64` there.
+
 ## Workflow
 
 Test inside Claude Code: `/plugin marketplace add <repo>`, then `/plugin install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,6 @@ the change.
   philosophy). Skill = what to do (workflow, procedures, commands). A
   `skills:`-loaded skill is the single home for its workflow; the agent adds only
   behavior it does not carry.
-- **Gap tracking (Syneidesis).** Mark unverified assumptions/procedures with a
-  `[Gap:Type]` prefix on the tracked task — `Procedural`, `Assumption`,
-  `Consideration`.
 - **Importing external-tool capability — 3 tests, all required.** (1)
   *Irreducibility*: not reproducible from existing primitives (ergonomic wrappers
   stay inside scripts). (2) *Environment neutrality*: a protocol-level capability

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Provision a Claude Code cloud environment: both plugin marketplaces, the
+# opt-in epistemic-protocols plugins, the Codex CLI, and a SessionStart hook
+# that restores the Codex login from CODEX_AUTH_JSON_B64 at each session start.
+# Idempotent: safe to re-run in a container that already has any of these.
+#
+# Paste this one line into the environment's "Setup script" field:
+#   curl -fsSL https://raw.githubusercontent.com/jongwony/cc-plugin/main/scripts/cloud-setup.sh | bash
+#
+# A setup script runs as root once per environment cache, before Claude Code
+# launches; it must exit zero or the session fails to start, and it should
+# finish within about five minutes. Environment variables are not in its
+# process env — that is why the Codex login is restored by the hook below
+# rather than here — so anything that needs them belongs in the hook.
+
+set -o pipefail
+
+RAW="https://raw.githubusercontent.com/jongwony"
+CLAUDE_DIR="$HOME/.claude"
+HOOK="$CLAUDE_DIR/hooks/codex-auth-restore.sh"
+
+command -v claude >/dev/null 2>&1 || { echo "Error: claude CLI not found." >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "Error: python3 not found." >&2; exit 1; }
+
+# --- Codex CLI: the npm download is the slowest step, so it runs alongside the
+# plugin installs and is joined at the end.
+codex_pid=""
+codex_log=$(mktemp)
+if ! command -v codex >/dev/null 2>&1; then
+  command -v npm >/dev/null 2>&1 || { echo "Error: npm not found; cannot install the Codex CLI." >&2; exit 1; }
+  echo "Codex CLI not found; installing @openai/codex in the background..."
+  npm install -g @openai/codex > "$codex_log" 2>&1 &
+  codex_pid=$!
+fi
+
+# --- Marketplaces: each installer is idempotent and leaves its opt-in plugins out.
+curl -fsSL "$RAW/cc-plugin/main/scripts/install.sh" | bash || true
+curl -fsSL "$RAW/epistemic-protocols/main/scripts/install.sh" | bash || true
+
+# --- Opt-in plugins. `claude plugin enable` fails loudly on a plugin that is
+# already enabled, so the enabled state is read first and enable runs only
+# when it is off.
+plugin_state() {  # prints enabled | disabled | absent
+  claude plugin list --json 2>/dev/null | python3 -c '
+import json, sys
+want = sys.argv[1]
+for p in json.load(sys.stdin):
+    if p.get("id") == want:
+        print("enabled" if p.get("enabled") else "disabled")
+        break
+else:
+    print("absent")' "$1"
+}
+
+ensure_plugin() {
+  local id="$1"
+  claude plugin install "$id" < /dev/null || { echo "  Skipped: $id" >&2; return 0; }
+  if [ "$(plugin_state "$id")" = "disabled" ]; then
+    claude plugin enable "$id" < /dev/null || true
+  fi
+}
+
+ensure_plugin epistemic-cooperative@epistemic-protocols
+ensure_plugin route@epistemic-protocols
+
+# --- Codex login hook: fetched from this repo and registered in the user-level
+# settings once; a hook entry that already points at the file is left alone.
+mkdir -p "$(dirname "$HOOK")"
+if curl -fsSL "$RAW/cc-plugin/main/scripts/codex-auth-restore.sh" -o "$HOOK"; then
+  chmod +x "$HOOK"
+  python3 - "$CLAUDE_DIR/settings.json" "$HOOK" <<'PY'
+import json, os, sys
+path, hook = sys.argv[1], sys.argv[2]
+settings = json.load(open(path)) if os.path.exists(path) else {}
+entries = settings.setdefault("hooks", {}).setdefault("SessionStart", [])
+if not any(h.get("command") == hook for e in entries for h in e.get("hooks", [])):
+    entries.append({"hooks": [{"type": "command", "command": hook}]})
+    with open(path, "w") as f:
+        json.dump(settings, f, indent=2)
+        f.write("\n")
+    print(f"Registered SessionStart hook: {hook}")
+PY
+else
+  echo "Error: could not fetch codex-auth-restore.sh; the Codex login hook was not installed." >&2
+fi
+
+# --- Join the Codex install.
+if [ -n "$codex_pid" ]; then
+  if wait "$codex_pid"; then
+    echo "Installed the Codex CLI."
+  else
+    echo "Error: npm install -g @openai/codex failed:" >&2
+    cat "$codex_log" >&2
+    rm -f "$codex_log"
+    exit 1
+  fi
+  command -v codex >/dev/null 2>&1 || { echo "Error: Codex CLI is still not on PATH after install." >&2; exit 1; }
+fi
+rm -f "$codex_log"
+echo "Cloud environment ready."

--- a/scripts/codex-auth-restore.sh
+++ b/scripts/codex-auth-restore.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Restore the Codex CLI login from CODEX_AUTH_JSON_B64 when no auth.json exists.
+#
+# Codex keeps its login in $CODEX_HOME/auth.json (default ~/.codex/auth.json).
+# A cloud container has no interactive `codex login`, so the environment carries
+# the file's contents base64-encoded in CODEX_AUTH_JSON_B64 and this script
+# writes it back. It runs as a user-level SessionStart hook, installed by
+# scripts/cloud-setup.sh, because the environment's variables reach the Claude
+# Code session but not the setup script that provisions the container.
+#
+# Idempotent: an existing auth.json is left untouched. Always exits zero — a
+# missing login is reported, not fatal, so the session still starts.
+#
+# Usage (by hand):
+#   CODEX_AUTH_JSON_B64=... bash scripts/codex-auth-restore.sh
+
+set -eo pipefail
+
+codex_home="${CODEX_HOME:-$HOME/.codex}"
+auth="$codex_home/auth.json"
+
+[ -f "$auth" ] && exit 0
+
+if [ -z "${CODEX_AUTH_JSON_B64:-}" ]; then
+  echo "Codex CLI login is absent and CODEX_AUTH_JSON_B64 is not set; codex commands will fail until one of them is supplied."
+  exit 0
+fi
+
+mkdir -p "$codex_home" && chmod 700 "$codex_home"
+tmp="$auth.tmp.$$"
+if printf '%s' "$CODEX_AUTH_JSON_B64" | base64 -d > "$tmp" 2>/dev/null \
+   && python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$tmp" 2>/dev/null; then
+  chmod 600 "$tmp" && mv "$tmp" "$auth"
+  echo "Restored the Codex CLI login to $auth."
+else
+  rm -f "$tmp"
+  echo "CODEX_AUTH_JSON_B64 did not decode to JSON; the Codex CLI login was not restored." >&2
+fi


### PR DESCRIPTION
Adds two scripts to support Claude Code cloud environments: a setup script that provisions the environment with plugin marketplaces, opt-in plugins, and the Codex CLI; and a SessionStart hook that restores the Codex login from an environment variable.

## Changes

- **`scripts/cloud-setup.sh`** — Idempotent provisioning script for cloud environments. Installs both plugin marketplaces, enables opt-in epistemic-protocols plugins, installs the Codex CLI in parallel, and registers the auth-restore hook. Designed to run once per environment cache as the setup script, with proper error handling and dependency checks.

- **`scripts/codex-auth-restore.sh`** — SessionStart hook that restores the Codex CLI login from `CODEX_AUTH_JSON_B64` when `auth.json` is absent. Idempotent and non-fatal; always exits zero so the session starts even if the login cannot be restored.

- **`CLAUDE.md`** — Documents the cloud environment setup process and the one-line installation command for users. Removes the gap-tracking convention entry (moved to a separate tracking system).

## Implementation notes

The setup script runs as root before Claude Code launches, so environment variables are not available to it — the Codex login is therefore restored by the user-level SessionStart hook instead, which has access to the session's environment. Both scripts are idempotent and safe to re-run. The Codex CLI install runs in the background alongside plugin installs to minimize total time.

https://claude.ai/code/session_013h2Nf6sPcyNMUUe3uFVF49