### PR TITLE
remote-tmux: 브리프의 supervisor 자리에 무엇을 넣는지 세운다

### DIFF
--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are addressable by SendMessage and, on a launch that takes --remote-control, app-reachable (remote-spawn skill), or keep a self-restarting --spawn worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -218,6 +218,14 @@ A spawned session never reads this file. Carry the contract in the brief itself:
 > (c) a completion report. Do not wait for a reply — durable output (PR, parked task)
 > ships regardless of the channel.
 
+**Look up your own address before writing the brief.** `ListAgents` opens with `This session
+is <name> [<ref>]`, and that exact string — ref included — is what `<supervisor-name>` takes.
+A description in that slot reads plausible and is not an address, and the worker cannot tell
+the difference: it does as instructed, finds no such peer among the many it is shown, and
+picks the nearest plausible row. The failure is silent from this end — the spawn succeeds, the
+worker runs, and its report reaches a stranger or nobody. Distinct from the `<parent>` token
+above, which is a topic short-form this session renders without a lookup.
+
 ## Receiving
 
 A message from another session is a claim, and its arrival establishes nothing about its


### PR DESCRIPTION
## 무엇이 비어 있었나

`remote-spawn` 의 **Reporting contract** 절은 워커 브리프에 실을 템플릿을 준다.

> You are a worker supervised by `<supervisor-name>`. To report: call `ListAgents` first, ...

그런데 그 `<supervisor-name>` 값을 **어디서 얻는지**는 파일 어디에도 없었다. 세션은 자기 이름을 묻지 않고는 모른다 — `ListAgents` 의 첫 줄 `This session is <name> [<ref>]` 가 그것을 말해 주는데, 이 사실 자체가 문서에 없다.

결과로 슬롯이 **주소가 아닌 서술**로 채워질 수 있고, 채워진 것을 워커는 구별하지 못한다. 지시대로 따르다가 조용히 어긋난다.

## 관측된 실패

오늘 한 spawn 이 그 자리에 `"the session that spawned you"` 를 넣었다.

- 워커는 지시대로 `ListAgents` 를 호출 → 피어 45개를 봤다
- 그중 누가 감독인지 알 근거가 없어 `jongwony-8a [c76ba3]` (cwd 로 이름 붙은 대화형 세션)을 골라 ACK 을 보냈다
- 그 세션은 자기 범위가 아니라고 회신
- 이후 `/sketch` 게이트는 갈 곳이 없어 워커 자신의 턴에 남았고, 워커는 이렇게 적었다: *"감독 세션 이름을 알려주시면 이후 게이트 상태를 그쪽으로도 중계하겠습니다."*
- **스폰 출력에는 아무 이상도 나타나지 않았다.** spawn 은 성공했고 워커는 정상으로 돌았다.

## 절이 이제 요구하는 것

`Reporting contract` 절, 템플릿 바로 뒤:

> **Look up your own address before writing the brief.** `ListAgents` opens with `This session is <name> [<ref>]`, and that exact string — ref included — is what `<supervisor-name>` takes. A description in that slot reads plausible and is not an address, and the worker cannot tell the difference: it does as instructed, finds no such peer among the many it is shown, and picks the nearest plausible row. The failure is silent from this end — the spawn succeeds, the worker runs, and its report reaches a stranger or nobody. Distinct from the `<parent>` token above, which is a topic short-form this session renders without a lookup.

마지막 문장이 있는 이유: `Naming a spawned session` 절이 `<parent>` 를 두고 *"without either of them having to look anything up"* 이라고 말한다. 그것은 화제 축약 토큰이지 주소가 아니어서, 브리프 작성 순간으로 옮겨 읽히면 정확히 이번 실패가 된다.

## 손대지 않은 것과 이유

| 대상 | 판단 |
|---|---|
| `Resuming` 절 | 재개 명령은 다음 지시만 싣고, 워커는 최초 브리프에서 계약을 이미 들고 있다. 같은 절의 반복은 중복이지 보강이 아니다 |
| `Naming a spawned session` 절 | `<parent>` 는 주소가 아니라 화제 축약. 새 절 안 한 문장으로 갈라 두는 편이 같은 사실을 두 곳에 쓰지 않는다 |
| `rc-pool/SKILL.md` | 이 템플릿을 싣지 않는다 — `remote-spawn` 을 가리키기만 한다 |
| `remote-tmux/README.md` | 감독 권한/권한 클래스 얘기만 있고 보고 계약 템플릿은 없다 |

## 검사

이 저장소에는 테스트 스위트가 없다 (`package.json` 없음, `scripts/` 는 셋업 셸 스크립트뿐). 유일한 검사인 버전 범프 가드를 두 진입점 모두에서 돌렸다.

- `.githooks/pre-commit` (index 모드, staged vs HEAD) → exit 0
- `.githooks/check-version-bump.sh --base origin/main` (CI range 모드) → exit 0

`remote-tmux` 5.3.2 → **5.3.3**. 문서 동작 수정이라 앞선 두 건(5.3.0→5.3.1, 5.3.1→5.3.2)과 같은 패치 범프.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4TuKPZiPvRY1PXzkRQBXf