### PR TITLE
refactor(remote-tmux): Stint를 독립 작업으로 정리

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     {
       "name": "remote-tmux",
       "source": "./remote-tmux",
-      "description": "`claude remote-control` toolkit: spawn one-off backgrounded sessions, app-reachable wherever the launch takes --remote-control, or keep a tmux-tracked self-restarting `--spawn worktree` pool host alive per project"
+      "description": "`claude remote-control` toolkit: /remote-spawn launches independent Stints and manages peer-addressable sessions, with Claude app access on launches that register --remote-control"
     },
     {
       "name": "hourly-digest",

--- a/remote-tmux/.claude-plugin/plugin.json
+++ b/remote-tmux/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-tmux",
-  "description": "`claude remote-control` toolkit: spawn backgrounded worker sessions that are addressable by SendMessage and, on a launch that takes --remote-control, reachable from claude.ai/code and the mobile app (remote-spawn skill)",
-  "version": "5.5.0",
+  "description": "`claude remote-control` toolkit: /remote-spawn launches independent Stints and manages peer-addressable sessions, with Claude app access on launches that register --remote-control",
+  "version": "6.0.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/remote-tmux/README.md
+++ b/remote-tmux/README.md
@@ -13,7 +13,7 @@ addressable by `SendMessage` from other sessions, and — on a launch that takes
 
 ```bash
 ( cd ~/src/foo && claude --bg --worktree foo \
-                         --remote-control "stint::foo::build" -n "stint::foo::build" \
+                         --remote-control "stint::foo-build" -n "stint::foo-build" \
                          --permission-mode auto -- "<brief>" )
 
 claude agents --json     # fleet view (no TTY needed)
@@ -29,13 +29,17 @@ along with the peer ref other sessions address it by — so neither is safe to c
 `--remote-control` registers the app bridge. The worktree token and the session name are
 separate on purpose — see the skill's naming section.
 
-A spawned session is a **Stint**: a bounded piece of work carried in its own context, reachable
-by message. The skill's job ends at the **handshake** — the Stint ACKs its creator once, and the
-creator checks the ACK's sender socket against the registry entry for the jobId the spawn line
-printed. Every brief names a durable destination for the session's output; what
-the Stint is after the handshake is set by the rest of it: a *supervised* Stint
-(`stint::<parent>::<child>`) carries a reporting contract and reports blocked decisions and
-completion; an *independent* Stint (`stint::<topic>`) owes nothing further.
+A **Stint** is independently managed bounded work carried in a spawned session's own
+context, named `stint::<topic>`. Work whose result the current session receives and
+integrates belongs to native subagents, using the context modes available in that harness.
+
+The spawn completes at the **handshake**: the Stint ACKs its creator once, and the creator
+checks the ACK's sender socket against the registry entry for the returned jobId. This
+confirms launch identity. The Stint completes its work at the durable destination named
+in its brief, with its output and verification; it owes no completion report to the creator.
+The brief also identifies the sources of its decision authority and where to park decisions
+it cannot make, or a source-authorized default. Independent work retains those limits.
+Retiring the resident session is a separate lifecycle operation.
 
 `--remote-control` is separable: what it buys is the app bridge alone. The messaging socket
 comes from the backgrounded launch itself and the name from `-n`, so `SendMessage`, the fleet

--- a/remote-tmux/skills/remote-spawn/SKILL.md
+++ b/remote-tmux/skills/remote-spawn/SKILL.md
@@ -3,8 +3,10 @@ name: remote-spawn
 description: >
   This skill should be used when the user asks to "spawn a remote-control session",
   "open this repo/folder in the Claude app", "remote control here", "spin one up",
-  "turn on remote-control in this directory", to spawn a Stint — a session that carries a
-  bounded piece of work in its own context — or to list/message/retire those sessions.
+  "turn on remote-control in this directory", to spawn a Stint — a session that carries an
+  independently managed bounded piece of work in its own context — or to
+  list/message/retire those sessions. Current-task work whose result the caller
+  integrates uses native subagents.
   Use it also whenever a message arrives from another Claude session, and whenever you
   are about to read the peer listing, address a peer, or judge whether one can be
   interrupted. It launches a backgrounded `claude` session addressable by `SendMessage`
@@ -26,8 +28,8 @@ reachable from the Claude app:
                              --permission-mode auto -- "<brief>" )
 ```
 
-`<name>` is one of the two shapes under **Naming a spawned session**; `<brief>` carries
-the handshake clause and whatever the session is to be after it, under **The brief**.
+`<name>` follows **Naming a spawned session**; `<brief>` carries the independent work
+and handshake obligations under **The brief**.
 
 It prints `backgrounded · <jobId> · <name>`. Report that back. The four flags are
 independent and each earns its place: `--bg` detaches without a PTY, `--worktree`
@@ -121,60 +123,16 @@ setting, so a class match cannot be inferred from a message having arrived.
 
 ## What a Stint is, and where this skill stops
 
-A Stint is a bounded unit of work that one spawned session carries in its own context.
-Messages reach it through the socket the backgrounded launch gives it, and it processes
-each against the context it holds; its creator's context stays on the creator's side.
-
-This skill's reach ends at the **handshake**. The spawned session sends one ACK to its
-creator on start, and the creator checks that the ACK came from the session it meant to
-spawn — the ACK's sender socket against the one the registry holds for the jobId the spawn
-line printed. A spawn is complete when that check passes, and what follows is set by the
-brief.
-
-After the handshake a session is one of two things. A **supervised** Stint carries a
-supervision contract in its brief and reports under it. An **independent** Stint carries
-no contract and owes its creator nothing further; the creator can still address it, and
-so can the Claude app when the launch took `--remote-control`. Addressing, receiving,
-observing and retiring below read the same for both.
+- **At work allocation:** a Stint is independently managed bounded work carried by a spawned session in its own context. Work whose result the current session must receive and integrate uses native subagents; select fork or fresh context from the modes the active harness provides.
+- **When native subagents lack a required capability:** surface that capability boundary before choosing another execution path; a background session does not become a supervised Stint by substitution.
+- **At Stint handoff:** the creator's context stays with the creator. Supply the brief below; the Stint reads messages against its own context and exercises only the judgment entrusted by the work's governing sources.
+- **At launch completion:** close the spawn through the verified handshake below. The ACK confirms the launched session's identity, not completion of its work.
+- **After the handshake:** the Stint owes no completion report to its creator. Its work and unresolved decisions land at the brief's durable destination. Peer addressing and app access remain available through the launch's capabilities; follow the communication and lifecycle sections below when using them.
 
 ## Naming a spawned session
 
-A supervised Stint is named after its creator; an independent one after its own work:
-
-    stint::<parent>::<child>     # supervised
-    stint::<topic>               # independent
-
-`stint` is the fixed first segment marking the row as a spawned session. `::` is the
-namespace connector, used at every boundary. `<parent>` is the session that created this
-Stint and holds its supervision contract, written as a short form of that session's own
-topic — read off the creator, not derived and not coined. Two Stints reporting to one
-session therefore carry the same token and Stints reporting to different creators do not,
-which is the grouping the convention exists for. `<child>` describes this Stint freely,
-distinctly enough to tell it from its siblings — `stint::comment-review::port` beside
-`stint::comment-review::review`.
-`<topic>` describes an independent Stint's work the same way, with no creator token
-because nothing groups under a creator that owes it no report.
-
-Neither segment may carry whitespace, which is why both substitutions are quoted in the
-command above. That bars the character, not the phrase: a multi-word name stays multi-word
-and hyphenated, since compressing a title into a single token to make it fit throws away
-the reading it was chosen for. The asymmetry is what to hold on to. `<surface>` has a
-validator behind it; the session name passes through none, so there a space is not an error
-but a truncation — unquoted, the name splits and only its first piece reaches the flag,
-leaving the rest as a stray positional and the worker under a name nobody can address it
-by. `--remote-control` takes its name the same way and truncates the same way, so quote
-both.
-
-Every name here is pinned explicitly with `-n`. Where `--remote-control` is passed it then
-deliberately takes the same value as `-n` — they are independent flags, one naming the
-session and one registering the app bridge, and holding them equal is what makes the name
-printed at spawn the same string peers address. Naming is `-n`'s job on its own, so a launch
-that cannot carry the bridge flag is named no differently and addressed no differently.
-
-The creator reports the name with the spawn line, and the handshake ACK is the only
-confirmation that follows. `<child>` and `<topic>` it describes; `<parent>` it renders from
-its own topic, the same way across every Stint that reports to it, so siblings match without
-either of them having to look anything up.
+- **At naming:** use `stint::<topic>`, where `<topic>` describes the independent work. Keep multi-word topics hyphenated and free of whitespace; keep the worktree's `<surface>` token separate.
+- **At launch:** pin the complete name with `-n`; pass the same quoted name to `--remote-control` when present. Report the actual name with the returned spawn line.
 
 ## Talking to it
 
@@ -230,7 +188,7 @@ Delegate that read rather than doing it inline. It is a bounded extract-and-judg
 delegating returns only what the send decision needs while keeping another session's
 conversation out of this one's context.
 
-## The brief — handshake, then what the session is
+## The brief
 
 A spawned session never reads this file. Everything it owes anyone is carried in the brief.
 
@@ -241,32 +199,15 @@ A spawned session never reads this file. Everything it owes anyone is carried in
 > `SendMessage` — a first send to a peer is answered with a re-send request unless it
 > carries the ref, and names collide.
 
-**Every brief names the durable destination for the session's output** — the PR, the parked
-task, the file — since that is where the work lands whatever the channel does: an
-independent Stint's result ships there, and a supervised report that finds no one to
-deliver to is recorded there.
-
-**A supervised brief adds the supervision contract**, under which the creator is the address
-every report goes to:
-
-> Report to the same address, resolving it through `ListAgents` before each send. Send your
-> state whenever progress depends on a decision outside your authority, and a completion
-> report naming the durable output (PR, parked task) and the verification you performed.
-> Continue authorized work without waiting for a reply to a report; work that depends on
-> an unresolved decision stays paused. If no listing row matches your creator, record the
-> undelivered report at the brief's durable output destination.
-
-**An independent brief carries no contract**, and instead names a disposition for a decision
-the session cannot make alone — where to park it, or which default to take. Nothing else is
-owed after the ACK.
+- **For the work:** name the bounded goal, its completion condition, and the durable destination for its output and verification — the PR, parked task, or file. Completion is recorded there; the creator is not a required completion-report recipient.
+- **For judgment:** point to the governing instructions and authorized revisions that establish the Stint's discretion and retained decisions. For a decision it cannot make, name where to park the unresolved matter or a default those sources authorize. Continue independent authorized work; work depending on that decision waits for its settlement. Independence supplies no additional decision grant.
 
 **Look up your own address before writing the brief.** `ListAgents` opens with `This session
 is <name> [<ref>]`, and that exact string — ref included — is what `<creator-address>` takes.
 A description in that slot reads plausible and is not an address, and the worker cannot tell
 the difference: it does as instructed, finds no such peer among the many it is shown, and
 picks the nearest plausible row. The failure is silent from this end — the spawn succeeds, the
-worker runs, and its ACK reaches a stranger or nobody. Distinct from the `<parent>` token
-above, which is a topic short-form this session renders without a lookup.
+worker runs, and its ACK reaches a stranger or nobody.
 
 **Verify the ACK against the launched session, keyed by the jobId.** The spawn line printed
 a jobId, and the row `claude agents --json` holds under that `id` is the session that launch
@@ -296,12 +237,7 @@ deliberate: reading outward is cheap, taking something inward and acting on it i
 This binds a message carrying a claim you would act on. An acknowledgement, a status note,
 or a reply that closes an exchange takes an answer, not an investigation.
 
-It binds what a Stint sends too, which is why the discipline sits in this file rather than
-anywhere on the delegation side. The handshake ACK and every supervised report travel by
-`SendMessage` — the brief instructs it — so they arrive on this inbound path and not as a
-completion notification from a dispatched agent. Nothing on the harvest-a-delegated-result
-side fires on them: an inbound message is the one moment in a session's lifecycle that
-somebody else starts, so a creator waiting on a notification is not waiting on this.
+- **On a Stint message:** apply the same claim check when adopting its content. The handshake ACK arrives through peer messaging and is checked for launch identity; it is not a native subagent result notification or a work-completion signal.
 
 ## Observing
 


### PR DESCRIPTION
Stint를 **독립적으로 진행하는 한정된 작업**으로 정리합니다. 현재 세션이 결과를 받아 통합하는 일은 네이티브 subagent에 맡기고, fork/fresh는 실제 harness가 제공하는 맥락 방식으로 선택합니다. 생성자 감독을 재현하던 Stint의 분기·보고 계약·부모/자식 이름을 제거하고 `remote-tmux`를 **6.0.0**으로 올렸습니다.

| 경계 | 결과 |
|---|---|
| 작업 배분 | 현재 세션이 통합할 위임은 native subagent, 독립 작업은 `stint::<topic>` |
| 판단권 | 독립성으로 권한이 늘지 않으며, 원래 지시가 정한 재량과 유보된 결정을 유지 |
| 완료 | ACK는 시작 신원 확인, 작업 완료는 지정한 산출물과 검증, session retirement는 별도 절차 |

독립 Stint는 생성자에게 완료 보고를 의무로 지지 않습니다. 결과와 권한 밖 미결정 사안은 brief의 지속 위치에 남기며, 기존 peer 후속 메시지와 답변은 계속 가능합니다. 신원 확인, 현재 주소 조회, 수신 주장 검증, app bridge, runtime supervisor와 관찰·재개·종료 절차는 보존했습니다. native subagent에 필요한 capability가 없으면 그 경계를 드러냅니다.

같은 플러그인의 marketplace 설명에 남아 있던 tmux pool host 광고도 정렬했습니다. 이 불일치는 기존 소스에도 있던 discovery drift입니다.

개인 로컬 지침인 Codex `AGENTS.md`와 Claude `rules/preferences.md`도 같은 책임 경계로 정렬해 각각의 로컬 Git 기록에 남겼습니다. Codex의 사용자 소유 새 작업은 명시적 요청이 있을 때만 만듭니다. 기존 코드 작업·커밋·PR 권한과 머지·배포 경계는 유지하며, 두 로컬 파일은 이 PR의 추적 파일에 포함되지 않습니다.

검증은 다음 범위입니다.

- skill frontmatter 검증, 버전 증가 검사, JSON/marketplace 경로 및 diff 검사를 통과했습니다.
- 동일한 여섯 상황의 격리된 baseline/candidate 소스 읽기 비교에서 두 독자 모두 의도한 배치에 도달했습니다. baseline은 기존 규칙에서 관계를 추론했고 candidate는 경계를 직접 명시했습니다. 검토 범위는 생성자 통합 fork/fresh, 명시적 독립 작업, 기존 peer 후속 통신, 인간 판단 유보와 생성자 부재, 시작·완료·종료 구분입니다.
- 독립 소스 리뷰의 marketplace 지적을 반영했습니다. 여섯 사례 이후의 최종 차이는 그 설명과 관사 수정뿐입니다.

이는 사용자가 정한 의미의 정렬과 제한된 소스 비교입니다. 실제 Stint 실행, 메시지 전송, 플러그인 설치, 실행 중인 세션 변경은 하지 않았습니다. `/realize` coverage나 실패율·성능 개선, 플랫폼 간 runtime 동일성을 주장하지 않습니다. 기존 Claude `rm`의 삭제 범위와 재시작 동작에 관한 불확실성도 이번 작업에서 해소하지 않았습니다. 격리 입력에 없던 native handshake/watch/retirement 세부는 각 도구 계약에 남깁니다.

로컬 증거는 `/tmp/stint-alignment-evidence/`의 baseline·candidate snapshots, prompts/outputs, `manual-verdicts.json`, manifests에 보존했습니다. 지속적인 변경 근거와 제거된 계약은 커밋 메시지와 diff에서 확인할 수 있습니다. 머지는 수행하지 않습니다.
