### PR TITLE
scripts: Codex 클라우드 환경에 Claude Code를 세우는 codex-cloud-setup.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,13 +119,17 @@ field, and gets Claude Code inside it:
 curl -fsSL https://raw.githubusercontent.com/jongwony/cc-plugin/main/scripts/codex-cloud-setup.sh | bash
 ```
 
-`scripts/codex-cloud-setup.sh` installs the Claude Code CLI, runs both
-marketplaces' installers, adds the opt-in epistemic-protocols plugins,
-persists the login, and registers Tavily's remote MCP server. Three Codex
-cloud constraints govern any edit to it:
+`scripts/codex-cloud-setup.sh` installs the Claude Code CLI with the native
+installer (`https://claude.ai/install.sh`), runs both marketplaces'
+installers, adds the opt-in epistemic-protocols plugins, persists the login,
+and registers Tavily's remote MCP server. Four Codex cloud constraints govern
+any edit to it:
 
 - Internet reaches the setup phase only — off by default during the agent
   phase — so every network step finishes inside the script.
+- The agent phase is a separate process inheriting no `export`, and the
+  installer's `$HOME/.local/bin` is not on the default PATH, so the binary is
+  symlinked into a directory already on PATH.
 - Secrets are stripped before the agent phase, so `CLAUDE_CODE_OAUTH_TOKEN`
   (or `ANTHROPIC_API_KEY`) is written into `~/.claude/settings.json`'s `env`
   block here rather than through a SessionStart hook.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,27 @@ as a user-level SessionStart hook: the environment's variables reach the
 session but not the setup script, so the Codex login is restored from
 `CODEX_AUTH_JSON_B64` there.
 
+An **OpenAI Codex cloud** environment takes one line in its own setup-script
+field, and gets Claude Code inside it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jongwony/cc-plugin/main/scripts/codex-cloud-setup.sh | bash
+```
+
+`scripts/codex-cloud-setup.sh` installs the Claude Code CLI, runs both
+marketplaces' installers, adds the opt-in epistemic-protocols plugins,
+persists the login, and registers Tavily's remote MCP server. Three Codex
+cloud constraints govern any edit to it:
+
+- Internet reaches the setup phase only — off by default during the agent
+  phase — so every network step finishes inside the script.
+- Secrets are stripped before the agent phase, so `CLAUDE_CODE_OAUTH_TOKEN`
+  (or `ANTHROPIC_API_KEY`) is written into `~/.claude/settings.json`'s `env`
+  block here rather than through a SessionStart hook.
+- `claude mcp add` has no `--bearer-token-env-var`, and `${VAR}` expansion is
+  `.mcp.json`-only, so `TAVILY_API_KEY` is resolved at setup time into the user
+  config, and registration is skipped when it is unset.
+
 ## Workflow
 
 Test inside Claude Code: `/plugin marketplace add <repo>`, then `/plugin install

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -61,6 +61,43 @@ fi
 rm -f "$claude_log"
 command -v claude >/dev/null 2>&1 || { echo "Error: Claude Code CLI is not on PATH after install." >&2; exit 1; }
 
+# --- Login. CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`) is the headless
+# path; ANTHROPIC_API_KEY is the fallback. Either may be supplied as a Secret,
+# which this script is the last thing to see, so it is persisted into the
+# settings `env` block where the agent phase still finds it. A missing login is
+# reported, not fatal — the environment still builds, and the CLI is there for
+# whoever supplies one later.
+# This precedes every `claude` call below: unlike cloud-setup.sh, which runs
+# against an already-authenticated CLI, the one installed above has no login.
+# It touches no network, so the background fetches keep overlapping the install.
+mkdir -p "$CLAUDE_DIR"
+auth_var=""
+for v in CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_API_KEY; do
+  if [ -n "${!v:-}" ]; then auth_var="$v"; break; fi
+done
+
+if [ -n "$auth_var" ]; then
+  # The value is read from the environment python3 inherits, never from argv,
+  # so it stays out of the process table.
+  if python3 - "$SETTINGS" "$auth_var" <<'PY'
+import json, os, sys
+path, key = sys.argv[1], sys.argv[2]
+settings = json.load(open(path)) if os.path.exists(path) else {}
+settings.setdefault("env", {})[key] = os.environ[key]
+with open(path, "w") as f:
+    json.dump(settings, f, indent=2)
+    f.write("\n")
+PY
+  then
+    chmod 600 "$SETTINGS"
+    echo "Persisted $auth_var into $SETTINGS for the agent phase."
+  else
+    echo "Error: could not write $SETTINGS; the login was not persisted." >&2
+  fi
+else
+  echo "Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is set; claude will have no login until one is supplied. Generate one with \`claude setup-token\` and add it to the environment's variables or secrets."
+fi
+
 # --- Marketplaces: each installer is idempotent and leaves its opt-in plugins out.
 wait "$cc_pid" && bash "$cc_installer" || echo "  Skipped: cc-plugin marketplace" >&2
 wait "$ep_pid" && bash "$ep_installer" || echo "  Skipped: epistemic-protocols marketplace" >&2
@@ -91,40 +128,6 @@ ensure_plugin() {
 
 ensure_plugin epistemic-cooperative@epistemic-protocols
 ensure_plugin route@epistemic-protocols
-
-# --- Login. CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`) is the headless
-# path; ANTHROPIC_API_KEY is the fallback. Either may be supplied as a Secret,
-# which this script is the last thing to see, so it is persisted into the
-# settings `env` block where the agent phase still finds it. A missing login is
-# reported, not fatal — the environment still builds, and the CLI is there for
-# whoever supplies one later.
-mkdir -p "$CLAUDE_DIR"
-auth_var=""
-for v in CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_API_KEY; do
-  if [ -n "${!v:-}" ]; then auth_var="$v"; break; fi
-done
-
-if [ -n "$auth_var" ]; then
-  # The value is read from the environment python3 inherits, never from argv,
-  # so it stays out of the process table.
-  if python3 - "$SETTINGS" "$auth_var" <<'PY'
-import json, os, sys
-path, key = sys.argv[1], sys.argv[2]
-settings = json.load(open(path)) if os.path.exists(path) else {}
-settings.setdefault("env", {})[key] = os.environ[key]
-with open(path, "w") as f:
-    json.dump(settings, f, indent=2)
-    f.write("\n")
-PY
-  then
-    chmod 600 "$SETTINGS"
-    echo "Persisted $auth_var into $SETTINGS for the agent phase."
-  else
-    echo "Error: could not write $SETTINGS; the login was not persisted." >&2
-  fi
-else
-  echo "Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is set; claude will have no login until one is supplied. Generate one with \`claude setup-token\` and add it to the environment's variables or secrets."
-fi
 
 # --- Tavily MCP: how the epistemic-cooperative goal-research skill reaches
 # external search. The codex side of cloud-setup.sh keeps the key off disk with

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -24,8 +24,12 @@
 # only place that can see them, here the setup script is the only place that
 # can see a Secret.
 #
-# The default `universal` image runs as root with npm and python3 present, so
-# no sudo and no runtime bootstrap.
+# The default `universal` image runs as plain root with curl and python3
+# present. The CLI comes from the native installer, which downloads a platform
+# binary and so carries no Node dependency at all — no version floor to meet at
+# install time and no optional-dependency resolution to fail inside a
+# container, the two ways the npm route breaks there. Its sudo guard fires only
+# when SUDO_USER names a real user, so plain root passes.
 
 set -o pipefail
 
@@ -34,11 +38,14 @@ CLAUDE_DIR="$HOME/.claude"
 SETTINGS="$CLAUDE_DIR/settings.json"
 
 command -v python3 >/dev/null 2>&1 || { echo "Error: python3 not found." >&2; exit 1; }
+# The Claude Code installer takes curl or wget; this script's own fetches below
+# are curl, so curl is what it requires.
+command -v curl >/dev/null 2>&1 || { echo "Error: curl not found." >&2; exit 1; }
 
-# --- Claude Code CLI. Unlike cloud-setup.sh, the slow npm install cannot run
-# alongside the plugin installs: `claude plugin install` is what the installers
-# below call, so the dependency runs the other way. What does overlap is the
-# network fetch of the two installer scripts, which needs nothing local.
+# --- Claude Code CLI. Unlike cloud-setup.sh, the install cannot run alongside
+# the plugin installs: `claude plugin install` is what the installers below
+# call, so the dependency runs the other way. What does overlap is the network
+# fetch of the two installer scripts, which needs nothing local.
 claude_log=$(mktemp)
 cc_installer=$(mktemp)
 ep_installer=$(mktemp)
@@ -48,17 +55,55 @@ curl -fsSL "$RAW/epistemic-protocols/main/scripts/install.sh" -o "$ep_installer"
 ep_pid=$!
 
 if ! command -v claude >/dev/null 2>&1; then
-  command -v npm >/dev/null 2>&1 || { echo "Error: npm not found; cannot install the Claude Code CLI." >&2; exit 1; }
-  echo "Claude Code CLI not found; installing @anthropic-ai/claude-code..."
-  if ! npm install -g @anthropic-ai/claude-code > "$claude_log" 2>&1; then
-    echo "Error: npm install -g @anthropic-ai/claude-code failed:" >&2
+  echo "Claude Code CLI not found; running the native installer..."
+  # rc is captured off the pipeline itself — `if ! cmd` would replace the
+  # installer's status with the negation, losing the 137 the OOM case turns on.
+  rc=0
+  { curl -fsSL https://claude.ai/install.sh | bash; } > "$claude_log" 2>&1 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "Error: the Claude Code installer failed (exit $rc):" >&2
     cat "$claude_log" >&2
+    # 137 is the kernel OOM killer; the installer needs roughly 512MB free and
+    # prints nothing of its own when the signal lands.
+    [ "$rc" -eq 137 ] && echo "Exit 137 is an out-of-memory kill — the installer needs about 512MB free." >&2
     rm -f "$claude_log" "$cc_installer" "$ep_installer"
     exit 1
   fi
   echo "Installed the Claude Code CLI."
 fi
 rm -f "$claude_log"
+
+# --- PATH. The installer puts the binary in $HOME/.local/bin, which is not on
+# the default PATH, and the agent phase is a separate process that inherits no
+# `export` from here. A symlink into a directory already on PATH is what
+# survives, assuming nothing about which shell init the agent phase reads.
+if ! command -v claude >/dev/null 2>&1; then
+  claude_bin=""
+  for c in "$HOME/.local/bin/claude" "$HOME/.claude/local/claude"; do
+    [ -x "$c" ] && { claude_bin="$c"; break; }
+  done
+  [ -n "$claude_bin" ] || { echo "Error: the installer reported success but no claude binary was found." >&2; exit 1; }
+
+  linked=""
+  for d in /usr/local/bin /usr/bin; do
+    case ":$PATH:" in *":$d:"*) ;; *) continue ;; esac
+    [ -d "$d" ] && [ -w "$d" ] || continue
+    if ln -sf "$claude_bin" "$d/claude"; then linked="$d/claude"; break; fi
+  done
+
+  if [ -n "$linked" ]; then
+    echo "Linked $claude_bin to $linked so the agent phase finds it on PATH."
+  else
+    # No writable PATH directory: fall back to the shell init files, which do
+    # assume the agent phase reads one of them.
+    for rcfile in "$HOME/.bashrc" "$HOME/.profile"; do
+      # shellcheck disable=SC2016  # $HOME must stay literal, to expand when the rc is read
+      grep -qsF '.local/bin' "$rcfile" || echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$rcfile"
+    done
+    export PATH="$HOME/.local/bin:$PATH"
+    echo "No writable directory on PATH; appended \$HOME/.local/bin to ~/.bashrc and ~/.profile instead." >&2
+  fi
+fi
 command -v claude >/dev/null 2>&1 || { echo "Error: Claude Code CLI is not on PATH after install." >&2; exit 1; }
 
 # --- Login. CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`) is the headless

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Provision an OpenAI Codex cloud environment with Claude Code inside it: the
+# CLI, both plugin marketplaces, the opt-in epistemic-protocols plugins, the
+# login, and the Tavily MCP server.
+# Idempotent: safe to re-run in a container that already has any of these.
+#
+# Paste this one line into the environment's "Setup script" field:
+#   curl -fsSL https://raw.githubusercontent.com/jongwony/cc-plugin/main/scripts/codex-cloud-setup.sh | bash
+#
+# This is scripts/cloud-setup.sh inverted: that one provisions a Claude Code
+# cloud environment and installs Codex inside it. Three facts about the Codex
+# cloud shape what follows.
+#
+# Internet reaches the SETUP phase only — during the agent phase it is off by
+# default — so everything that touches the network finishes here, and nothing
+# is deferred to first use.
+#
+# Environment variables are set for the whole chat, setup and agent phase
+# alike, while Secrets reach the setup script only and are stripped before the
+# agent phase starts. So the login is written to disk HERE rather than deferred
+# to a SessionStart hook. That is the exact inversion of why
+# scripts/codex-auth-restore.sh exists on the Claude cloud side, where the
+# variables reach the session but not the setup script: there the hook is the
+# only place that can see them, here the setup script is the only place that
+# can see a Secret.
+#
+# The default `universal` image runs as root with npm and python3 present, so
+# no sudo and no runtime bootstrap.
+
+set -o pipefail
+
+RAW="https://raw.githubusercontent.com/jongwony"
+CLAUDE_DIR="$HOME/.claude"
+SETTINGS="$CLAUDE_DIR/settings.json"
+
+command -v python3 >/dev/null 2>&1 || { echo "Error: python3 not found." >&2; exit 1; }
+
+# --- Claude Code CLI. Unlike cloud-setup.sh, the slow npm install cannot run
+# alongside the plugin installs: `claude plugin install` is what the installers
+# below call, so the dependency runs the other way. What does overlap is the
+# network fetch of the two installer scripts, which needs nothing local.
+claude_log=$(mktemp)
+cc_installer=$(mktemp)
+ep_installer=$(mktemp)
+curl -fsSL "$RAW/cc-plugin/main/scripts/install.sh" -o "$cc_installer" &
+cc_pid=$!
+curl -fsSL "$RAW/epistemic-protocols/main/scripts/install.sh" -o "$ep_installer" &
+ep_pid=$!
+
+if ! command -v claude >/dev/null 2>&1; then
+  command -v npm >/dev/null 2>&1 || { echo "Error: npm not found; cannot install the Claude Code CLI." >&2; exit 1; }
+  echo "Claude Code CLI not found; installing @anthropic-ai/claude-code..."
+  if ! npm install -g @anthropic-ai/claude-code > "$claude_log" 2>&1; then
+    echo "Error: npm install -g @anthropic-ai/claude-code failed:" >&2
+    cat "$claude_log" >&2
+    rm -f "$claude_log" "$cc_installer" "$ep_installer"
+    exit 1
+  fi
+  echo "Installed the Claude Code CLI."
+fi
+rm -f "$claude_log"
+command -v claude >/dev/null 2>&1 || { echo "Error: Claude Code CLI is not on PATH after install." >&2; exit 1; }
+
+# --- Marketplaces: each installer is idempotent and leaves its opt-in plugins out.
+wait "$cc_pid" && bash "$cc_installer" || echo "  Skipped: cc-plugin marketplace" >&2
+wait "$ep_pid" && bash "$ep_installer" || echo "  Skipped: epistemic-protocols marketplace" >&2
+rm -f "$cc_installer" "$ep_installer"
+
+# --- Opt-in plugins. `claude plugin enable` fails loudly on a plugin that is
+# already enabled, so the enabled state is read first and enable runs only
+# when it is off.
+plugin_state() {  # prints enabled | disabled | absent
+  claude plugin list --json 2>/dev/null | python3 -c '
+import json, sys
+want = sys.argv[1]
+for p in json.load(sys.stdin):
+    if p.get("id") == want:
+        print("enabled" if p.get("enabled") else "disabled")
+        break
+else:
+    print("absent")' "$1"
+}
+
+ensure_plugin() {
+  local id="$1"
+  claude plugin install "$id" < /dev/null || { echo "  Skipped: $id" >&2; return 0; }
+  if [ "$(plugin_state "$id")" = "disabled" ]; then
+    claude plugin enable "$id" < /dev/null || true
+  fi
+}
+
+ensure_plugin epistemic-cooperative@epistemic-protocols
+ensure_plugin route@epistemic-protocols
+
+# --- Login. CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`) is the headless
+# path; ANTHROPIC_API_KEY is the fallback. Either may be supplied as a Secret,
+# which this script is the last thing to see, so it is persisted into the
+# settings `env` block where the agent phase still finds it. A missing login is
+# reported, not fatal — the environment still builds, and the CLI is there for
+# whoever supplies one later.
+mkdir -p "$CLAUDE_DIR"
+auth_var=""
+for v in CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_API_KEY; do
+  if [ -n "${!v:-}" ]; then auth_var="$v"; break; fi
+done
+
+if [ -n "$auth_var" ]; then
+  # The value is read from the environment python3 inherits, never from argv,
+  # so it stays out of the process table.
+  if python3 - "$SETTINGS" "$auth_var" <<'PY'
+import json, os, sys
+path, key = sys.argv[1], sys.argv[2]
+settings = json.load(open(path)) if os.path.exists(path) else {}
+settings.setdefault("env", {})[key] = os.environ[key]
+with open(path, "w") as f:
+    json.dump(settings, f, indent=2)
+    f.write("\n")
+PY
+  then
+    chmod 600 "$SETTINGS"
+    echo "Persisted $auth_var into $SETTINGS for the agent phase."
+  else
+    echo "Error: could not write $SETTINGS; the login was not persisted." >&2
+  fi
+else
+  echo "Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is set; claude will have no login until one is supplied. Generate one with \`claude setup-token\` and add it to the environment's variables or secrets."
+fi
+
+# --- Tavily MCP: how the epistemic-cooperative goal-research skill reaches
+# external search. The codex side of cloud-setup.sh keeps the key off disk with
+# `--bearer-token-env-var`; `claude mcp add` has no equivalent, and ${VAR}
+# expansion in MCP config is a .mcp.json feature that user scope does not
+# share, so the value is resolved here and lands in the user config. That is
+# the same ephemeral container disk the login above is already written to, and
+# registration is skipped entirely when no key is set.
+if [ -n "${TAVILY_API_KEY:-}" ]; then
+  if claude mcp add --transport http --scope user tavily https://mcp.tavily.com/mcp/ \
+      --header "Authorization: Bearer $TAVILY_API_KEY" < /dev/null; then
+    echo "Registered the Tavily MCP server for Claude Code."
+  else
+    echo "Error: could not register the Tavily MCP server." >&2
+  fi
+else
+  echo "TAVILY_API_KEY is not set; the Tavily MCP server was not registered."
+fi
+
+echo "Codex cloud environment ready."


### PR DESCRIPTION
`scripts/cloud-setup.sh`는 **Claude Code 클라우드** 환경을 세우면서 그 안에 Codex를 설치한다. 그 역방향이 없었다. 이 PR은 **OpenAI Codex 클라우드** 환경을 세우면서 그 안에 Claude Code를 설치하는 `scripts/codex-cloud-setup.sh`를 추가한다.

Codex 환경 설정의 "Setup script" 칸에 한 줄:

```bash
curl -fsSL https://raw.githubusercontent.com/jongwony/cc-plugin/main/scripts/codex-cloud-setup.sh | bash
```

## 하는 일

CLI 설치(native installer) → **PATH 영속화** → **로그인 영속화** → 두 마켓플레이스 installer 실행 → opt-in 플러그인(`epistemic-cooperative`, `route`) → Tavily MCP 등록.

## 설치는 native installer로

`curl -fsSL https://claude.ai/install.sh | bash`. Anthropic 문서의 권장 경로이고, 트러블슈팅의 "Install hangs in Docker"가 컨테이너 사례에 이것을 직접 지목한다. npm은 같은 바이너리를 설치하지만 컨테이너에서만 붙는 실패 모드가 둘 있다 — 설치 시점 Node 22+ 요구, optional dependency 비활성 시 네이티브 바이너리 패키지 미발견. **전환의 실질은 Node 의존이 통째로 사라진다는 것.**

설치기를 읽어 확인한 것(실행은 안 함): sudo 가드는 `SUDO_USER`가 실제 사용자를 가리킬 때만 발동해 `universal` 이미지의 plain root는 통과, curl/wget 중 하나 필요, exit 137은 커널 OOM(≈512MB) — 시그널사 시 설치기가 아무것도 출력 못 하므로 설명을 이쪽에서 붙였다.

## PATH 영속화

설치기는 `$HOME/.local/bin`에 놓는데 기본 PATH에 없고, agent phase는 setup script와 별개 프로세스라 `export`가 살아남지 않는다. **이미 PATH에 있는 디렉터리로의 심링크**를 택했다 — agent phase의 셸이 어떤 init 파일을 읽는지에 대해 아무 가정도 하지 않는 유일한 수단이다. 쓰기 가능한 PATH 디렉터리가 없을 때만 셸 rc 추가로 물러서며, 그 경로는 init 파일을 읽는다는 가정을 실제로 진다.

로그인이 두 번째인 것이 중요하다. 마켓플레이스 설치가 방금 깐 CLI의 첫 실행이므로, 토큰이 그보다 뒤에 있으면 `claude plugin install`이 온보딩을 요구할 때 두 마켓플레이스가 통째로 조용히 건너뛰어진다(각 호출이 `||`로 감싸여 있어 스크립트는 그대로 exit 0). 원본 `cloud-setup.sh`는 이미 인증된 CLI를 전제하므로 이 제약이 없었다. 인증 블록은 네트워크를 안 쓰므로 이 자리에 들어가도 백그라운드 curl 페치와의 겹침은 그대로다.

## 설계의 핵심: 인증이 정반대로 흐른다

두 환경이 **상대가 노출하는 바로 그 국면에서** 자격증명을 감춘다.

| | 환경변수가 닿는 곳 | 그래서 필요한 것 |
|---|---|---|
| Claude 클라우드 (`cloud-setup.sh`) | 세션에는 닿고 setup script에는 안 닿음 | `codex-auth-restore.sh` SessionStart 훅 |
| Codex 클라우드 (이 PR) | Secret이 setup script에만 닿고 agent phase 직전 제거 | setup 시점에 디스크로 영속화 |

그래서 이쪽에는 훅이 없다. 훅을 둘 자리가 없는 게 아니라, **훅이 읽을 것이 그때는 이미 사라지고 없다.** `CLAUDE_CODE_OAUTH_TOKEN`(없으면 `ANTHROPIC_API_KEY`)을 `~/.claude/settings.json`의 `env` 블록에 써 두는 이유다. 값은 argv가 아니라 python3가 상속한 환경에서 읽어 프로세스 테이블에 남기지 않는다.

## 그대로 옮겨오지 못한 것 두 가지

**병렬화.** `cloud-setup.sh`는 claude가 이미 있으니 codex의 npm 설치를 플러그인 설치와 겹친다. 여기서는 플러그인 설치가 곧 `claude plugin install`이라 의존이 반대로 흐른다 — npm 설치가 선행 조건이다. 대신 로컬 의존이 없는 두 installer의 curl 페치를 npm 설치에 겹쳤다.

**Tavily.** `codex mcp add`는 `--bearer-token-env-var`로 키를 디스크 밖에 두지만 `claude mcp add`에는 대응 플래그가 없고, MCP 설정의 `${VAR}` 확장은 `.mcp.json` 전용이라 user scope가 공유하지 않는다 ([anthropics/claude-code#43693](https://github.com/anthropics/claude-code/issues/43693), not planned). 그래서 값을 setup 시점에 해소해 user config에 넣는다. 같은 임시 컨테이너 디스크에 바로 위 로그인 토큰이 이미 적혀 있으므로 추가 노출은 없고, `TAVILY_API_KEY`가 없으면 등록 자체를 건너뛴다.

## CLAUDE.md

Install 절에 카운터파트를 더했다. 항상 로드되는 표면이라 **운용 계약만** 실었다 — 편집자가 깨뜨리면 안 되는 세 제약(네트워크는 setup phase 한정, Secret은 agent phase 전에 제거, Tavily 키는 setup 시점 해소). 위의 근거는 커밋 메시지에 있다.

## 검증

- `bash -n` 통과
- `shellcheck` 0.11.0 통과 (경고 0)
- 버전 범프 규칙: `scripts/`와 `CLAUDE.md`는 어떤 플러그인 디렉터리에도 속하지 않아 범프 불필요 — `.githooks/check-version-bump.sh` exit 0으로 확인
- **종단 실행은 확인하지 못했다.** Codex 컨테이너가 없어 실제 프로비저닝은 돌려보지 않았다. `install.sh`도 읽기만 하고 실행하지 않았다 — 로컬의 기존 claude 설치를 덮어쓰기 때문. 심링크 경로와 설치 위치는 첫 Codex 환경 빌드에서만 확인된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTgtecnmvUBZExxCMsJQFw
