### PR TITLE
codex-plus: 실행 후 무조건 AskUserQuestion으로 다음 단계를 묻던 절을 걷는다

### DIFF
--- a/codex-plus/.claude-plugin/plugin.json
+++ b/codex-plus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-plus",
   "description": "Enhanced OpenAI Codex CLI integration (multi-model, context classification)",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/codex-plus/skills/codex/SKILL.md
+++ b/codex-plus/skills/codex/SKILL.md
@@ -108,13 +108,10 @@ Modifiers, added to any base pattern above:
 - Model and effort — `-m gpt-5.6-sol`, `-r xhigh` (effort defaults to `medium`; `-r` raises it)
 - Capture the answer to a file — `-o <FILE>` writes codex's final message to FILE deterministically
 
-## Following Up
-After `codex` completes, use `AskUserQuestion` to confirm next steps. Restate model/reasoning/sandbox when proposing actions.
-
 ## Error Handling
 - Stop and report failures whenever `codex --version` or a `codex exec` command exits non-zero; request direction before retrying.
 - Before you use high-impact flags (`--sandbox danger-full-access`, `--skip-git-repo-check`) ask the user for permission using AskUserQuestion unless it was already given.
-- When output includes warnings or partial results, summarize them and ask how to adjust using `AskUserQuestion`.
+- When output includes warnings or partial results, report them beside the outcome summary.
 
 ## Reference Guide
 


### PR DESCRIPTION
## 무엇을

`codex-plus/skills/codex/SKILL.md`에서 두 곳을 걷습니다.

- `## Following Up` 절 전체 삭제. codex가 끝날 때마다 `AskUserQuestion`으로 다음 단계를 확인하라고 했습니다.
- `## Error Handling` 셋째 줄. 경고·부분 결과가 있으면 조정 방법을 물으라던 것을, 결과 요약 옆에 보고하는 것으로 바꿉니다.

고위험 플래그(`--sandbox danger-full-access`, `--skip-git-repo-check`) 앞의 허가 요청은 비가역 경계이므로 그대로 둡니다. `codex-plus` 버전 2.15.0 → 2.15.1.

## 왜

요청한 작업이 끝난 뒤 계속할지를 되묻는 것은 범위 안 작업에 승인 절차를 덧붙이는 일입니다. 이 스킬이 `references/gpt-6-astra_prompting_guide.md`에 직접 둔 안내문이 같은 말을 합니다. "ask first를 반복하면 범위 안 행동에도 불필요한 승인 요청이 생긴다." OpenAI의 GPT-6 Astra 모델 안내(Initiative and follow-through)도 계속할지 제안하는 데서 멈추지 말라고 적습니다.

다음 단계가 정말 열려 있을 때 묻는 것은 기본 동작이라 대체 규칙을 두지 않았습니다.

## 검증

- `.githooks/check-version-bump.sh --base origin/main` 통과.

## 교차 검증

같은 질문을 Codex gpt-6-astra(xhigh)에 수정 전 스냅샷으로 독립 리뷰시킨 결과, `:112`의 무조건 확인과 `:117`의 조정 질문을 같은 결함으로 짚었고 스킬 자체의 `references/gpt-6-astra_prompting_guide.md:60`과 충돌한다고 보았습니다. Codex는 `:115`(실패 시 재시도 전 지시 요청)도 같은 묶음으로 보았으나, 이 PR은 남겨 둡니다. 비가역이 아닌 실패의 bounded 재시도를 허용할지는 별도 판단입니다. 그 밖에 `pdf-split/skills/pdf-split/SKILL.md:59`(가역 분할 앞 경계 확인)와 `media-download/skills/media-download/SKILL.md:76`(명시 요청에도 플레이리스트 재확인)을 후속 후보로 짚었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrwyL88pW1Dae5N7bFdkJx