### PR TITLE
remote-tmux: key the rc-pool singleton by project path, not by name (5.3.4)

### DIFF
--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
   "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are addressable by SendMessage and, on a launch that takes --remote-control, app-reachable (remote-spawn skill), or keep a self-restarting --spawn worktree pool host alive per project for CLI-free session origination (rc-pool skill)",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/scripts/rc-pool.sh
+++ b/remote-tmux/scripts/rc-pool.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # rc-pool — self-restarting, project-singleton keep-alive for a `claude remote-control
 # --spawn worktree` POOL HOST (capacity N on-demand worktree sessions), one singleton
-# per project.
+# per project. The singleton is keyed by the project's canonical path (tmux session
+# `rcpool-<sanitized path>`); the [name] is the host's display name only.
 #
 # WHY THIS SCRIPT STILL EXISTS. Spawning a single worker no longer needs a script — a
 # backgrounded `claude --bg --worktree ... --remote-control ...` is app-reachable and
@@ -16,10 +17,11 @@
 #
 # Subcommands:
 #   up     <dir> [name] [capacity]   start the singleton pool host (idempotent)
-#   down   <name|dir>                graceful stop (SIGTERM host -> children flush -> drop)
+#   down   <name|dir>                graceful stop (SIGTERM host -> children flush -> drop);
+#                                    a name resolves through the running hosts' @rcpool_name
 #   toggle <dir> [name] [capacity]   up if down, down if up (used by the /rc-pool skill)
 #   status <name|dir>                report running/stopped
-#   _run   <dir> <name> <capacity>   INTERNAL: tmux pane foreground re-exec loop
+#   _run   <dir> <name> <capacity> <key>   INTERNAL: tmux pane foreground re-exec loop
 #
 # WHY tmux (not nohup/launchd): the remote-control host is an interactive TUI that needs a
 # live PTY — under script/nohup it reads EOF on stdin and exits immediately; a tmux pane
@@ -46,11 +48,30 @@ SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 sanitize() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-' | sed 's/--*/-/g; s/^-//; s/-$//'; }
 need() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' not found on PATH (required by rc-pool)" >&2; return 127; }; }
 
-# Resolve a <dir|name> argument to a sanitized singleton name: an existing dir -> its
-# basename; otherwise treat the argument as a name already.
-resolve_name() {
-  local a="$1"
-  if [ -d "$a" ]; then sanitize "$(basename "$(cd "$a" && pwd)")"; else sanitize "$a"; fi
+# The singleton key is the project's canonical path, sanitized. Two projects sharing a
+# basename therefore get two hosts, and one project gets one host whatever name it runs under.
+# tmux rewrites `.` and `:` in a session name to `_` on creation, which would make the name
+# created differ from the name looked up, so the key maps both to `-` as well.
+key_of_dir() { sanitize "$(cd "$1" && pwd)" | tr '.:' '--' | sed 's/--*/-/g; s/^-//; s/-$//'; }
+
+# Resolve a <dir|name> argument to a tmux session name. A dir resolves through its key. A
+# name is matched against the @rcpool_name option each running host carries: exactly one
+# match -> that session; several -> error (the caller must pass the dir); none -> the legacy
+# session `rcpool-<name>` from before path keying, so an older host can still be brought down.
+resolve_sess() {
+  local a="$1" n matches
+  if [ -d "$a" ]; then printf 'rcpool-%s' "$(key_of_dir "$a")"; return 0; fi
+  n="$(sanitize "$a")"
+  [ -n "$n" ] || return 2
+  matches="$(tmux list-sessions -F '#{session_name} #{@rcpool_name} #{@rcpool_dir}' 2>/dev/null \
+    | awk -v n="$n" '$2 == n { print $1 " " $3 }')"
+  case "$(printf '%s\n' "$matches" | grep -c .)" in
+    0) printf 'rcpool-%s' "$n";;
+    1) printf '%s' "${matches%% *}";;
+    *) echo "ERROR: several pool hosts are named '$n' — pass the project dir instead:" >&2
+       printf '%s\n' "$matches" | awk '{ print "  " $2 }' >&2
+       return 3;;
+  esac
 }
 
 up() {
@@ -78,39 +99,41 @@ base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~")
 d = json.load(open(os.path.join(base, ".claude.json")))
 sys.exit(0 if d.get("projects", {}).get(sys.argv[1], {}).get("hasTrustDialogAccepted") else 1)
 PY
-  local sess="rcpool-$name"
+  local key sess; key="$(key_of_dir "$dir")"; sess="rcpool-$key"
   if tmux has-session -t "$sess" 2>/dev/null; then
-    echo "ALREADY-RUNNING $name  attach: $ATTACH_ENV tmux attach -t $sess"; return 0
+    echo "ALREADY-RUNNING $name  (dir: $dir)  attach: $ATTACH_ENV tmux attach -t $sess"; return 0
   fi
   # Build the pane command with printf %q so a SELF or dir path containing spaces or quotes
   # can't break tmux's shell parse or inject syntax before _run. name is sanitized and cap is
   # numeric, but quote them uniformly. tmux runs this string via its shell, re-entering _run.
-  local cmd; cmd="$(printf 'bash %q _run %q %q %q' "$SELF" "$dir" "$name" "$cap")"
+  local cmd; cmd="$(printf 'bash %q _run %q %q %q %q' "$SELF" "$dir" "$name" "$cap" "$key")"
   if ! tmux new-session -d -s "$sess" -x 220 -y 55 -c "$dir" "$cmd"; then
     echo "ERROR: failed to launch tmux session $sess" >&2; return 1
   fi
+  tmux set-option -t "$sess" @rcpool_name "$name"
+  tmux set-option -t "$sess" @rcpool_dir "$dir"
   echo "STARTED-POOL $name  (dir: $dir, capacity: $cap, spawn: worktree, permissions: bypass, self-restarting)"
   echo "  -> reachable in the Claude app once Ready; on-demand sessions get isolated worktrees"
-  echo "  -> attach: $ATTACH_ENV tmux attach -t $sess   |   stop: rc-pool.sh down $name"
+  echo "  -> attach: $ATTACH_ENV tmux attach -t $sess   |   stop: rc-pool.sh down $dir"
 }
 
 _run() {
-  local dir="$1" name="$2" cap="$3"
-  local log="$TMUX_TMPDIR/rcpool-$name.log"
+  local dir="$1" name="$2" cap="$3" key="$4"
+  local log="$TMUX_TMPDIR/rcpool-$key.log"
   cd "$dir" || exit 1
-  echo "[$(date '+%F %T')] rcpool-$name host starting (capacity=$cap spawn=worktree permission-mode=bypassPermissions)" >> "$log"
+  echo "[$(date '+%F %T')] rcpool-$key host starting (name=$name capacity=$cap spawn=worktree permission-mode=bypassPermissions)" >> "$log"
   claude remote-control --name "$name" --spawn worktree --capacity "$cap" --permission-mode bypassPermissions
-  echo "[$(date '+%F %T')] rcpool-$name host exited (code $?) — reloading from disk in 3s" >> "$log"
+  echo "[$(date '+%F %T')] rcpool-$key host exited (code $?) — reloading from disk in 3s" >> "$log"
   sleep 3
-  exec bash "$SELF" _run "$dir" "$name" "$cap"
+  exec bash "$SELF" _run "$dir" "$name" "$cap" "$key"
 }
 
 down() {
-  local name; name="$(resolve_name "$1")"
-  [ -n "$name" ] || { echo "usage: rc-pool.sh down <name|dir>" >&2; return 2; }
+  [ -n "$1" ] || { echo "usage: rc-pool.sh down <name|dir>" >&2; return 2; }
   need tmux || return 127
-  local sess="rcpool-$name"
-  if ! tmux has-session -t "$sess" 2>/dev/null; then echo "NOT-RUNNING $name"; return 0; fi
+  local sess name; sess="$(resolve_sess "$1")" || return $?
+  if ! tmux has-session -t "$sess" 2>/dev/null; then echo "NOT-RUNNING $1"; return 0; fi
+  name="$(tmux show-option -t "$sess" -qv @rcpool_name)"; name="${name:-$1}"
   # Graceful: SIGTERM the host first (children flush, no orphans), then drop the session inside
   # the loop's 3s pre-re-exec window so it can't relaunch behind us. Resolve the target ONLY
   # through THIS session's own tmux pane — never a global `ps | grep`, which would also match
@@ -135,24 +158,24 @@ down() {
 }
 
 toggle() {
-  local dir="$1" name="$2" cap="$3" rn
-  rn="$(resolve_name "${name:-$dir}")"
-  if [ -n "$rn" ] && tmux has-session -t "rcpool-$rn" 2>/dev/null; then
-    down "$rn"
+  local dir="$1" name="$2" cap="$3"
+  [ -d "$dir" ] || { echo "usage: rc-pool.sh toggle <dir> [name] [capacity]" >&2; return 2; }
+  if tmux has-session -t "$(resolve_sess "$dir")" 2>/dev/null; then
+    down "$dir"
   else
     up "$dir" "$name" "$cap"
   fi
 }
 
 status() {
-  local name; name="$(resolve_name "$1")"
-  [ -n "$name" ] || { echo "usage: rc-pool.sh status <name|dir>" >&2; return 2; }
+  [ -n "$1" ] || { echo "usage: rc-pool.sh status <name|dir>" >&2; return 2; }
   need tmux || return 127
-  local sess="rcpool-$name"
+  local sess name dir; sess="$(resolve_sess "$1")" || return $?
   if tmux has-session -t "$sess" 2>/dev/null; then
-    echo "RUNNING $name  attach: $ATTACH_ENV tmux attach -t $sess"
+    name="$(tmux show-option -t "$sess" -qv @rcpool_name)"; dir="$(tmux show-option -t "$sess" -qv @rcpool_dir)"
+    echo "RUNNING ${name:-$1}  (dir: ${dir:-?})  attach: $ATTACH_ENV tmux attach -t $sess"
   else
-    echo "STOPPED $name"
+    echo "STOPPED $1"
   fi
 }
 
@@ -161,6 +184,6 @@ case "${1:-}" in
   down)   down "${2:-}";;
   toggle) toggle "${2:-}" "${3:-}" "${4:-}";;
   status) status "${2:-}";;
-  _run)   _run "${2:-}" "${3:-}" "${4:-}";;
+  _run)   _run "${2:-}" "${3:-}" "${4:-}" "${5:-}";;
   *) echo "usage: rc-pool.sh {up <dir> [name] [cap] | down <name|dir> | toggle <dir> [name] [cap] | status <name|dir>}" >&2; exit 2;;
 esac

--- a/remote-tmux/skills/rc-pool/SKILL.md
+++ b/remote-tmux/skills/rc-pool/SKILL.md
@@ -10,8 +10,9 @@ description: >
 # Remote-Control Pool-Host Toggle
 
 Toggle a self-restarting pool host — `claude remote-control --spawn worktree --capacity N
---permission-mode bypassPermissions` — for a project. One singleton per project (tmux session
-`rcpool-<name>`); the host hosts a pool of on-demand, worktree-isolated sessions reachable
+--permission-mode bypassPermissions` — for a project. One singleton per project, keyed by the
+project's canonical path (tmux session `rcpool-<sanitized path>`; `[name]` is the host's display
+name only); the host hosts a pool of on-demand, worktree-isolated sessions reachable
 from claude.ai/code + the mobile app.
 
 **What the pool is for, and what it cannot do.** Its purpose is originating a session
@@ -47,4 +48,6 @@ Notes to pass on when relevant:
   worktree-isolated ones).
 - **tmux, not launchd**: the host needs a live pane PTY (it exits on EOF under script/nohup);
   login-session resilient, no autostart — re-run `up` after a reboot.
-- One singleton per project; `name` defaults to the project dir's basename.
+- One singleton per project, keyed by the project dir's path; `name` is the display name and
+  defaults to the dir's basename. `down`/`status` take the dir, or a name — a name that several
+  running hosts share is refused with their dirs listed, so pass the dir then.


### PR DESCRIPTION
## What changes

`rc-pool.sh` promised one pool host per project and delivered one per **name**, with the name defaulting to the directory basename. Two projects sharing a basename shared one tmux session (`rcpool-<name>`), so `toggle` on the second stopped the first. Codex reproduced this during the review loop on #169 (round 3, finding R3-1); it predates that PR and was outside its subject, so it lands here on its own.

- **Key vs. name.** The singleton key is now the project's canonical path, sanitized (tmux session `rcpool-<sanitized path>`, log `rcpool-<key>.log`). The `[name]` is the display name passed to `claude remote-control --name` and stays what it was: explicit, or the basename.
- **`down <name>` / `status <name>` still work.** `up` records `@rcpool_name` and `@rcpool_dir` on the session. A name resolves to the one running host carrying it; several → refused with their dirs listed (pass the dir); none → legacy `rcpool-<name>` fallback.
- **`toggle` takes a dir**; a dir always resolves through its key.
- tmux rewrites `.` and `:` in session names to `_`, so the key maps both to `-` (a path containing `.claude/` would otherwise be created under one name and looked up under another — caught by the test).
- `rc-pool` SKILL.md states the key and the name/dir resolution. README's "one host per project" needed no edit — this change is what makes it literally true.

## Test performed

End to end with real tmux under an isolated `TMUX_TMPDIR`: two temp git repos with the same basename under different parents, a PATH shim `claude` that records its args and sleeps, `CLAUDE_CONFIG_DIR` marking both dirs trusted. 15/15 assertions pass:

```
PASS: up on two same-basename projects yields two sessions
PASS: both hosts launched with --name proj (display name = basename)
PASS: toggle on b leaves a RUNNING
PASS: toggle on b stopped b
PASS: down <basename> with one host up stops it
PASS: no rcpool sessions remain
PASS: down <basename> with both up exits 3
PASS: ambiguity error names the case
PASS: ambiguity error lists both dirs
PASS: ambiguous down stops nothing
PASS: down <dir> stopped a
PASS: down <dir> left b running
PASS: second up on the same project under another name is ALREADY-RUNNING
PASS: legacy rcpool-<name> session reachable by down <name>
PASS: legacy session gone
```

`scripts/rc-pool.sh` is byte-identical before and after the rebase below, so that run still stands for this head.

## Migration

A host started before this change runs under `rcpool-<name>` with no `@rcpool_name` option. `down <name>` still reaches it through the legacy fallback; `down <dir>` / `status <dir>` will report it STOPPED because the path key does not match. Bring such a host down by name once, then `up` again.

## Version

`5.4.3` → `5.4.4`. This branch was cut when main was at 5.3.3 and first carried 5.3.4; #169 then merged as `e68baa2` and took remote-tmux to 5.4.3, so the branch was rebased onto that and the one conflicting line resolved to 5.4.4. The earlier version-clash note is discharged — nothing further is owed on merge order.

That version line was the only conflict. `rc-pool` SKILL.md auto-merged: #169's English trigger phrase in the description stands beside this branch's key lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
