### PR TITLE
feat(scripts): cloud-setup에 Codex용 Tavily MCP 등록 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,10 +105,12 @@ curl -fsSL https://raw.githubusercontent.com/jongwony/cc-plugin/main/scripts/clo
 ```
 
 `scripts/cloud-setup.sh` runs both marketplaces' installers, adds the opt-in
-epistemic-protocols plugins and the Codex CLI, and registers
-`scripts/codex-auth-restore.sh` as a user-level SessionStart hook: the
-environment's variables reach the session but not the setup script, so the
-Codex login is restored from `CODEX_AUTH_JSON_B64` there.
+epistemic-protocols plugins and the Codex CLI, registers Tavily's remote MCP
+server for Codex (the key is read from `TAVILY_API_KEY` at call time, so the
+setup script writes no secret), and registers `scripts/codex-auth-restore.sh`
+as a user-level SessionStart hook: the environment's variables reach the
+session but not the setup script, so the Codex login is restored from
+`CODEX_AUTH_JSON_B64` there.
 
 ## Workflow
 

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Provision a Claude Code cloud environment: both plugin marketplaces, the
-# opt-in epistemic-protocols plugins, the Codex CLI, and a SessionStart hook
-# that restores the Codex login from CODEX_AUTH_JSON_B64 at each session start.
+# opt-in epistemic-protocols plugins, the Codex CLI with the Tavily MCP server
+# registered, and a SessionStart hook that restores the Codex login from
+# CODEX_AUTH_JSON_B64 at each session start.
 # Idempotent: safe to re-run in a container that already has any of these.
 #
 # Paste this one line into the environment's "Setup script" field:
@@ -11,7 +12,10 @@
 # launches; it must exit zero or the session fails to start, and it should
 # finish within about five minutes. Environment variables are not in its
 # process env — that is why the Codex login is restored by the hook below
-# rather than here — so anything that needs them belongs in the hook.
+# rather than here — so anything that needs them belongs in the hook. The
+# Tavily registration is the exception that stays here: Codex reads the key
+# from the session's TAVILY_API_KEY at call time, so no value is needed now
+# and none is written to disk.
 
 set -o pipefail
 
@@ -97,4 +101,15 @@ if [ -n "$codex_pid" ]; then
   command -v codex >/dev/null 2>&1 || { echo "Error: Codex CLI is still not on PATH after install." >&2; exit 1; }
 fi
 rm -f "$codex_log"
+
+# --- Tavily MCP for Codex: the remote server, authenticated by a bearer token
+# that Codex reads from TAVILY_API_KEY when it launches the server. That is
+# how the epistemic-cooperative goal-research skill reaches external search
+# from inside a Codex session. `codex mcp add` overwrites an existing entry
+# of the same name, so a re-run converges on this shape.
+if codex mcp add tavily --url https://mcp.tavily.com/mcp/ --bearer-token-env-var TAVILY_API_KEY < /dev/null; then
+  echo "Registered the Tavily MCP server for Codex; set TAVILY_API_KEY in the environment's variables to enable it."
+else
+  echo "Error: could not register the Tavily MCP server for Codex." >&2
+fi
 echo "Cloud environment ready."


### PR DESCRIPTION
Codex 세션 안에서 goal-research가 외부 검색에 도달하려면 Codex에 Tavily MCP가
등록되어 있어야 하는데, 클라우드 VM의 Codex에는 MCP 서버가 하나도 없었다.
그 상태에서는 Codex가 검색 없이 기억으로 답하고 인용만 흉내 낼 수 있다.

setup script는 환경 변수를 받지 못하므로 값을 요구하는 등록은 훅으로 가야
하지만, Tavily 원격 MCP는 bearer 토큰을 받고 Codex는 `--bearer-token-env-var`로
그 토큰을 호출 시점의 세션 환경에서 읽는다. 그래서 등록 자체는 setup script에
두고 비밀값은 어디에도 쓰지 않는다. stdio 방식(`npx tavily-mcp`)은 `--env`에
값을 박아야 해 이 조건을 만족하지 못한다.

검증: 클라우드 세션에서 `codex mcp add ... --bearer-token-env-var TAVILY_API_KEY`
후 gpt-5.6-luna 실행이 `mcp: tavily/tavily_search`를 실제로 호출하는 것을 확인.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BoJZ9xsLXqC35MuXoNYRUa